### PR TITLE
codegen: Generate client option helpers

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -138,6 +138,28 @@ final class ServiceGenerator implements Runnable {
             generateApplicationProtocolConfig();
         }).write("");
 
+        writer.writeDocs("WithAPIOptions returns a functional option for setting the Client's APIOptions option.");
+        writer.openBlock("func WithAPIOptions(optFns ...func(*middleware.Stack) error) func(*Options) {", "}", () -> {
+            writer.openBlock("return func(o *Options) {", "}", () -> {
+                writer.write("o.APIOptions = append(o.APIOptions, optFns...)");
+            });
+        });
+
+        getAllConfigFields().stream().filter(ConfigField::withHelper)
+                .forEach(configField -> {
+                    writer.writeDocs(
+                            String.format("With%s returns a functional option for setting the Client's %s option.",
+                                    configField.getName(), configField.getName()));
+                    writer.openBlock("func With$L(v $P) func(*Options) {", "}", configField.getName(),
+                            configField.getType(),
+                            () -> {
+                                writer.openBlock("return func(o *Options) {", "}", () -> {
+                                    writer.write("o.$L = v", configField.getName());
+                                });
+                            }).write("");
+
+                });
+
         generateApplicationProtocolTypes();
 
         writer.writeDocs("Copy creates a clone where the APIOptions list is deep copied.");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ConfigField.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ConfigField.java
@@ -28,11 +28,13 @@ public class ConfigField implements ToSmithyBuilder<ConfigField> {
     private final String name;
     private final Symbol type;
     private final String documentation;
+    private final Boolean withHelper;
 
     public ConfigField(Builder builder) {
         this.name = Objects.requireNonNull(builder.name);
         this.type = Objects.requireNonNull(builder.type);
         this.documentation = builder.documentation;
+        this.withHelper = builder.withHelper;
     }
 
     /**
@@ -47,6 +49,13 @@ public class ConfigField implements ToSmithyBuilder<ConfigField> {
      */
     public Symbol getType() {
         return type;
+    }
+
+    /**
+     * @return Returns if the config option should have a with helper or not.
+     */
+    public Boolean withHelper() {
+        return withHelper;
     }
 
     /**
@@ -91,6 +100,7 @@ public class ConfigField implements ToSmithyBuilder<ConfigField> {
         private String name;
         private Symbol type;
         private String documentation;
+        private Boolean withHelper = false;
 
         @Override
         public ConfigField build() {
@@ -127,6 +137,27 @@ public class ConfigField implements ToSmithyBuilder<ConfigField> {
          */
         public Builder documentation(String documentation) {
             this.documentation = documentation;
+            return this;
+        }
+
+        /**
+         * Sets if the client include a With__ helper for this config option.
+         *
+         * @param withHelper if with helper should be generated or not.
+         * @return Returns the builder.
+         */
+        public Builder withHelper(Boolean withHelper) {
+            this.withHelper = withHelper;
+            return this;
+        }
+
+        /**
+         * Sets that the client will  include a With__ helper for the client option.
+         *
+         * @return Returns the builder.
+         */
+        public Builder withHelper() {
+            this.withHelper = true;
             return this;
         }
     }


### PR DESCRIPTION
Adds generating client functional option helpers to client packages. These make it a little bit more convenient to set Client options without creating the closure manually.

Client options must be opt-in to have the With helpers generated for them.

Fixes #143

V2 SDK api_client.go diff

```diff
+// WithAPIOptions returns a functional option for setting the Client's APIOptions
+// option.
+func WithAPIOptions(optFns ...func(*middleware.Stack) error) func(*Options) {
+       return func(o *Options) {
+               o.APIOptions = append(o.APIOptions, optFns...)
+       }
+}
```

A aws-sdk-go-v2 PR will need to be made to update the AWS SDK specific config fields that should include `With `helpers.
