### PR TITLE
add support for withHelper for config field

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -145,7 +145,7 @@ final class ServiceGenerator implements Runnable {
             });
         });
 
-        getAllConfigFields().stream().filter(ConfigField::withHelper)
+        getAllConfigFields().stream().filter(ConfigField::getWithHelper)
                 .forEach(configField -> {
                     writer.writeDocs(
                             String.format("With%s returns a functional option for setting the Client's %s option.",

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ConfigField.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ConfigField.java
@@ -54,7 +54,7 @@ public class ConfigField implements ToSmithyBuilder<ConfigField> {
     /**
      * @return Returns if the config option should have a with helper or not.
      */
-    public Boolean withHelper() {
+    public Boolean getWithHelper() {
         return withHelper;
     }
 
@@ -67,7 +67,7 @@ public class ConfigField implements ToSmithyBuilder<ConfigField> {
 
     @Override
     public SmithyBuilder<ConfigField> toBuilder() {
-        return builder().type(type).name(name).documentation(documentation);
+        return builder().type(type).name(name).documentation(documentation).withHelper(withHelper);
     }
 
     public static Builder builder() {
@@ -85,12 +85,13 @@ public class ConfigField implements ToSmithyBuilder<ConfigField> {
         ConfigField that = (ConfigField) o;
         return Objects.equals(getName(), that.getName())
                 && Objects.equals(getType(), that.getType())
-                && Objects.equals(getDocumentation(), that.getDocumentation());
+                && Objects.equals(getDocumentation(), that.getDocumentation())
+                && Objects.equals(getWithHelper(), that.getWithHelper());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getName(), getType(), getDocumentation());
+        return Objects.hash(getName(), getType(), getDocumentation(), getWithHelper());
     }
 
     /**


### PR DESCRIPTION
Updates Config field to support withHelper option it partially supports. The withHelper option is used to generate a With-Helper function for a Config Field.