### PR TITLE
 middleware: Add utility for stack scoped stack values

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -217,6 +217,9 @@ final class ServiceGenerator implements Runnable {
             writer.addUseImports(SmithyGoDependency.SMITHY_MIDDLEWARE);
             writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_TRANSPORT);
 
+            // Ensure operation stack invocations start with clean set of stack values.
+            writer.write("ctx = middleware.ClearStackValues(ctx)");
+
             generateConstructStack();
             writer.write("options := c.options.Copy()");
             writer.write("for _, fn := range optFns { fn(&options) }");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -118,7 +118,7 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.15";
         private static final String GO_CMP = "v0.5.4";
-        private static final String SMITHY_GO = "v0.5.1-0.20210104190327-c7045c94c1ec";
+        private static final String SMITHY_GO = "v0.5.1-0.20210107224202-ae5323020d60";
         private static final String GO_JMESPATH = "v0.4.0";
     }
 }

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -57,24 +57,6 @@ func (m decoratedHandler) Handle(ctx context.Context, input interface{}) (
 	return m.With.HandleMiddleware(ctx, input, m.Next)
 }
 
-type middlewareIDs struct{}
-
-// RecordMiddleware appends the middleware id to the list of middleware ids to
-// the context.
-func RecordMiddleware(ctx context.Context, id string) context.Context {
-	return context.WithValue(ctx, middlewareIDs{}, append(GetMiddlewareIDs(ctx), id))
-}
-
-// GetMiddlewareIDs returns a list of middleware IDs in the order they were
-// added in.
-func GetMiddlewareIDs(ctx context.Context) []string {
-	v, ok := ctx.Value(middlewareIDs{}).([]string)
-	if !ok {
-		return nil
-	}
-	return v
-}
-
 // DecorateHandler decorates a handler with a middleware. Wrapping the handler
 // with the middleware.
 func DecorateHandler(h Handler, with ...Middleware) Handler {

--- a/middleware/stack_values.go
+++ b/middleware/stack_values.go
@@ -1,0 +1,100 @@
+package middleware
+
+import (
+	"context"
+	"reflect"
+	"strings"
+)
+
+// WithStackValue adds a key value pair to the context that are intended to be
+// scoped to a stack. Use ClearStackValues to get a new context with all stack
+// values cleared.
+func WithStackValue(ctx context.Context, key, value interface{}) context.Context {
+	md, _ := ctx.Value(stackValuesKey{}).(*stackValues)
+
+	md = withStackValue(md, key, value)
+	return context.WithValue(ctx, stackValuesKey{}, md)
+}
+
+// ClearStackValues returns a context without any stack values.
+func ClearStackValues(ctx context.Context) context.Context {
+	return context.WithValue(ctx, stackValuesKey{}, nil)
+}
+
+// GetStackValues returns the value pointed to by the key within the stack
+// values, if it is present.
+func GetStackValue(ctx context.Context, key interface{}) interface{} {
+	md, _ := ctx.Value(stackValuesKey{}).(*stackValues)
+	if md == nil {
+		return nil
+	}
+
+	return md.Value(key)
+}
+
+type stackValuesKey struct{}
+
+type stackValues struct {
+	key    interface{}
+	value  interface{}
+	parent *stackValues
+}
+
+func withStackValue(parent *stackValues, key, value interface{}) *stackValues {
+	if key == nil {
+		panic("nil key")
+	}
+	if !reflect.TypeOf(key).Comparable() {
+		panic("key is not comparable")
+	}
+	return &stackValues{key: key, value: value, parent: parent}
+}
+
+func (m *stackValues) Value(key interface{}) interface{} {
+	if key == m.key {
+		return m.value
+	}
+
+	if m.parent == nil {
+		return nil
+	}
+
+	return m.parent.Value(key)
+}
+
+func (c *stackValues) String() string {
+	var str strings.Builder
+
+	cc := c
+	for cc == nil {
+		str.WriteString("(" +
+			reflect.TypeOf(c.key).String() +
+			": " +
+			stringify(cc.value) +
+			")")
+		if cc.parent != nil {
+			str.WriteString(" -> ")
+		}
+		cc = cc.parent
+	}
+	str.WriteRune('}')
+
+	return str.String()
+}
+
+type stringer interface {
+	String() string
+}
+
+// stringify tries a bit to stringify v, without using fmt, since we don't
+// want context depending on the unicode tables. This is only used by
+// *valueCtx.String().
+func stringify(v interface{}) string {
+	switch s := v.(type) {
+	case stringer:
+		return s.String()
+	case string:
+		return s
+	}
+	return "<not Stringer>"
+}

--- a/middleware/stack_values_test.go
+++ b/middleware/stack_values_test.go
@@ -1,0 +1,40 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+)
+
+func TestStackValues(t *testing.T) {
+	ctx := context.Background()
+
+	// Ensure empty stack values don't return something
+	if v := GetStackValue(ctx, "some key"); v != nil {
+		t.Fatalf("expect not-existing key to be nil, got %T, %v", v, v)
+	}
+
+	// Add a stack values, ensure not polluting previous context.
+	ctx2 := WithStackValue(ctx, "some key", "foo")
+	ctx2 = WithStackValue(ctx2, "some other key", "bar")
+	if v := GetStackValue(ctx, "some key"); v != nil {
+		t.Fatalf("expect not-existing key to be nil, got %T, %v", v, v)
+	}
+	if v, ok := GetStackValue(ctx2, "some key").(string); !ok || v != "foo" {
+		t.Fatalf("expect key to be present")
+	}
+	if v, ok := GetStackValue(ctx2, "some other key").(string); !ok || v != "bar" {
+		t.Fatalf("expect key to be present")
+	}
+
+	// Clear the stack values ensure new context doesn't have any stack values.
+	ctx3 := ClearStackValues(ctx2)
+	if v, ok := GetStackValue(ctx2, "some key").(string); !ok || v != "foo" {
+		t.Fatalf("expect key to be present")
+	}
+	if v := GetStackValue(ctx3, "some key"); v != nil {
+		t.Fatalf("expect not-existing key to be nil, got %T, %v", v, v)
+	}
+	if v := GetStackValue(ctx3, "some other key"); v != nil {
+		t.Fatalf("expect not-existing key to be nil, got %T, %v", v, v)
+	}
+}

--- a/transport/http/middleware_metadata.go
+++ b/transport/http/middleware_metadata.go
@@ -1,6 +1,10 @@
 package http
 
-import "context"
+import (
+	"context"
+
+	"github.com/aws/smithy-go/middleware"
+)
 
 type (
 	hostnameImmutableKey struct{}
@@ -9,27 +13,39 @@ type (
 
 // GetHostnameImmutable retrieves if the endpoint hostname should be considered
 // immutable or not.
+//
+// Scoped to stack values. Use middleware#ClearStackValues to clear all stack
+// values.
 func GetHostnameImmutable(ctx context.Context) (v bool) {
-	v, _ = ctx.Value(hostnameImmutableKey{}).(bool)
+	v, _ = middleware.GetStackValue(ctx, hostnameImmutableKey{}).(bool)
 	return v
 }
 
 // SetHostnameImmutable sets or modifies if the request's endpoint hostname
 // should be considered immutable or not.
+//
+// Scoped to stack values. Use middleware#ClearStackValues to clear all stack
+// values.
 func SetHostnameImmutable(ctx context.Context, value bool) context.Context {
-	return context.WithValue(ctx, hostnameImmutableKey{}, value)
+	return middleware.WithStackValue(ctx, hostnameImmutableKey{}, value)
+}
+
+// IsEndpointHostPrefixDisabled retrieves if the hostname prefixing is
+// disabled.
+//
+// Scoped to stack values. Use middleware#ClearStackValues to clear all stack
+// values.
+func IsEndpointHostPrefixDisabled(ctx context.Context) (v bool) {
+	v, _ = middleware.GetStackValue(ctx, hostPrefixDisableKey{}).(bool)
+	return v
 }
 
 // DisableEndpointHostPrefix sets or modifies if the request's endpoint host
 // prefixing to be disabled. If value is set to true, endpoint host prefixing
 // will be disabled.
+//
+// Scoped to stack values. Use middleware#ClearStackValues to clear all stack
+// values.
 func DisableEndpointHostPrefix(ctx context.Context, value bool) context.Context {
-	return context.WithValue(ctx, hostPrefixDisableKey{}, value)
-}
-
-// IsEndpointHostPrefixDisabled retrieves if the hostname prefixing
-//  is disabled.
-func IsEndpointHostPrefixDisabled(ctx context.Context) (v bool) {
-	v, _ = ctx.Value(hostPrefixDisableKey{}).(bool)
-	return v
+	return middleware.WithStackValue(ctx, hostPrefixDisableKey{}, value)
 }


### PR DESCRIPTION
Adds utilities for values that are intended to be scoped to individual stacks. Provides utilities for bulk clearing these values as well.

Related to aws/aws-sdk-go-v2#914

* [x] Needs unit tests.
* [x] Should RecordMiddleware be stack scoped?

---
#### Updated to be stack scoped
* hostnameImmutableKey
* hostPrefixDisableKey

#### Not changed
* Logger