### PR TITLE
transport/http : Loosen hostname validation to allow ports to be specified

### DIFF
--- a/transport/http/host_test.go
+++ b/transport/http/host_test.go
@@ -5,6 +5,28 @@ import (
 	"testing"
 )
 
+func TestValidPortNumber(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+		{Input: "123", Valid: true},
+		{Input: "123.0", Valid: false},
+		{Input: "-123", Valid: false},
+		{Input: "65536", Valid: false},
+		{Input: "0", Valid: true},
+	}
+	for i, c := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			valid := ValidPortNumber(c.Input)
+			if e, a := c.Valid, valid; e != a {
+				t.Errorf("expect valid %v, got %v", e, a)
+			}
+		})
+	}
+
+}
+
 func TestValidHostLabel(t *testing.T) {
 	cases := []struct {
 		Input string
@@ -48,6 +70,10 @@ func TestValidateEndpointHostHandler(t *testing.T) {
 			Input: "123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456",
 			Valid: false,
 		},
+		"valid host with port number":         {Input: "abd.123:1234", Valid: true},
+		"valid host with invalid port number": {Input: "abc.123:99999", Valid: false},
+		"empty host with port number":         {Input: ":1234", Valid: false},
+		"valid host with empty port number":   {Input: "abc.123:", Valid: false},
 	}
 
 	for name, c := range cases {


### PR DESCRIPTION
*Issue #, if available:*

* customers can not specify ports with endpoints. 

*Description of changes:*

* Update validateEndpointHost function to allow valid port usage. 

* Adds test.

Fixes https://github.com/aws/aws-sdk-go-v2/issues/1035


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
