### PR TITLE
Create operation input/output synthetic shapes before integrations preprocess model

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -85,13 +85,13 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
         fileManifest = context.getFileManifest();
 
         Model resolvedModel = context.getModel();
+        // Add unique operation input/output shapes
+        resolvedModel = AddOperationShapes.execute(resolvedModel, settings.getService());
+
         LOGGER.info(() -> "Preprocessing smithy model");
         for (GoIntegration goIntegration : integrations) {
             resolvedModel = goIntegration.preprocessModel(resolvedModel, settings);
         }
-
-        // Add unique operation input/output shapes
-        resolvedModel = AddOperationShapes.execute(resolvedModel, settings.getService());
 
         model = resolvedModel;
 


### PR DESCRIPTION
Updates smithy-go codegen to clone operation top level input and output to be performed before other integrations can preprocess models. This ensures that the preprocessors are working on the correct operation top level shapes.