### PR TITLE
Serialize Unboxed Members marked as Required

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoValueAccessUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoValueAccessUtils.java
@@ -52,7 +52,7 @@ public final class GoValueAccessUtils {
             GoWriter writer,
             MemberShape member,
             String operand,
-            Boolean ignoreEmptyString,
+            boolean ignoreEmptyString,
             Runnable lambda
     ) {
         Shape targetShape = model.expectShape(member.getTarget());
@@ -191,7 +191,7 @@ public final class GoValueAccessUtils {
             GoWriter writer,
             MemberShape member,
             String operand,
-            Boolean ignoreEmptyString,
+            boolean ignoreEmptyString,
             Runnable lambda
     ) {
         Shape targetShape = model.expectShape(member.getTarget());

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -683,7 +683,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         if (location.equals(HttpBinding.Location.LABEL)) {
             // labels must always be set to be serialized on URI, and non empty strings,
             GoValueAccessUtils.writeIfZeroValueMember(context.getModel(), context.getSymbolProvider(), writer,
-                    memberShape, "v", false, operand -> {
+                    memberShape, "v", false, true, operand -> {
                         writer.addUseImports(SmithyGoDependency.SMITHY);
                         writer.write("return &smithy.SerializationError { "
                                         + "Err: fmt.Errorf(\"input member $L must not be empty\")}",
@@ -694,7 +694,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         boolean allowZeroStrings = location != HttpBinding.Location.HEADER;
 
         GoValueAccessUtils.writeIfNonZeroValueMember(context.getModel(), context.getSymbolProvider(), writer,
-                memberShape, "v", allowZeroStrings, (operand) -> {
+                memberShape, "v", allowZeroStrings, memberShape.isRequired(), (operand) -> {
                     final String locationName = binding.getLocationName().isEmpty()
                             ? memberShape.getMemberName() : binding.getLocationName();
                     switch (location) {
@@ -716,7 +716,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                             writer.addUseImports(SmithyGoDependency.NET_HTTP);
                             writer.openBlock("for mapKey, mapVal := range $L {", "}", operand, () -> {
                                 GoValueAccessUtils.writeIfNonZeroValue(context.getModel(), writer, valueMemberShape,
-                                        "mapVal", false, () -> {
+                                        "mapVal", false, false, () -> {
                                             writeHeaderBinding(context, valueMemberShape, "mapVal", location,
                                                     "http.CanonicalHeaderKey(mapKey)", "hv");
                                         });
@@ -781,7 +781,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             // Only set non-empty non-nil header values
             String indexedOperand = operand + "[i]";
             GoValueAccessUtils.writeIfNonZeroValue(context.getModel(), writer, collectionMemberShape, indexedOperand,
-                    false, () -> {
+                    false, false, () -> {
                         String op = conditionallyBase64Encode(writer, targetShape, indexedOperand);
                         writeHttpBindingSetter(context, writer, collectionMemberShape, location, op, (w, s) -> {
                             w.writeInline("$L.AddHeader($L).$L", dest, locationName, s);


### PR DESCRIPTION
Unboxed types for numbers and boolean values will be serialized regardless if they are the default value if they are marked with the required trait.

* Fixes an uncovered bug where URI parameters for numbers or boolean that were 0 or false would result in an invalid error. This condition is only applicable to prevent empty string values from being present in the URI.