### PR TITLE
codegen: Update generated serde to skip unmodeled input/outputs

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/AddOperationShapes.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/AddOperationShapes.java
@@ -81,6 +81,7 @@ public final class AddOperationShapes {
     private static StructureShape emptyOperationStructure(ShapeId opShapeId, String suffix) {
         return StructureShape.builder()
                 .id(ShapeId.fromParts(CodegenUtils.getSyntheticTypeNamespace(), opShapeId.getName() + suffix))
+                .addTrait(SyntheticClone.builder().build())
                 .build();
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
@@ -160,7 +160,7 @@ public final class CodegenUtils {
         }
 
         SyntheticClone synthClone = optional.get();
-        return synthClone.getArchetype() == null;
+        return !synthClone.getArchetype().isPresent();
     }
 
     /**

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 import software.amazon.smithy.codegen.core.CodegenException;
@@ -145,6 +146,22 @@ public final class CodegenUtils {
         return CodegenUtils.SYNTHETIC_NAMESPACE;
     }
 
+    /**
+     * Get if the passed in shape is decorated as a synthetic clone, but there is no other shape the clone is
+     * created from.
+     *
+     * @param shape the shape to check if its a stubbed synthetic clone without an archetype.
+     * @return if the shape is synthetic clone, but not based on a specific shape.
+     */
+    public static boolean isStubSyntheticClone(Shape shape) {
+        Optional<SyntheticClone> optional = shape.getTrait(SyntheticClone.class);
+        if (!optional.isPresent()) {
+            return false;
+        }
+
+        SyntheticClone synthClone = optional.get();
+        return synthClone.getArchetype() == null;
+    }
 
     /**
      * Returns the operand decorated with an &amp; if the address of the shape type can be taken.

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SyntheticClone.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SyntheticClone.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.go.codegen;
 
+import java.util.Optional;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -25,7 +26,7 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
  * Defines a shape as being a clone of another modeled shape.
- *
+ * <p>
  * Must only be used as a runtime trait-only applied to shapes based on model processing
  */
 public final class SyntheticClone extends AbstractTrait implements ToSmithyBuilder<SyntheticClone> {
@@ -33,7 +34,7 @@ public final class SyntheticClone extends AbstractTrait implements ToSmithyBuild
 
     private static final String ARCHETYPE = "archetype";
 
-    private final ShapeId archetype;
+    private final Optional<ShapeId> archetype;
 
     private SyntheticClone(Builder builder) {
         super(ID, builder.getSourceLocation());
@@ -45,7 +46,7 @@ public final class SyntheticClone extends AbstractTrait implements ToSmithyBuild
      *
      * @return the original archetype shape
      */
-    public ShapeId getArchetype() {
+    public Optional<ShapeId> getArchetype() {
         return archetype;
     }
 
@@ -56,8 +57,10 @@ public final class SyntheticClone extends AbstractTrait implements ToSmithyBuild
 
     @Override
     public SmithyBuilder<SyntheticClone> toBuilder() {
-        return builder()
-                .archetype(getArchetype());
+        Builder builder = builder();
+        getArchetype().ifPresent(builder::archetype);
+
+        return builder;
     }
 
     /**
@@ -71,7 +74,7 @@ public final class SyntheticClone extends AbstractTrait implements ToSmithyBuild
      * Builder for {@link SyntheticClone}.
      */
     public static final class Builder extends AbstractTraitBuilder<SyntheticClone, Builder> {
-        private ShapeId archetype;
+        private Optional<ShapeId> archetype = Optional.empty();
 
         private Builder() {
         }
@@ -82,7 +85,12 @@ public final class SyntheticClone extends AbstractTrait implements ToSmithyBuild
         }
 
         public Builder archetype(ShapeId archetype) {
-            this.archetype = archetype;
+            this.archetype = Optional.ofNullable(archetype);
+            return this;
+        }
+
+        public Builder removeArchetype() {
+            this.archetype = Optional.empty();
             return this;
         }
     }

--- a/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/AddOperationShapesTest.java
+++ b/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/AddOperationShapesTest.java
@@ -72,7 +72,7 @@ public class AddOperationShapesTest {
             if (opSynthClone.isPresent()) {
                 SyntheticClone synthClone = opSynthClone.get();
                 MatcherAssert.assertThat(shapeId + " shape must not have archetype",
-                        synthClone.getArchetype(), Matchers.equalTo(null));
+                        synthClone.getArchetype().isPresent(), Matchers.equalTo(false));
             } else {
                 MatcherAssert.assertThat(shapeId + " shape must be synthetic clone", false);
             }
@@ -132,7 +132,7 @@ public class AddOperationShapesTest {
             if (!syntheticClone.isPresent()) {
                 MatcherAssert.assertThat(shapeId + " shape must be marked as synthetic clone", false);
             } else {
-                MatcherAssert.assertThat(syntheticClone.get().getArchetype().toString(),
+                MatcherAssert.assertThat(syntheticClone.get().getArchetype().get().toString(),
                         Matchers.is(Matchers.oneOf(NAMESPACE + "#TestOperationRequest",
                                 NAMESPACE + "#TestOperationResponse")));
             }
@@ -189,7 +189,7 @@ public class AddOperationShapesTest {
                     if (opSynthClone.isPresent()) {
                         SyntheticClone synthClone = opSynthClone.get();
                         MatcherAssert.assertThat(shapeId + " shape must not have archetype",
-                                synthClone.getArchetype(), Matchers.equalTo(null));
+                                synthClone.getArchetype().isPresent(), Matchers.equalTo(false));
                     } else {
                         MatcherAssert.assertThat(shapeId + " shape must be synthetic clone", false);
                     }

--- a/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/AddOperationShapesTest.java
+++ b/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/AddOperationShapesTest.java
@@ -67,8 +67,14 @@ public class AddOperationShapesTest {
                     shape.isPresent(), Matchers.is(true));
             MatcherAssert.assertThat(shapeId + " shape must have no members",
                     shape.get().members().size(), Matchers.equalTo(0));
-            if (shape.get().getTrait(SyntheticClone.class).isPresent()) {
-                MatcherAssert.assertThat("shape is not synthetic clone", false);
+
+            Optional<SyntheticClone> opSynthClone = shape.get().getTrait(SyntheticClone.class);
+            if (opSynthClone.isPresent()) {
+                SyntheticClone synthClone = opSynthClone.get();
+                MatcherAssert.assertThat(shapeId + " shape must not have archetype",
+                        synthClone.getArchetype(), Matchers.equalTo(null));
+            } else {
+                MatcherAssert.assertThat(shapeId + " shape must be synthetic clone", false);
             }
         });
     }
@@ -118,12 +124,13 @@ public class AddOperationShapesTest {
             MatcherAssert.assertThat("foo member present", fooMember.isPresent(), Matchers.is(true));
 
             ShapeId id = fooMember.get().getId();
-            MatcherAssert.assertThat("foo is correct namespace", id.getNamespace(), Matchers.equalTo(shapeId.getNamespace()));
+            MatcherAssert.assertThat("foo is correct namespace", id.getNamespace(),
+                    Matchers.equalTo(shapeId.getNamespace()));
             MatcherAssert.assertThat("foo is correct parent", id.getName(), Matchers.equalTo(shapeId.getName()));
 
             Optional<SyntheticClone> syntheticClone = shape.get().getTrait(SyntheticClone.class);
             if (!syntheticClone.isPresent()) {
-                MatcherAssert.assertThat("shape must be marked as synthetic clone", false);
+                MatcherAssert.assertThat(shapeId + " shape must be marked as synthetic clone", false);
             } else {
                 MatcherAssert.assertThat(syntheticClone.get().getArchetype().toString(),
                         Matchers.is(Matchers.oneOf(NAMESPACE + "#TestOperationRequest",
@@ -161,7 +168,7 @@ public class AddOperationShapesTest {
         ShapeId expInputRename = ShapeId.fromParts(CodegenUtils.getSyntheticTypeNamespace(), "TestOperationInput");
         ShapeId expOutputRename = ShapeId.fromParts(CodegenUtils.getSyntheticTypeNamespace(), "TestOperationOutput");
 
-        ListUtils.of(expInputRename, expOutputRename, inputConflict.getId(), outputConflict.getId())
+        ListUtils.of(inputConflict.getId(), outputConflict.getId())
                 .forEach(shapeId -> {
                     Optional<Shape> shape = processedModel.getShape(shapeId);
                     MatcherAssert.assertThat(shapeId + " shape must be present in model",
@@ -169,6 +176,22 @@ public class AddOperationShapesTest {
 
                     if (shape.get().getTrait(SyntheticClone.class).isPresent()) {
                         MatcherAssert.assertThat("shape must not be marked as synthetic clone", false);
+                    }
+                });
+
+        ListUtils.of(expInputRename, expOutputRename)
+                .forEach(shapeId -> {
+                    Optional<Shape> shape = processedModel.getShape(shapeId);
+                    MatcherAssert.assertThat(shapeId + " shape must be present in model",
+                            shape.isPresent(), Matchers.is(true));
+
+                    Optional<SyntheticClone> opSynthClone = shape.get().getTrait(SyntheticClone.class);
+                    if (opSynthClone.isPresent()) {
+                        SyntheticClone synthClone = opSynthClone.get();
+                        MatcherAssert.assertThat(shapeId + " shape must not have archetype",
+                                synthClone.getArchetype(), Matchers.equalTo(null));
+                    } else {
+                        MatcherAssert.assertThat(shapeId + " shape must be synthetic clone", false);
                     }
                 });
     }


### PR DESCRIPTION
Updates the SDK's generated serializers and deserializers to skip unmodeled
input and output shapes for operations.

This issue caused generated deserializers to attempt to deserialize
operation responses that were not modeled, resulting in an error.
Whereas the SDK should of ignored the response if one was present for
operations without a modeled output.

Related to https://github.com/aws/aws-sdk-go-v2/issues/1047
Fixes #262

#### Input
Unmodeled Input shape serializer functions are not generated.

This update changes API protocol operation serializers for HTTP binding protocols to skip serialization of the request document if the operation's input was not modeled.

This change is **not** applied to HTTP RPC protocol serializations. This is due to the AwsQuery protocol requiring some protocol specific elements to always be serialized regardless if an input is modeled or not.

#### Output
Unmodeled output shape serializer functions are not generated.

This update changes all API protocol operation deserializers to discard the response body if the operation's output was not modeled.



