### PR TITLE
Fix RingBuffer panic due to out of bounds index

### DIFF
--- a/io/ringbuffer.go
+++ b/io/ringbuffer.go
@@ -45,7 +45,7 @@ func (r *RingBuffer) Write(p []byte) (int, error) {
 		r.end++
 		r.size++
 	}
-	return r.size, nil
+	return len(p), nil
 }
 
 // Read copies the data on the ring buffer into the byte slice provided to the method.
@@ -60,18 +60,23 @@ func (r *RingBuffer) Read(p []byte) (int, error) {
 			return readCount, io.EOF
 		}
 
+		if r.start == len(r.slice) {
+			r.start = 0
+		}
+
 		p[j] = r.slice[r.start]
 		readCount++
 		// increment the start pointer for ring buffer
 		r.start++
 		// decrement the size of ring buffer
 		r.size--
-
-		if r.start == len(r.slice) {
-			r.start = 0
-		}
 	}
 	return readCount, nil
+}
+
+// Len returns the number of unread bytes in the buffer.
+func (r *RingBuffer) Len() int {
+	return r.size
 }
 
 // Bytes returns a copy of the RingBuffer's bytes.


### PR DESCRIPTION
Fixes an index out of bounds in the RingBuffer implementation.

Fixes https://github.com/aws/aws-sdk-go-v2/issues/1200