### PR TITLE
Remove CLA and clarify license in pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,4 +3,4 @@
 *Description of changes:*
 
 
-By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,5 +57,3 @@ If you discover a potential security issue in this project we ask that you notif
 ## Licensing
 
 See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
-
-We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.


### PR DESCRIPTION
*Description of changes:*

This removes the CLA provision from CONTRIBUTING.md and clarifies the license
in the pr template.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
