### PR TITLE
Update Module Path, XML NodeDecoder Fixes

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -118,7 +118,7 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.15";
         private static final String GO_CMP = "v0.5.4";
-        private static final String SMITHY_GO = "v0.4.1-0.20201216214517-20e212c92831";
+        private static final String SMITHY_GO = "v0.4.1-0.20201222001052-74df8ddd8c79";
         private static final String GO_JMESPATH = "v0.4.0";
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -60,7 +60,7 @@ public final class SmithyGoDependency {
 
     public static final GoDependency GO_JMESPATH = goJmespath(null);
 
-    private static final String SMITHY_SOURCE_PATH = "github.com/awslabs/smithy-go";
+    private static final String SMITHY_SOURCE_PATH = "github.com/aws/smithy-go";
     private static final String GO_CMP_SOURCE_PATH = "github.com/google/go-cmp";
     private static final String GO_JMESPATH_SOURCE_PATH = "github.com/jmespath/go-jmespath";
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/OperationInterfaceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/OperationInterfaceGenerator.java
@@ -40,7 +40,7 @@ import software.amazon.smithy.waiters.WaitableTrait;
  */
 public class OperationInterfaceGenerator implements GoIntegration {
 
-    private static Map<ShapeId, Set<ShapeId>> mapOfClientInterfaceOperations = new HashMap<>();
+    private final Map<ShapeId, Set<ShapeId>> mapOfClientInterfaceOperations = new HashMap<>();
 
     /**
      * Returns name of an API client interface.
@@ -48,17 +48,12 @@ public class OperationInterfaceGenerator implements GoIntegration {
      * @param operationSymbol Symbol of operation shape for which Api client interface is being generated.
      * @return name of the interface.
      */
-    public static String getApiClientInterfaceName(
-            Symbol operationSymbol
-    ) {
+    public static String getApiClientInterfaceName(Symbol operationSymbol) {
         return String.format("%sAPIClient", operationSymbol.getName());
     }
 
     @Override
-    public void processFinalizedModel(
-            GoSettings settings,
-            Model model
-    ) {
+    public void processFinalizedModel(GoSettings settings, Model model) {
         ServiceShape serviceShape = settings.getService(model);
         TopDownIndex topDownIndex = TopDownIndex.of(model);
         PaginatedIndex paginatedIndex = PaginatedIndex.of(model);
@@ -93,7 +88,7 @@ public class OperationInterfaceGenerator implements GoIntegration {
 
         if (mapOfClientInterfaceOperations.containsKey(serviceId)) {
             Set<ShapeId> listOfClientInterfaceOperations = mapOfClientInterfaceOperations.get(serviceId);
-            listOfClientInterfaceOperations.stream().forEach(shapeId -> {
+            listOfClientInterfaceOperations.forEach(shapeId -> {
                 OperationShape operationShape = model.expectShape(shapeId, OperationShape.class);
                 goDelegator.useShapeWriter(operationShape, writer -> {
                     generateApiClientInterface(writer, model, symbolProvider, operationShape);

--- a/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.go.codegen.integration.GoIntegration
+++ b/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.go.codegen.integration.GoIntegration
@@ -3,7 +3,7 @@ software.amazon.smithy.go.codegen.integration.IdempotencyTokenMiddlewareGenerato
 software.amazon.smithy.go.codegen.integration.AddChecksumRequiredMiddleware
 software.amazon.smithy.go.codegen.integration.RequiresLengthTraitSupport
 software.amazon.smithy.go.codegen.integration.EndpointHostPrefixMiddleware
-software.amazon.smithy.go.codegen.integration.ClientLogger
 software.amazon.smithy.go.codegen.integration.OperationInterfaceGenerator
 software.amazon.smithy.go.codegen.integration.Paginators
 software.amazon.smithy.go.codegen.integration.Waiters
+software.amazon.smithy.go.codegen.integration.ClientLogger

--- a/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GoDependencyTest.java
+++ b/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GoDependencyTest.java
@@ -44,8 +44,8 @@ public class GoDependencyTest {
     public void testSingleDependency() {
         GoDependency dependency = GoDependency.builder()
                 .type(GoDependency.Type.DEPENDENCY)
-                .sourcePath("github.com/awslabs/smithy-go")
-                .importPath("github.com/awslabs/smithy-go/middleware")
+                .sourcePath("github.com/aws/smithy-go")
+                .importPath("github.com/aws/smithy-go/middleware")
                 .version("1.2.3")
                 .build();
         List<SymbolDependency> symbolDependencies = dependency.getDependencies();
@@ -53,7 +53,7 @@ public class GoDependencyTest {
         SymbolDependency symbolDependency = symbolDependencies.get(0);
 
         assertThat(symbolDependency.getDependencyType(), Matchers.equalTo("dependency"));
-        assertThat(symbolDependency.getPackageName(), Matchers.equalTo("github.com/awslabs/smithy-go"));
+        assertThat(symbolDependency.getPackageName(), Matchers.equalTo("github.com/aws/smithy-go"));
         assertThat(symbolDependency.getVersion(), Matchers.equalTo("1.2.3"));
     }
 
@@ -66,8 +66,8 @@ public class GoDependencyTest {
                 .version("1.2.3")
                 .addDependency(GoDependency.builder()
                         .type(GoDependency.Type.DEPENDENCY)
-                        .sourcePath("github.com/awslabs/smithy-go")
-                        .importPath("github.com/awslabs/smithy-go/middleware")
+                        .sourcePath("github.com/aws/smithy-go")
+                        .importPath("github.com/aws/smithy-go/middleware")
                         .version("3.4.5")
                         .build())
                 .build();
@@ -81,7 +81,7 @@ public class GoDependencyTest {
                         .build()),
                 Matchers.equalTo(SymbolDependency.builder()
                         .dependencyType("dependency")
-                        .packageName("github.com/awslabs/smithy-go")
+                        .packageName("github.com/aws/smithy-go")
                         .version("3.4.5")
                         .build())
         ));
@@ -96,8 +96,8 @@ public class GoDependencyTest {
                 .version("1.2.3")
                 .addDependency(GoDependency.builder()
                         .type(GoDependency.Type.DEPENDENCY)
-                        .sourcePath("github.com/awslabs/smithy-go")
-                        .importPath("github.com/awslabs/smithy-go/middleware")
+                        .sourcePath("github.com/aws/smithy-go")
+                        .importPath("github.com/aws/smithy-go/middleware")
                         .version("3.4.5")
                         .addDependency(GoDependency.builder()
                                 .type(GoDependency.Type.DEPENDENCY)
@@ -128,7 +128,7 @@ public class GoDependencyTest {
                         .build()),
                 Matchers.equalTo(SymbolDependency.builder()
                         .dependencyType("dependency")
-                        .packageName("github.com/awslabs/smithy-go")
+                        .packageName("github.com/aws/smithy-go")
                         .version("3.4.5")
                         .build()),
                 Matchers.equalTo(SymbolDependency.builder()

--- a/encoding/json/decoder_util_test.go
+++ b/encoding/json/decoder_util_test.go
@@ -3,8 +3,9 @@ package json
 import (
 	"bytes"
 	"encoding/json"
-	smithytesting "github.com/awslabs/smithy-go/testing"
 	"testing"
+
+	smithytesting "github.com/aws/smithy-go/testing"
 )
 
 func TestDiscardUnknownField(t *testing.T) {

--- a/encoding/json/encoder_test.go
+++ b/encoding/json/encoder_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/awslabs/smithy-go/encoding/json"
+	"github.com/aws/smithy-go/encoding/json"
 )
 
 func TestEncoder(t *testing.T) {

--- a/encoding/json/value.go
+++ b/encoding/json/value.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 	"strconv"
 
-	"github.com/awslabs/smithy-go/encoding"
+	"github.com/aws/smithy-go/encoding"
 )
 
 // Value represents a JSON Value type

--- a/encoding/xml/encoder_test.go
+++ b/encoding/xml/encoder_test.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"testing"
 
-	"github.com/awslabs/smithy-go/encoding/xml"
+	"github.com/aws/smithy-go/encoding/xml"
 )
 
 var root = xml.StartElement{Name: xml.Name{Local: "root"}}

--- a/encoding/xml/value.go
+++ b/encoding/xml/value.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 	"strconv"
 
-	"github.com/awslabs/smithy-go/encoding"
+	"github.com/aws/smithy-go/encoding"
 )
 
 // Value represents an XML Value type

--- a/encoding/xml/xml_decoder.go
+++ b/encoding/xml/xml_decoder.go
@@ -3,6 +3,7 @@ package xml
 import (
 	"encoding/xml"
 	"fmt"
+	"strings"
 )
 
 // NodeDecoder is a XML decoder wrapper that is responsible to decoding
@@ -43,31 +44,67 @@ func (d NodeDecoder) Token() (t xml.StartElement, done bool, err error) {
 		// skip token if it is a comment or preamble or empty space value due to indentation
 		// or if it's a value and is not expected
 	}
+}
 
-	return
+// GetElement looks for the given tag name at the current level, and returns the element if found, and
+// skipping over non-matching elements. Returns an error if the node is not found, or if an error occurs while walking
+// the document.
+func (d NodeDecoder) GetElement(name string) (t xml.StartElement, err error) {
+	for {
+		token, done, err := d.Token()
+		if err != nil {
+			return t, err
+		}
+		if done {
+			return t, fmt.Errorf("%s node not found", name)
+		}
+		switch {
+		case strings.EqualFold(name, token.Name.Local):
+			return token, nil
+		default:
+			err = d.Decoder.Skip()
+			if err != nil {
+				return t, err
+			}
+		}
+	}
 }
 
 // Value provides an abstraction to retrieve char data value within an xml element.
 // The method will return an error if it encounters a nested xml element instead of char data.
 // This method should only be used to retrieve simple type or blob shape values as []byte.
-func (d NodeDecoder) Value() (c []byte, done bool, err error) {
+func (d NodeDecoder) Value() (c []byte, err error) {
 	t, e := d.Decoder.Token()
 	if e != nil {
-		return c, done, e
+		return c, e
 	}
 
-	// check if token is of type charData
-	if ev, ok := t.(xml.CharData); ok {
-		return ev, done, err
+	endElement := d.StartEl.End()
+
+	switch ev := t.(type) {
+	case xml.CharData:
+		c = ev.Copy()
+	case xml.EndElement: // end tag or self-closing
+		if ev == endElement {
+			return []byte{}, err
+		}
+		return c, fmt.Errorf("expected value for %v element, got %T type %v instead", d.StartEl.Name.Local, t, t)
+	default:
+		return c, fmt.Errorf("expected value for %v element, got %T type %v instead", d.StartEl.Name.Local, t, t)
+	}
+
+	t, e = d.Decoder.Token()
+	if e != nil {
+		return c, e
 	}
 
 	if ev, ok := t.(xml.EndElement); ok {
-		if ev == d.StartEl.End() {
-			return c, true, err
+		if ev == endElement {
+			return c, err
 		}
 	}
 
-	return c, done, fmt.Errorf("expected value for %v element, got %T type %v instead", d.StartEl.Name.Local, t, t)
+	return c, fmt.Errorf("expected end element %v, got %T type %v instead", endElement, t, t)
 }
 
 // FetchRootElement takes in a decoder and returns the first start element within the xml body.

--- a/encoding/xml/xml_decoder_test.go
+++ b/encoding/xml/xml_decoder_test.go
@@ -160,7 +160,11 @@ func TestXMLNodeDecoder_Value(t *testing.T) {
 		},
 		"no value": {
 			responseBody: bytes.NewReader([]byte(`<Response></Response>`)),
-			expectedDone: true,
+			expectedValue: []byte{},
+		},
+		"self-closing": {
+			responseBody: bytes.NewReader([]byte(`<Response />`)),
+			expectedValue: []byte{},
 		},
 		"empty body": {
 			responseBody:  bytes.NewReader([]byte(``)),
@@ -186,7 +190,7 @@ func TestXMLNodeDecoder_Value(t *testing.T) {
 				}
 			}
 			nodeDecoder := WrapNodeDecoder(xmlDecoder, st)
-			token, done, err := nodeDecoder.Value()
+			token, err := nodeDecoder.Value()
 			if err != nil {
 				if len(c.expectedError) == 0 {
 					t.Fatalf("Expected no error, got %v", err)
@@ -195,10 +199,6 @@ func TestXMLNodeDecoder_Value(t *testing.T) {
 				if e, a := c.expectedError, err; !strings.Contains(err.Error(), c.expectedError) {
 					t.Fatalf("expected error to contain %v, found %v", e, a.Error())
 				}
-			}
-
-			if e, a := c.expectedDone, done; e != a {
-				t.Fatalf("expected a valid end element token for the xml document, got none")
 			}
 
 			if diff := cmp.Diff(c.expectedValue, token); len(diff) != 0 {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/awslabs/smithy-go
+module github.com/aws/smithy-go
 
 go 1.14
 

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/awslabs/smithy-go/logging"
+	"github.com/aws/smithy-go/logging"
 )
 
 func TestNewStandardLogger(t *testing.T) {

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"context"
 
-	"github.com/awslabs/smithy-go/logging"
+	"github.com/aws/smithy-go/logging"
 )
 
 // loggerKey is the context value key for which the logger is associated with.

--- a/middleware/logging_test.go
+++ b/middleware/logging_test.go
@@ -5,8 +5,8 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/awslabs/smithy-go/logging"
-	"github.com/awslabs/smithy-go/middleware"
+	"github.com/aws/smithy-go/logging"
+	"github.com/aws/smithy-go/middleware"
 )
 
 type mockWithContextLogger struct {

--- a/ptr/generate.go
+++ b/ptr/generate.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"text/template"
 
-	"github.com/awslabs/smithy-go/ptr"
+	"github.com/aws/smithy-go/ptr"
 )
 
 func main() {

--- a/rand/uuid_test.go
+++ b/rand/uuid_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/awslabs/smithy-go/rand"
+	"github.com/aws/smithy-go/rand"
 )
 
 func TestUUID(t *testing.T) {

--- a/testing/document.go
+++ b/testing/document.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/awslabs/smithy-go/testing/xml"
+	"github.com/aws/smithy-go/testing/xml"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/transport/http/checksum_middleware.go
+++ b/transport/http/checksum_middleware.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/awslabs/smithy-go/middleware"
+	"github.com/aws/smithy-go/middleware"
 )
 
 const contentMD5Header = "Content-Md5"

--- a/transport/http/checksum_middleware_test.go
+++ b/transport/http/checksum_middleware_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	smithyio "github.com/awslabs/smithy-go/io"
-	"github.com/awslabs/smithy-go/middleware"
+	smithyio "github.com/aws/smithy-go/io"
+	"github.com/aws/smithy-go/middleware"
 )
 
 func TestChecksumMiddleware(t *testing.T) {

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
-	smithy "github.com/awslabs/smithy-go"
-	"github.com/awslabs/smithy-go/middleware"
+	smithy "github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/middleware"
 )
 
 // ClientDo provides the interface for custom HTTP client implementations.

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"testing"
 
-	smithy "github.com/awslabs/smithy-go"
+	smithy "github.com/aws/smithy-go"
 )
 
 func TestClientHandler_Handle(t *testing.T) {

--- a/transport/http/deserailize_example_test.go
+++ b/transport/http/deserailize_example_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/awslabs/smithy-go/middleware"
+	"github.com/aws/smithy-go/middleware"
 )
 
 func ExampleResponse_deserializeMiddleware() {

--- a/transport/http/middleware_close_response_body.go
+++ b/transport/http/middleware_close_response_body.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/awslabs/smithy-go/middleware"
+	"github.com/aws/smithy-go/middleware"
 )
 
 // AddErrorCloseResponseBodyMiddleware adds the middleware to automatically

--- a/transport/http/middleware_content_length.go
+++ b/transport/http/middleware_content_length.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/awslabs/smithy-go/middleware"
+	"github.com/aws/smithy-go/middleware"
 )
 
 // ComputeContentLength provides a middleware to set the content-length

--- a/transport/http/middleware_content_length_test.go
+++ b/transport/http/middleware_content_length_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/awslabs/smithy-go/middleware"
+	"github.com/aws/smithy-go/middleware"
 )
 
 func TestContentLengthMiddleware(t *testing.T) {

--- a/transport/http/middleware_headers.go
+++ b/transport/http/middleware_headers.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/awslabs/smithy-go/middleware"
+	"github.com/aws/smithy-go/middleware"
 )
 
 type headerValue struct {

--- a/transport/http/middleware_headers_test.go
+++ b/transport/http/middleware_headers_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/awslabs/smithy-go/middleware"
-	smithyhttp "github.com/awslabs/smithy-go/transport/http"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/transport/http/middleware_http_logging.go
+++ b/transport/http/middleware_http_logging.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http/httputil"
 
-	"github.com/awslabs/smithy-go/logging"
-	"github.com/awslabs/smithy-go/middleware"
+	"github.com/aws/smithy-go/logging"
+	"github.com/aws/smithy-go/middleware"
 )
 
 // RequestResponseLogger is a deserialize middleware that will log the request and response HTTP messages and optionally

--- a/transport/http/middleware_http_logging_test.go
+++ b/transport/http/middleware_http_logging_test.go
@@ -10,9 +10,9 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/awslabs/smithy-go/logging"
-	"github.com/awslabs/smithy-go/middleware"
-	smithyhttp "github.com/awslabs/smithy-go/transport/http"
+	"github.com/aws/smithy-go/logging"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/transport/http/request.go
+++ b/transport/http/request.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"net/url"
 
-	iointernal "github.com/awslabs/smithy-go/transport/http/internal/io"
+	iointernal "github.com/aws/smithy-go/transport/http/internal/io"
 )
 
 // Request provides the HTTP specific request structure for HTTP specific

--- a/transport/http/response_error_example_test.go
+++ b/transport/http/response_error_example_test.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/awslabs/smithy-go"
-	"github.com/awslabs/smithy-go/middleware"
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/middleware"
 )
 
 func ExampleResponseError() {

--- a/transport/http/serialize_example_test.go
+++ b/transport/http/serialize_example_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/awslabs/smithy-go/middleware"
+	"github.com/aws/smithy-go/middleware"
 )
 
 func ExampleRequest_serializeMiddleware() {

--- a/waiter/logger.go
+++ b/waiter/logger.go
@@ -3,8 +3,9 @@ package waiter
 import (
 	"context"
 	"fmt"
-	"github.com/awslabs/smithy-go/logging"
-	"github.com/awslabs/smithy-go/middleware"
+
+	"github.com/aws/smithy-go/logging"
+	"github.com/aws/smithy-go/middleware"
 )
 
 // Logger is the Logger middleware used by the waiter to log an attempt

--- a/waiter/waiter.go
+++ b/waiter/waiter.go
@@ -2,9 +2,10 @@ package waiter
 
 import (
 	"fmt"
-	"github.com/awslabs/smithy-go/rand"
 	"math"
 	"time"
+
+	"github.com/aws/smithy-go/rand"
 )
 
 // ComputeDelay computes delay between waiter attempts. The function takes in a current attempt count,

--- a/waiter/waiter_test.go
+++ b/waiter/waiter_test.go
@@ -1,11 +1,12 @@
 package waiter
 
 import (
-	"github.com/awslabs/smithy-go/rand"
 	mathrand "math/rand"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/aws/smithy-go/rand"
 )
 
 func TestComputeDelay(t *testing.T) {


### PR DESCRIPTION
* Updates the smithy-go Go module path and import statements to reflect the new repository location.
* Updates `NodeDecoder`'s `Value` method
* Adds a new `GetElement` method to `NodeDecoder`