### PR TITLE
Add ParseTime for HTTP Date Parsing

### DIFF
--- a/transport/http/time.go
+++ b/transport/http/time.go
@@ -1,0 +1,27 @@
+package http
+
+import (
+	"fmt"
+	"time"
+)
+
+// Time parsing function sourced from stdlib with an additional time format so
+// non-compliant timestamps are still parseable.
+// https://github.com/golang/go/blob/8869086d8f0a31033ccdc103106c768dc17216b1/src/net/http/header.go#L110-L127
+var timeFormats = []string{
+	"Mon, _2 Jan 2006 15:04:05 GMT", // Modifies http.TimeFormat with a leading underscore for day number (leading 0 optional).
+	time.RFC850,
+	time.ANSIC,
+}
+
+// ParseTime parses a time header like the HTTP Date header.
+// This uses a more relaxed rule set for date parsing compared to the standard library.
+func ParseTime(text string) (t time.Time, err error) {
+	for _, layout := range timeFormats {
+		t, err = time.Parse(layout, text)
+		if err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unknown time format: %w", err)
+}

--- a/transport/http/time_test.go
+++ b/transport/http/time_test.go
@@ -1,0 +1,67 @@
+package http_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/smithy-go/transport/http"
+)
+
+func TestParseTime(t *testing.T) {
+	cases := map[string]struct {
+		date    string
+		expect  time.Time
+		wantErr bool
+	}{
+		"with leading zero on day": {
+			date:   "Fri, 05 Feb 2021 19:12:15 GMT",
+			expect: time.Date(2021, 2, 5, 19, 12, 15, 0, time.UTC),
+		},
+		"without leading zero on day": {
+			date:   "Fri, 5 Feb 2021 19:12:15 GMT",
+			expect: time.Date(2021, 2, 5, 19, 12, 15, 0, time.UTC),
+		},
+		"with double digit day": {
+			date:   "Fri, 15 Feb 2021 19:12:15 GMT",
+			expect: time.Date(2021, 2, 15, 19, 12, 15, 0, time.UTC),
+		},
+		"RFC850": {
+			date:   "Friday, 05-Feb-21 19:12:15 UTC",
+			expect: time.Date(2021, 2, 5, 19, 12, 15, 0, time.UTC),
+		},
+		"ANSIC with leading zero on day": {
+			date:   "Fri Feb 05 19:12:15 2021",
+			expect: time.Date(2021, 2, 5, 19, 12, 15, 0, time.UTC),
+		},
+		"ANSIC without leading zero on day": {
+			date:   "Fri Feb 5 19:12:15 2021",
+			expect: time.Date(2021, 2, 5, 19, 12, 15, 0, time.UTC),
+		},
+		"ANSIC with double digit day": {
+			date:   "Fri Feb 15 19:12:15 2021",
+			expect: time.Date(2021, 2, 15, 19, 12, 15, 0, time.UTC),
+		},
+		"invalid time format": {
+			date:    "1985-04-12T23:20:50.52Z",
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			result, err := http.ParseTime(tt.date)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if result.IsZero() {
+				t.Fatalf("expected non-zero timestamp")
+			}
+			if tt.expect != result {
+				t.Fatalf("expected '%s' got '%s'", tt.expect, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Co-authored-by: Daniel Hochman <danielhochman@users.noreply.github.com>

Fixes https://github.com/aws/aws-sdk-go-v2/issues/1115 by relaxing the standard library's `http.ParseTime`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
