### PR TITLE
Support the delegation of determining the errors that can occur for an operation

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -357,7 +357,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         goWriter.write("");
 
         Set<StructureShape> errorShapes = HttpProtocolGeneratorUtils.generateErrorDispatcher(
-                context, operation, responseType, this::writeErrorMessageCodeDeserializer);
+                context, operation, responseType, this::writeErrorMessageCodeDeserializer,
+                this::getOperationErrors);
         deserializingErrorShapes.addAll(errorShapes);
         deserializeDocumentBindingShapes.addAll(errorShapes);
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
@@ -289,7 +289,8 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         writer.write("");
 
         Set<StructureShape> errorShapes = HttpProtocolGeneratorUtils.generateErrorDispatcher(
-                context, operation, responseType, this::writeErrorMessageCodeDeserializer);
+                context, operation, responseType, this::writeErrorMessageCodeDeserializer,
+                this::getOperationErrors);
         deserializingErrorShapes.addAll(errorShapes);
         deserializingDocumentShapes.addAll(errorShapes);
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.go.codegen.integration;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.SymbolProvider;
@@ -246,6 +247,17 @@ public interface ProtocolGenerator {
         return protocol
                 + "_deserializeOp"
                 + operationShapeId.getName(service);
+    }
+
+    /**
+     * Returns a map of error names to their {@link ShapeId}.
+     *
+     * @param context the generation context
+     * @param operation the operation shape to retrieve errors for
+     * @return map of error names to {@link ShapeId}
+     */
+    default Map<String, ShapeId> getOperationErrors(GenerationContext context, OperationShape operation) {
+        return HttpProtocolGeneratorUtils.getOperationErrors(context, operation);
     }
 
     /**


### PR DESCRIPTION
Support the delegation of determining the errors that can occur for an operation. Required to implement support for [awsQueryError](https://awslabs.github.io/smithy/1.0/spec/aws/aws-query-protocol.html#aws-protocols-awsqueryerror-trait) trait.