### PR TITLE
Update master to main

### DIFF
--- a/.github/workflows/api_diff_check.yml
+++ b/.github/workflows/api_diff_check.yml
@@ -2,7 +2,7 @@ name: Go
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     branches: [ '*' ]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ matrix:
 
 branches:
   only:
-    - master
+    - main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ reported the issue. Please try to include as much information as you can. Detail
 ## Contributing via Pull Requests
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *master* branch.
+1. You are working against the latest source on the *main* branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 


### PR DESCRIPTION
Updates TravisCI and GitHub Actions to refer to main branch.