### PR TITLE
Add GitHub actions instead of Travis for Go CI tests

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -1,0 +1,34 @@
+name: Codegen Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  codegen-test:
+    name: SDK Codegen Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        java-version: ['11', '8']
+        go-version: [1.16]
+    env:
+      JAVA_TOOL_OPTIONS: "-Xmx2g"
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-java@v2
+      with:
+        distribution: 'zulu'
+        java-version: ${{ matrix.java-version }}
+
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: SDK Codegen
+      run: cd codegen && ./gradlew clean build -Plog-tests
+

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,27 @@
+name: Go Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  unit-tests:
+    name: Test SDK
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version: [1.16, 1.15]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Test
+      run: go test -v ./...
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,28 @@
-language: java
+language: go
 sudo: true
 dist: bionic
-
-install:
-    - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.16.x bash)"
-    - echo `go env`
-    - echo `which go`
-
-script: cd codegen && ./gradlew clean build -Plog-tests
-
-matrix:
-  include:
-    - language: java
-      go: 1.16.x
-      jdk: openjdk8
-
-    - language: java
-      go: 1.16.x
-      jdk: openjdk11
-
-    - language: go
-      go: 1.15.x
-      script: go test -v ./...
-
-    - language: go
-      go: 1.16.x
-      script: go test -v ./...
-
-  allow_failures:
-    - language: go
-      go: tip
-      script: go test -v ./...
 
 branches:
   only:
     - main
+
+os:
+  - linux
+  - osx
+  # Travis doesn't work with windows and Go tip
+  #- windows
+
+go:
+  - tip
+
+matrix:
+  allow_failures:
+    - go: tip
+
+before_install:
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then choco install make; fi
+  - (cd /tmp/; go get golang.org/x/lint/golint)
+
+script:
+  - make go test -v ./...;
+


### PR DESCRIPTION
Updates the SDK's CI to use GitHub actions intead of Travis for most CI tasks. Travis is still used for Go tip.