### PR TITLE
Fix GitHub APIDiff action workflow to get gorelease tool correctly

### DIFF
--- a/.github/workflows/api_diff_check.yml
+++ b/.github/workflows/api_diff_check.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.14
+        go-version: ^1.15
       id: go
 
     - name: Check out code into the Go module directory
@@ -24,7 +24,7 @@ jobs:
 
     - name: Get dependencies
       run: |
-        go install golang.org/x/exp/cmd/gorelease
+        (cd /tmp && go get golang.org/x/exp/cmd/gorelease@latest)
 
     - name: Check APIs
       run: $(go env GOPATH)/bin/gorelease

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/aws/smithy-go
 
-go 1.14
+go 1.15
 
-require github.com/google/go-cmp v0.4.1
+require github.com/google/go-cmp v0.5.4

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
-github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Fixes the APIDiff GitHub action to correctly get the gorelease tooling.

Correct the smithy-go module's minimum Go version to 1.15 not 1.14. Also updates `go-cmp` to correct 0.5.4 version.