### PR TITLE
Update java group id

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 allprojects {
-    group = "software.amazon.smithy"
+    group = "software.amazon.smithy.go"
     version = "0.1.0"
 }
 


### PR DESCRIPTION
This updates the java group id to be namespaced to the language. This
will be necessary for eventually publishing the generators.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
