### PR TITLE
 middleware: Preallocate middleware ordering slices to reduce allocations

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -118,7 +118,7 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.15";
         private static final String GO_CMP = "v0.5.4";
-        private static final String SMITHY_GO = "v0.5.0";
+        private static final String SMITHY_GO = "v0.5.1-0.20210104190327-c7045c94c1ec";
         private static final String GO_JMESPATH = "v0.4.0";
     }
 }

--- a/middleware/ordered_group.go
+++ b/middleware/ordered_group.go
@@ -19,13 +19,16 @@ type ider interface {
 // orderedIDs provides an ordered collection of items with relative ordering
 // by name.
 type orderedIDs struct {
-	order relativeOrder
+	order *relativeOrder
 	items map[string]ider
 }
 
+const baseOrderedItems = 5
+
 func newOrderedIDs() *orderedIDs {
 	return &orderedIDs{
-		items: map[string]ider{},
+		order: newRelativeOrder(),
+		items: make(map[string]ider, baseOrderedItems),
 	}
 }
 
@@ -136,6 +139,12 @@ func (g *orderedIDs) GetOrder() []interface{} {
 // relativeOrder provides ordering of item
 type relativeOrder struct {
 	order []string
+}
+
+func newRelativeOrder() *relativeOrder {
+	return &relativeOrder{
+		order: make([]string, 0, baseOrderedItems),
+	}
 }
 
 // Add inserts a item into the order relative to the position provided.


### PR DESCRIPTION
Updates the middleware ordering behavior to preallocate its order item slices/maps to prevent future allocations.

Fixes #162

Example of v2 SDK's benchmark different

```go
benchmark                                          old ns/op     new ns/op     delta
BenchmarkCustomizations/small/smithy/default-4     98471         80525         -18.22%
BenchmarkCustomizations/small/smithy/default-4     127331        95931         -24.66%
BenchmarkCustomizations/small/smithy/default-4     143848        87465         -39.20%
BenchmarkCustomizations/small/smithy/default-4     250105        98629         -60.56%
BenchmarkCustomizations/small/smithy/default-4     190916        93149         -51.21%
BenchmarkCustomizations/small/smithy/default-4     149556        86324         -42.28%
BenchmarkCustomizations/small/smithy/default-4     171215        86332         -49.58%
BenchmarkCustomizations/small/smithy/default-4     149547        84465         -43.52%
BenchmarkCustomizations/small/smithy/default-4     138599        95963         -30.76%
BenchmarkCustomizations/small/smithy/default-4     145238        100273        -30.96%

benchmark                                          old allocs     new allocs     delta
BenchmarkCustomizations/small/smithy/default-4     681            675            -0.88%
BenchmarkCustomizations/small/smithy/default-4     681            675            -0.88%
BenchmarkCustomizations/small/smithy/default-4     681            675            -0.88%
BenchmarkCustomizations/small/smithy/default-4     681            675            -0.88%
BenchmarkCustomizations/small/smithy/default-4     681            675            -0.88%
BenchmarkCustomizations/small/smithy/default-4     681            675            -0.88%
BenchmarkCustomizations/small/smithy/default-4     681            675            -0.88%
BenchmarkCustomizations/small/smithy/default-4     681            675            -0.88%
BenchmarkCustomizations/small/smithy/default-4     681            675            -0.88%
BenchmarkCustomizations/small/smithy/default-4     681            675            -0.88%

benchmark                                          old bytes     new bytes     delta
BenchmarkCustomizations/small/smithy/default-4     51196         51068         -0.25%
BenchmarkCustomizations/small/smithy/default-4     51197         51069         -0.25%
BenchmarkCustomizations/small/smithy/default-4     51197         51069         -0.25%
BenchmarkCustomizations/small/smithy/default-4     51197         51069         -0.25%
BenchmarkCustomizations/small/smithy/default-4     51198         51068         -0.25%
BenchmarkCustomizations/small/smithy/default-4     51197         51068         -0.25%
BenchmarkCustomizations/small/smithy/default-4     51197         51068         -0.25%
BenchmarkCustomizations/small/smithy/default-4     51197         51068         -0.25%
BenchmarkCustomizations/small/smithy/default-4     51197         51068         -0.25%
BenchmarkCustomizations/small/smithy/default-4     51197         51068         -0.25%
```