### PR TITLE
 Fix codegen artifact unit test for Go 1.16

### DIFF
--- a/codegen/smithy-go-codegen-test/build.gradle.kts
+++ b/codegen/smithy-go-codegen-test/build.gradle.kts
@@ -36,6 +36,6 @@ dependencies {
 tasks.create<Exec>("verifyGoCodegen") {
     dependsOn ("build")
     workingDir("$buildDir/smithyprojections/smithy-go-codegen-test/source/go-codegen")
-    commandLine ("go", "test", "-run", "NONE", "./...")
+    commandLine ("go", "test", "-mod", "mod", "-run", "NONE", "./...")
 }
 tasks["build"].finalizedBy(tasks["verifyGoCodegen"])


### PR DESCRIPTION
Fixes the codegen artifact unit test for Go 1.16 to work with the go.sum file not being updated.