### PR TITLE
Add smithy-go's v1.2.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: true
 dist: bionic
 
 install:
-    - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.15.x bash)"
+    - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.16.x bash)"
     - echo `go env`
     - echo `which go`
 
@@ -12,15 +12,19 @@ script: cd codegen && ./gradlew clean build -Plog-tests
 matrix:
   include:
     - language: java
-      go: 1.15.x
+      go: 1.16.x
       jdk: openjdk8
 
     - language: java
-      go: 1.15.x
+      go: 1.16.x
       jdk: openjdk11
 
     - language: go
       go: 1.15.x
+      script: go test -v ./...
+
+    - language: go
+      go: 1.16.x
       script: go test -v ./...
 
   allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Release 2021-03-12 v1.2.0
+
+### Smithy Go module
+* Fix support for parsing shortened year format in HTTP Date header.
+* Fix GitHub APIDiff action workflow to get gorelease tool correctly.
+* Fix codegen artifact unit test for Go 1.16
+
+### Codegen
+* Fix generating paginator nil parameter handling before usage.
+* Fix Serialize unboxed members decorated as required.
+* Add ability to define resolvers at both client construction and operation invocation.
+* Support for extending paginators with custom runtime trait

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -118,7 +118,7 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.15";
         private static final String GO_CMP = "v0.5.4";
-        private static final String SMITHY_GO = "v1.1.0";
+        private static final String SMITHY_GO = "v1.2.0";
         private static final String GO_JMESPATH = "v0.4.0";
     }
 }


### PR DESCRIPTION
Adds change notes for smithy-go v1.2.0 go module release, and codegen update.

```
# Release 2021-03-12 v1.2.0

### Smithy Go module
* Fix support for parsing shortened year format in HTTP Date header.
* Fix GitHub APIDiff action workflow to get gorelease tool correctly.
* Fix codegen artifact unit test for Go 1.16

### Codegen
* Fix generating paginator nil parameter handling before usage.
* Fix Serialize unboxed members decorated as required.
* Add ability to define resolvers at both client construction and operation invocation.
* Support for extending paginators with custom runtime trait
```
