### PR TITLE
Update smithy-go version to point to release v1.3.1

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -118,7 +118,7 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.15";
         private static final String GO_CMP = "v0.5.4";
-        private static final String SMITHY_GO = "v1.3.0";
+        private static final String SMITHY_GO = "v1.3.1";
         private static final String GO_JMESPATH = "v0.4.0";
     }
 }


### PR DESCRIPTION
Update smithy-go version to point to release v1.3.1. 

PR should be merged before #284 is merged.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
