### PR TITLE
Add support for shortened year format in HTTP Date

### DIFF
--- a/transport/http/time.go
+++ b/transport/http/time.go
@@ -10,6 +10,7 @@ import (
 // https://github.com/golang/go/blob/8869086d8f0a31033ccdc103106c768dc17216b1/src/net/http/header.go#L110-L127
 var timeFormats = []string{
 	"Mon, _2 Jan 2006 15:04:05 GMT", // Modifies http.TimeFormat with a leading underscore for day number (leading 0 optional).
+	"Mon, _2 Jan 06 15:04:05 GMT",   // two digit year
 	time.RFC850,
 	time.ANSIC,
 }

--- a/transport/http/time_test.go
+++ b/transport/http/time_test.go
@@ -45,6 +45,18 @@ func TestParseTime(t *testing.T) {
 			date:    "1985-04-12T23:20:50.52Z",
 			wantErr: true,
 		},
+		"shortened year with double digit day": {
+			date:   "Thu, 11 Feb 21 11:04:03 GMT",
+			expect: time.Date(2021, 2, 11, 11, 04, 03, 0, time.UTC),
+		},
+		"shortened year without leading zero day": {
+			date:   "Thu, 5 Feb 21 11:04:03 GMT",
+			expect: time.Date(2021, 2, 5, 11, 04, 03, 0, time.UTC),
+		},
+		"shortened year with leading zero day": {
+			date:   "Thu, 05 Feb 21 11:04:03 GMT",
+			expect: time.Date(2021, 2, 5, 11, 04, 03, 0, time.UTC),
+		},
 	}
 
 	for name, tt := range cases {


### PR DESCRIPTION
Adds support for HTTP date formats that contain a shortened two-digit year.

Related: https://github.com/aws/aws-sdk-go-v2/issues/1131 