### PR TITLE
Escape Next Line and Line Start in XML Encoder

### DIFF
--- a/encoding/xml/escape.go
+++ b/encoding/xml/escape.go
@@ -21,6 +21,10 @@ var (
 	escNL   = []byte("&#xA;")
 	escCR   = []byte("&#xD;")
 	escFFFD = []byte("\uFFFD") // Unicode replacement character
+
+	// Additional Escapes
+	escNextLine = []byte("&#x85;")
+	escLS       = []byte("&#x2028;")
 )
 
 // Decide whether the given rune is in the XML Character Range, per
@@ -61,6 +65,12 @@ func escapeString(e writer, s string) {
 			esc = escNL
 		case '\r':
 			esc = escCR
+		case '\u0085':
+			// Not escaped by stdlib
+			esc = escNextLine
+		case '\u2028':
+			// Not escaped by stdlib
+			esc = escLS
 		default:
 			if !isInCharacterRange(r) || (r == 0xFFFD && width == 1) {
 				esc = escFFFD
@@ -101,11 +111,17 @@ func escapeText(e writer, s []byte) {
 		case '\t':
 			esc = escTab
 		case '\n':
-			// TODO: This always escapes newline, which is different than stdlib's optional
-			// escape of new line
+			// This always escapes newline, which is different than stdlib's optional
+			// escape of new line.
 			esc = escNL
 		case '\r':
 			esc = escCR
+		case '\u0085':
+			// Not escaped by stdlib
+			esc = escNextLine
+		case '\u2028':
+			// Not escaped by stdlib
+			esc = escLS
 		default:
 			if !isInCharacterRange(r) || (r == 0xFFFD && width == 1) {
 				esc = escFFFD

--- a/local-mod-replace.sh
+++ b/local-mod-replace.sh
@@ -1,0 +1,39 @@
+#1/usr/bin/env bash
+
+PROJECT_DIR=""
+SMITHY_SOURCE_DIR=$(cd `dirname $0` && pwd)
+
+usage() {
+  echo "Usage: $0 [-s SMITHY_SOURCE_DIR] [-d PROJECT_DIR]" 1>&2
+  exit 1
+}
+
+while getopts "hs:d:" options; do
+  case "${options}" in
+  s)
+    SMITHY_SOURCE_DIR=${OPTARG}
+    if [ "$SMITHY_SOURCE_DIR" == "" ]; then
+      echo "path to smithy-go source directory is required" || exit
+      usage
+    fi
+    ;;
+  d)
+    PROJECT_DIR=${OPTARG}
+    ;;
+  h)
+    usage
+    ;;
+  *)
+    usage
+    ;;
+  esac
+done
+
+if [ "$PROJECT_DIR" != "" ]; then
+  cd $PROJECT_DIR || exit
+fi
+
+go mod graph | awk '{print $1}' | cut -d '@' -f 1 | sort | uniq | grep "github.com/aws/smithy-go" | while read x; do
+  repPath=${x/github.com\/aws\/smithy-go/${SMITHY_SOURCE_DIR}}
+  echo -replace $x=$repPath
+done | xargs go mod edit


### PR DESCRIPTION
Adds escaping rules for `next line` (U+0085) and `line separator` (U+2028) to XML encoder.