### PR TITLE
Un-resolve xml attribute namespaces

### DIFF
--- a/encoding/xml/xml_decoder_test.go
+++ b/encoding/xml/xml_decoder_test.go
@@ -52,6 +52,30 @@ func TestXMLNodeDecoder_Token(t *testing.T) {
 				Attr: []xml.Attr{},
 			},
 		},
+		"attr with namespace": {
+			responseBody: bytes.NewReader([]byte(`<Response><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"></Grantee></Response>`)),
+			expectedStartElement: xml.StartElement{
+				Name: xml.Name{
+					Local: "Grantee",
+				},
+				Attr: []xml.Attr{
+					{
+						Name: xml.Name{
+							Space: "xmlns",
+							Local: "xsi",
+						},
+						Value: "http://www.w3.org/2001/XMLSchema-instance",
+					},
+					{
+						Name: xml.Name{
+							Space: "xsi",
+							Local: "type",
+						},
+						Value: "CanonicalUser",
+					},
+				},
+			},
+		},
 	}
 
 	for name, c := range cases {


### PR DESCRIPTION
*Issue #, if available:*

This the smithy-go half of what's needed to address aws/aws-sdk-go-v2#1013

*Description of changes:*

This updates the XML decoder to un-resolve xml namspaces in
attributes. The Go decoder resolves them fully by default, but we
need the short names to match attributes to members while
decoding.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
