### PR TITLE
Update smithy-go codegen version to v1.4.0

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -118,7 +118,7 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.15";
         private static final String GO_CMP = "v0.5.4";
-        private static final String SMITHY_GO = "v1.3.2-0.20210505063801-56a3fe683671";
+        private static final String SMITHY_GO = "v1.4.0";
         private static final String GO_JMESPATH = "v0.4.0";
     }
 }


### PR DESCRIPTION
Updates smithy-go's codegen to use version v1.4.0 of smithy-go Go modules.