### PR TITLE
Smithy Document Shape Support

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -39,7 +39,6 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.neighbor.Walker;
-import software.amazon.smithy.model.shapes.DocumentShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -168,8 +167,8 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
             shape.accept(this);
         }
 
-        // Generate standard DocumentShape interface
-        protocolDocumentGenerator.generateStandardTypes();
+        // Generate any required types and functions need to support protocol documents.
+        protocolDocumentGenerator.generateDocumentSupport();
 
         // Generate a struct to handle unknown tags in unions
         List<UnionShape> unions = serviceShapes.stream()
@@ -231,12 +230,6 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
     @Override
     protected Void getDefault(Shape shape) {
-        return null;
-    }
-
-    @Override
-    public Void documentShape(DocumentShape shape) {
-        protocolDocumentGenerator.addDocumentShape(shape);
         return null;
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
@@ -257,6 +257,20 @@ public final class GoWriter extends CodeWriter {
     }
 
     /**
+     * Writes the doc to the Go package docs that are written prior to the go package statement. This does not perform
+     * line wrapping and the provided formatting must be valid Go doc.
+     *
+     * @param docs documentation to write to package doc.
+     * @return writer
+     */
+    public GoWriter writeRawPackageDocs(String docs) {
+        writeDocs(packageDocs, () -> {
+            packageDocs.write(docs);
+        });
+        return this;
+    }
+
+    /**
      * Writes shape documentation comments if docs are present.
      *
      * @param shape Shape to write the documentation of.

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ProtocolDocumentGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ProtocolDocumentGenerator.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen;
+
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Consumer;
+
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
+import software.amazon.smithy.go.codegen.integration.ProtocolGenerator.GenerationContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.DocumentShape;
+
+/**
+ * Generates the Smithy document type for the service client.
+ */
+public final class ProtocolDocumentGenerator {
+    public static final String DOCUMENT_INTERFACE_NAME = "Interface";
+    public static final String NO_DOCUMENT_SERDE_TYPE_NAME = "noSmithyDocumentSerde";
+    public static final String NEW_LAZY_DOCUMENT = "NewLazyDocument";
+    public static final String INTERNAL_NEW_DOCUMENT_MARSHALER_FUNC = "NewDocumentMarshaler";
+    public static final String INTERNAL_NEW_DOCUMENT_UNMARSHALER_FUNC = "NewDocumentUnmarshaler";
+    public static final String INTERNAL_IS_DOCUMENT_INTERFACE = "IsInterface";
+    public static final String UNMARSHAL_SMITHY_DOCUMENT_METHOD = "UnmarshalSmithyDocument";
+    public static final String MARSHAL_SMITHY_DOCUMENT_METHOD = "MarshalSmithyDocument";
+
+    private static final String SERVICE_SMITHY_DOCUMENT_INTERFACE = "smithyDocument";
+    private static final String IS_SMITHY_DOCUMENT_METHOD = "isSmithyDocument";
+
+
+    private final GoSettings settings;
+    private final GoDelegator delegator;
+    private final Set<DocumentShape> documentShapes = new TreeSet<>();
+    private final Model model;
+
+    public ProtocolDocumentGenerator(
+            GoSettings settings,
+            Model model,
+            GoDelegator delegator
+    ) {
+        this.settings = settings;
+        this.model = model;
+        this.delegator = delegator;
+    }
+
+    /**
+     * Get the set of document shapes for the service.
+     *
+     * @return the service's document shapes.
+     */
+    public Set<DocumentShape> getDocumentShapes() {
+        return documentShapes;
+    }
+
+    /**
+     * Returns whether the service has any document shapes.
+     *
+     * @return whether the service has one or more document types.
+     */
+    public boolean hasDocumentShapes() {
+        return getDocumentShapes().size() > 0;
+    }
+
+    /**
+     * Add a document shape to the generator.
+     *
+     * @param shape the document shape to add.
+     */
+    public void addDocumentShape(DocumentShape shape) {
+        documentShapes.add(shape);
+    }
+
+    /**
+     *
+     */
+    public void generateStandardTypes() {
+        generateNoSerdeType();
+        generateInternalDocumentInterface();
+        generateDocumentPackage();
+    }
+
+    private void generateDocumentPackage() {
+        if (!hasDocumentShapes()) {
+            return;
+        }
+
+        writeDocumentPackage("document.go", writer -> {
+            writer.write("type $L = $T", DOCUMENT_INTERFACE_NAME,
+                            getInternalDocumentSymbol(DOCUMENT_INTERFACE_NAME))
+                    .write("");
+
+            writer.openBlock("func $L(v interface{}) $T {", "}", NEW_LAZY_DOCUMENT,
+                            getDocumentSymbol(DOCUMENT_INTERFACE_NAME), () -> {
+                                writer.write("return $T(v)",
+                                        getInternalDocumentSymbol(INTERNAL_NEW_DOCUMENT_MARSHALER_FUNC));
+                            })
+                    .write("");
+        });
+    }
+
+    private void generateNoSerdeType() {
+        Symbol noSerde = SymbolUtils.createValueSymbolBuilder("NoSerde",
+                SmithyGoDependency.SMITHY_DOCUMENT).build();
+
+        delegator.useShapeWriter(settings.getService(model), writer -> {
+            writer.write("type $L = $T", NO_DOCUMENT_SERDE_TYPE_NAME, noSerde);
+        });
+
+        delegator.useFileWriter("./types/types.go", settings.getModuleName() + "/types", writer -> {
+            writer.write("type $L = $T", NO_DOCUMENT_SERDE_TYPE_NAME, noSerde);
+        });
+    }
+
+    private void generateInternalDocumentInterface() {
+        if (!hasDocumentShapes()) {
+            return;
+        }
+
+        writeInternalDocumentPackage("document.go", writer -> {
+            Symbol serviceSmithyDocumentInterface = getInternalDocumentSymbol(SERVICE_SMITHY_DOCUMENT_INTERFACE);
+
+            writer.openBlock("type $T interface {", "}", serviceSmithyDocumentInterface,
+                            () -> writer.write("$L()", IS_SMITHY_DOCUMENT_METHOD))
+                    .write("");
+
+            Symbol internalDocumentInterface = getInternalDocumentSymbol(DOCUMENT_INTERFACE_NAME);
+            Symbol smithyDocumentMarshaler = SymbolUtils.createValueSymbolBuilder("SmithyDocumentMarshaler",
+                    SmithyGoDependency.SMITHY_DOCUMENT).build();
+            Symbol smithyDocumentUnmarshaler = SymbolUtils.createValueSymbolBuilder("SmithyDocumentUnmarshaler",
+                    SmithyGoDependency.SMITHY_DOCUMENT).build();
+
+            writer.openBlock("type $T interface {", "}", internalDocumentInterface, () -> {
+                writer.write("$T", serviceSmithyDocumentInterface);
+                writer.write("$T", smithyDocumentMarshaler);
+                writer.write("$T", smithyDocumentUnmarshaler);
+            }).write("");
+
+            writer.write("var _ $T = ($P)(nil)",
+                    serviceSmithyDocumentInterface, internalDocumentInterface);
+            writer.write("var _ $T = ($P)(nil)",
+                    smithyDocumentMarshaler, internalDocumentInterface);
+            writer.write("var _ $T = ($P)(nil)",
+                    smithyDocumentUnmarshaler,
+                    internalDocumentInterface);
+            writer.write("");
+        });
+    }
+
+    /**
+     * Generates the internal document Go package for the service client. Delegates the logic for document marshaling
+     * and unmarshalling types to the provided protocol generator using the given context.
+     *
+     * @param protocolGenerator the protocol generator.
+     * @param context           the protocol generator context.
+     */
+    public void generateInternalDocumentTypes(ProtocolGenerator protocolGenerator, GenerationContext context) {
+        if (!hasDocumentShapes()) {
+            return;
+        }
+
+        delegator.useFileWriter(getInternalDocumentFilePath("document.go"), getInternalDocumentPackage(), writer -> {
+            Symbol marshalerSymbol = getInternalDocumentSymbol("documentMarshaler",
+                    true);
+            Symbol unmarshalerSymbol = getInternalDocumentSymbol("documentUnmarshaler", true);
+
+            Symbol isDocumentInterface = getInternalDocumentSymbol(INTERNAL_IS_DOCUMENT_INTERFACE);
+
+            writeInternalDocumentImplementation(
+                    writer,
+                    marshalerSymbol,
+                    () -> {
+                        protocolGenerator.generateProtocolDocumentMarshalerUnmarshalDocument(context.toBuilder()
+                                .writer(writer)
+                                .build());
+                    },
+                    () -> {
+                        protocolGenerator.generateProtocolDocumentMarshalerMarshalDocument(context.toBuilder()
+                                .writer(writer)
+                                .build());
+                    });
+            writeInternalDocumentImplementation(writer,
+                    unmarshalerSymbol,
+                    () -> {
+                        protocolGenerator.generateProtocolDocumentUnmarshalerUnmarshalDocument(context.toBuilder()
+                                .writer(writer)
+                                .build());
+                    },
+                    () -> {
+                        protocolGenerator.generateProtocolDocumentUnmarshalerMarshalDocument(context.toBuilder()
+                                .writer(writer)
+                                .build());
+                    });
+
+            Symbol documentInterfaceSymbol = getInternalDocumentSymbol(DOCUMENT_INTERFACE_NAME);
+
+            writer.openBlock("func $L(v interface{}) $T {", "}", INTERNAL_NEW_DOCUMENT_MARSHALER_FUNC,
+                    documentInterfaceSymbol, () -> {
+                        protocolGenerator.generateNewDocumentMarshaler(context.toBuilder()
+                                .writer(writer)
+                                .build(), marshalerSymbol);
+                    }).write("");
+
+            writer.openBlock("func $L(v interface{}) $T {", "}", INTERNAL_NEW_DOCUMENT_UNMARSHALER_FUNC,
+                    documentInterfaceSymbol, () -> {
+                        protocolGenerator.generateNewDocumentUnmarshaler(context.toBuilder()
+                                .writer(writer)
+                                .build(), unmarshalerSymbol);
+                    }).write("");
+
+            writer.openBlock("func $T(v Interface) (ok bool) {", "}", isDocumentInterface, () -> {
+                writer.openBlock("defer func() {", "}()", () -> {
+                    writer.openBlock("if err := recover(); err != nil {", "}", () -> writer.write("ok = false"));
+                });
+                writer.write("v.$L()", IS_SMITHY_DOCUMENT_METHOD);
+                writer.write("return true");
+            }).write("");
+        });
+    }
+
+    private void writeInternalDocumentImplementation(
+            GoWriter writer,
+            Symbol typeSymbol,
+            Runnable unmarshalMethodDefinition,
+            Runnable marshalMethodDefinition
+    ) {
+        writer.openBlock("type $T struct {", "}", typeSymbol, () -> {
+            writer.write("value interface{}");
+        });
+        writer.write("");
+
+        writer.openBlock("func (m $P) $L(v interface{}) error {", "}", typeSymbol, UNMARSHAL_SMITHY_DOCUMENT_METHOD,
+                unmarshalMethodDefinition);
+        writer.write("");
+
+        writer.openBlock("func (m $P) $L() ([]byte, error) {", "}", typeSymbol, MARSHAL_SMITHY_DOCUMENT_METHOD,
+                marshalMethodDefinition);
+        writer.write("");
+
+        writer.write("func (m $P) $L() {}", typeSymbol, IS_SMITHY_DOCUMENT_METHOD);
+        writer.write("");
+
+        writer.write("var _ $T = ($P)(nil)", getInternalDocumentSymbol(DOCUMENT_INTERFACE_NAME, true), typeSymbol);
+        writer.write("");
+    }
+
+    private void writeDocumentPackage(String fileName, Consumer<GoWriter> writerConsumer) {
+        delegator.useFileWriter(getDocumentFilePath(fileName), getDocumentPackage(), writerConsumer);
+    }
+
+    private void writeInternalDocumentPackage(String fileName, Consumer<GoWriter> writerConsumer) {
+        delegator.useFileWriter(getInternalDocumentFilePath(fileName), getInternalDocumentPackage(), writerConsumer);
+    }
+
+    private String getInternalDocumentPackage() {
+        return Utilities.getInternalDocumentPackage(settings);
+    }
+
+    private String getDocumentPackage() {
+        return Utilities.getDocumentPackage(settings);
+    }
+
+    private String getInternalDocumentFilePath(String fileName) {
+        return "./internal/document/" + fileName;
+    }
+
+    private String getDocumentFilePath(String fileName) {
+        return "./document/" + fileName;
+    }
+
+    private Symbol getDocumentSymbol(String typeName) {
+        return getDocumentSymbol(typeName, false);
+    }
+
+    private Symbol getDocumentSymbol(String typeName, boolean pointable) {
+        return Utilities.getDocumentSymbolBuilder(settings, typeName, pointable).build();
+    }
+
+    private Symbol getInternalDocumentSymbol(String typeName) {
+        return getInternalDocumentSymbol(typeName, false);
+    }
+
+    private Symbol getInternalDocumentSymbol(String typeName, boolean pointable) {
+        return Utilities.getInternalDocumentSymbolBuilder(settings, typeName, pointable).build();
+    }
+
+    /**
+     * Collection of helper utility functions for creating references to the service client's internal
+     * and external document package types.
+     */
+    public static final class Utilities {
+        /**
+         * Create a non-pointable {@link Symbol.Builder} for typeName in the service's document package.
+         *
+         * @param settings the Smithy Go settings.
+         * @param typeName the name of the Go type.
+         * @return the symbol builder.
+         */
+        public static Symbol.Builder getDocumentSymbolBuilder(GoSettings settings, String typeName) {
+            return getDocumentSymbolBuilder(settings, typeName, false);
+        }
+
+        /**
+         * Create {@link Symbol.Builder} for typeName in the service's document package.
+         *
+         * @param settings  the Smithy Go settings.
+         * @param typeName  the name of the Go type.
+         * @param pointable whether typeName is pointable.
+         * @return the symbol builder.
+         */
+        public static Symbol.Builder getDocumentSymbolBuilder(
+                GoSettings settings,
+                String typeName,
+                boolean pointable
+        ) {
+            return pointable
+                    ? SymbolUtils.createPointableSymbolBuilder(typeName, getDocumentPackage(settings))
+                    : SymbolUtils.createValueSymbolBuilder(typeName, getDocumentPackage(settings));
+        }
+
+        /**
+         * Create a non-pointable {@link Symbol.Builder} for typeName in the service's internal document package.
+         *
+         * @param settings the Smithy Go settings.
+         * @param typeName the name of the Go type.
+         * @return the symbol builder.
+         */
+        public static Symbol.Builder getInternalDocumentSymbolBuilder(GoSettings settings, String typeName) {
+            return getInternalDocumentSymbolBuilder(settings, typeName, false);
+        }
+
+        /**
+         * Create {@link Symbol.Builder} for typeName in the service's internal document package.
+         *
+         * @param settings  the Smithy Go settings.
+         * @param typeName  the name of the Go type.
+         * @param pointable whether typeName is pointable.
+         * @return the symbol builder.
+         */
+        public static Symbol.Builder getInternalDocumentSymbolBuilder(
+                GoSettings settings,
+                String typeName,
+                boolean pointable
+        ) {
+            Symbol.Builder builder = pointable
+                    ? SymbolUtils.createPointableSymbolBuilder(typeName, getInternalDocumentPackage(settings))
+                    : SymbolUtils.createValueSymbolBuilder(typeName, getInternalDocumentPackage(settings));
+            builder.putProperty(SymbolUtils.NAMESPACE_ALIAS, "internaldocument");
+            return builder;
+        }
+
+        private static String getInternalDocumentPackage(GoSettings settings) {
+            return settings.getModuleName() + "/internal/document";
+        }
+
+        private static String getDocumentPackage(GoSettings settings) {
+            return settings.getModuleName() + "/document";
+        }
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeValueGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeValueGenerator.java
@@ -55,6 +55,7 @@ import software.amazon.smithy.utils.SmithyBuilder;
 public final class ShapeValueGenerator {
     private static final Logger LOGGER = Logger.getLogger(ShapeValueGenerator.class.getName());
 
+    private final GoSettings settings;
     private final Model model;
     private final SymbolProvider symbolProvider;
     private final GoPointableIndex pointableIndex;
@@ -63,21 +64,24 @@ public final class ShapeValueGenerator {
     /**
      * Initializes a shape value generator.
      *
+     * @param settings       the Smithy Go settings.
      * @param model          the Smithy model references.
      * @param symbolProvider the symbol provider.
      */
-    public ShapeValueGenerator(Model model, SymbolProvider symbolProvider) {
-        this(model, symbolProvider, Config.builder().build());
+    public ShapeValueGenerator(GoSettings settings, Model model, SymbolProvider symbolProvider) {
+        this(settings, model, symbolProvider, Config.builder().build());
     }
 
     /**
      * Initializes a shape value generator.
      *
+     * @param settings       the Smithy Go settings.
      * @param model          the Smithy model references.
      * @param symbolProvider the symbol provider.
      * @param config         the shape value generator config.
      */
-    public ShapeValueGenerator(Model model, SymbolProvider symbolProvider, Config config) {
+    public ShapeValueGenerator(GoSettings settings, Model model, SymbolProvider symbolProvider, Config config) {
+        this.settings = settings;
         this.model = model;
         this.symbolProvider = symbolProvider;
         this.pointableIndex = GoPointableIndex.of(model);
@@ -150,13 +154,21 @@ public final class ShapeValueGenerator {
                 break;
 
             case DOCUMENT:
-                LOGGER.warning("Skipping " + member.getType() + " shape type not supported, " + member.getId());
-                writer.writeInline("nil");
+                documentDeclShapeValue(writer, member, params);
                 break;
 
             default:
                 writeScalarPointerInline(writer, member, params);
         }
+    }
+
+    private void documentDeclShapeValue(GoWriter writer, MemberShape member, Node params) {
+        Symbol newMarshaler = ProtocolDocumentGenerator.Utilities.getDocumentSymbolBuilder(settings,
+                ProtocolDocumentGenerator.NEW_LAZY_DOCUMENT).build();
+
+        writer.writeInline("$T(", newMarshaler);
+        new DocumentValueNodeVisitor(writer).getDefault(params);
+        writer.writeInline(")");
     }
 
     /**
@@ -395,6 +407,107 @@ public final class ShapeValueGenerator {
         }
     }
 
+    private static final class DocumentValueNodeVisitor extends NodeVisitor.Default<Void> {
+        private final GoWriter writer;
+
+        private DocumentValueNodeVisitor(GoWriter writer) {
+            this.writer = writer;
+        }
+
+        @Override
+        public Void arrayNode(ArrayNode node) {
+            writer.writeInline("[]interface{}{\n");
+            for (Node element : node.getElements()) {
+                getDefault(element);
+                writer.writeInline(",\n");
+            }
+            writer.writeInline("}");
+            return null;
+        }
+
+        @Override
+        public Void booleanNode(BooleanNode node) {
+            if (node.getValue()) {
+                writer.writeInline("true");
+            } else {
+                writer.writeInline("false");
+            }
+            return null;
+        }
+
+        @Override
+        public Void nullNode(NullNode node) {
+            writer.writeInline("nil");
+            return null;
+        }
+
+        @Override
+        public Void numberNode(NumberNode node) {
+            if (node.isNaturalNumber()) {
+                writer.writeInline("$L", node.getValue());
+            } else {
+                Number value = node.getValue();
+                if (value instanceof Float) {
+                    writer.writeInline("float32($L)", value.floatValue(), value);
+                } else if (value instanceof Double) {
+                    writer.writeInline("float64($L)", value.doubleValue(), value);
+                } else {
+                    writer.addUseImports(SmithyGoDependency.BIG);
+                    writer.writeInline("func () *big.Float {\n"
+                            + "\tf, ok := (&big.Float{}).SetString($S)\n"
+                            + "\tif !ok { panic(\"failed to parse string to float: \" + $S) }\n"
+                            + "\treturn f\n"
+                            + "}()", value, value);
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public Void objectNode(ObjectNode node) {
+            writer.writeInline("map[string]interface{}{\n");
+            node.getMembers().forEach((key, value) -> {
+                writer.writeInline("$S: ", key.getValue());
+                getDefault(value);
+                writer.writeInline(",\n");
+            });
+            writer.writeInline("}");
+            return null;
+        }
+
+        @Override
+        public Void stringNode(StringNode node) {
+            writer.writeInline("$S", node.getValue());
+            return null;
+        }
+
+        public Void getDefault(Node node) {
+            switch (node.getType()) {
+                case OBJECT:
+                    objectNode(node.expectObjectNode());
+                    break;
+                case ARRAY:
+                    arrayNode(node.expectArrayNode());
+                    break;
+                case STRING:
+                    stringNode(node.expectStringNode());
+                    break;
+                case NUMBER:
+                    numberNode(node.expectNumberNode());
+                    break;
+                case BOOLEAN:
+                    booleanNode(node.expectBooleanNode());
+                    break;
+                case NULL:
+                    nullNode(node.expectNullNode());
+                    break;
+                default:
+                    throw new CodegenException("unknown node type: " + node.getType());
+            }
+            return null;
+        }
+    }
+
     /**
      * NodeVisitor to walk shape value declarations with node values.
      */
@@ -499,7 +612,7 @@ public final class ShapeValueGenerator {
                         String keyValue = keyNode.getValue();
                         if (config.isNormalizeHttpPrefixHeaderKeys()) {
                             keyValue = OptionalUtils.or(getTrait(HttpPrefixHeadersTrait.class),
-                                    () -> mapShape.getTrait(HttpPrefixHeadersTrait.class))
+                                            () -> mapShape.getTrait(HttpPrefixHeadersTrait.class))
                                     .map(httpPrefixHeadersTrait -> keyNode.getValue().toLowerCase())
                                     .orElse(keyValue);
                         }
@@ -667,5 +780,4 @@ public final class ShapeValueGenerator {
             return Optional.empty();
         }
     }
-
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -54,6 +54,8 @@ public final class SmithyGoDependency {
     public static final GoDependency SMITHY_RAND = smithy("rand", "smithyrand");
     public static final GoDependency SMITHY_TESTING = smithy("testing", "smithytesting");
     public static final GoDependency SMITHY_WAITERS = smithy("waiter", "smithywaiter");
+    public static final GoDependency SMITHY_DOCUMENT = smithy("document", "smithydocument");
+    public static final GoDependency SMITHY_DOCUMENT_JSON = smithy("document/json", "smithydocumentjson");
 
     public static final GoDependency GO_CMP = goCmp("cmp");
     public static final GoDependency GO_CMP_OPTIONS = goCmp("cmp/cmpopts");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
@@ -111,6 +111,10 @@ final class StructureGenerator implements Runnable {
         });
 
         runnable.run();
+
+        writer.write("");
+        writer.write("$L", ProtocolDocumentGenerator.NO_DOCUMENT_SERDE_TYPE_NAME);
+
         writer.closeBlock("}").write("");
     }
 
@@ -138,6 +142,9 @@ final class StructureGenerator implements Runnable {
                     writer.write("$L $P", memberName, symbolProvider.toSymbol(member));
                 }
             }
+
+            writer.write("");
+            writer.write("$L", ProtocolDocumentGenerator.NO_DOCUMENT_SERDE_TYPE_NAME);
         }).write("");
 
         // write the Error method to satisfy the standard error interface

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
@@ -112,6 +112,11 @@ final class StructureGenerator implements Runnable {
 
         runnable.run();
 
+        // At this moment there is no support for the concept of modeled document structure types.
+        // We embed the NoSerde type to prevent usage of the generated structure shapes from being used
+        // as document types themselves, or part of broader document-type structures. This avoids making backwards
+        // incompatible changes if the document type representation changes if it is later annotated as a modeled
+        // document type. This restriction may be relaxed later by removing this constraint.
         writer.write("");
         writer.write("$L", ProtocolDocumentGenerator.NO_DOCUMENT_SERDE_TYPE_NAME);
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -408,8 +408,8 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol documentShape(DocumentShape shape) {
-        String name = getDefaultShapeName(shape);
-        return symbolBuilderFor(shape, name, SmithyGoDependency.SMITHY)
+        return ProtocolDocumentGenerator.Utilities.getDocumentSymbolBuilder(settings,
+                ProtocolDocumentGenerator.DOCUMENT_INTERFACE_NAME)
                 .build();
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/UnionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/UnionGenerator.java
@@ -84,6 +84,8 @@ public class UnionGenerator {
                 } else {
                     writer.write("Value $P", memberSymbol);
                 }
+                writer.write("");
+                writer.write("$L", ProtocolDocumentGenerator.NO_DOCUMENT_SERDE_TYPE_NAME);
             });
 
             writer.write("func (*$L) is$L() {}", exportedMemberName, symbol.getName());
@@ -154,6 +156,8 @@ public class UnionGenerator {
             writer.write("Tag string");
             // The value received.
             writer.write("Value []byte");
+            writer.write("");
+            writer.write("$L", ProtocolDocumentGenerator.NO_DOCUMENT_SERDE_TYPE_NAME);
         });
 
         for (UnionShape union : unions) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/DocumentShapeDeserVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/DocumentShapeDeserVisitor.java
@@ -411,7 +411,7 @@ public abstract class DocumentShapeDeserVisitor extends ShapeVisitor.Default<Voi
             BiConsumer<GenerationContext, Shape> functionBody
     ) {
         SymbolProvider symbolProvider = context.getSymbolProvider();
-        GoWriter writer = context.getWriter();
+        GoWriter writer = context.getWriter().get();
 
         Symbol symbol = symbolProvider.toSymbol(shape);
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/DocumentShapeSerVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/DocumentShapeSerVisitor.java
@@ -320,7 +320,7 @@ public abstract class DocumentShapeSerVisitor extends ShapeVisitor.Default<Void>
             BiConsumer<GenerationContext, Shape> functionBody
     ) {
         SymbolProvider symbolProvider = context.getSymbolProvider();
-        GoWriter writer = context.getWriter();
+        GoWriter writer = context.getWriter().get();
 
         Symbol symbol = symbolProvider.toSymbol(shape);
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -196,7 +196,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 ProtocolGenerator.getSerializeMiddlewareName(operation.getId(), service, getProtocolName()),
                 ProtocolUtils.OPERATION_SERIALIZER_MIDDLEWARE_ID);
 
-        middleware.writeMiddleware(context.getWriter(), (generator, writer) -> {
+        middleware.writeMiddleware(context.getWriter().get(), (generator, writer) -> {
             writer.addUseImports(SmithyGoDependency.FMT);
             writer.addUseImports(SmithyGoDependency.SMITHY);
             writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_BINDING);
@@ -283,7 +283,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         ApplicationProtocol applicationProtocol = getApplicationProtocol();
         Symbol responseType = applicationProtocol.getResponseType();
-        GoWriter goWriter = context.getWriter();
+        GoWriter goWriter = context.getWriter().get();
 
         GoStackStepMiddlewareGenerator middleware = GoStackStepMiddlewareGenerator.createDeserializeStepMiddleware(
                 ProtocolGenerator.getDeserializeMiddlewareName(operation.getId(), service, getProtocolName()),
@@ -401,7 +401,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             GenerationContext context,
             MemberShape memberShape
     ) {
-        GoWriter writer = context.getWriter();
+        GoWriter writer = context.getWriter().get();
         Model model = context.getModel();
         Shape payloadShape = model.expectShape(memberShape.getTarget());
 
@@ -536,7 +536,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     private void generateOperationHttpBindingSerializer(GenerationContext context, OperationShape operation) {
         SymbolProvider symbolProvider = context.getSymbolProvider();
         Model model = context.getModel();
-        GoWriter writer = context.getWriter();
+        GoWriter writer = context.getWriter().get();
 
         Shape inputShape = model.expectShape(operation.getInput()
                 .orElseThrow(() -> new CodegenException("missing input shape for operation: " + operation.getId())));
@@ -678,7 +678,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             GenerationContext context,
             HttpBinding binding
     ) {
-        GoWriter writer = context.getWriter();
+        GoWriter writer = context.getWriter().get();
         Model model = context.getModel();
         MemberShape memberShape = binding.getMember();
         Shape targetShape = model.expectShape(memberShape.getTarget());
@@ -784,7 +784,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             String dest,
             boolean isQueryParams
     ) {
-        GoWriter writer = context.getWriter();
+        GoWriter writer = context.getWriter().get();
 
         if (targetShape instanceof CollectionShape) {
             MemberShape collectionMember = CodegenUtils.expectCollectionShape(targetShape)
@@ -813,7 +813,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             String locationName,
             String dest
     ) {
-        GoWriter writer = context.getWriter();
+        GoWriter writer = context.getWriter().get();
         Model model = context.getModel();
         Shape targetShape = model.expectShape(memberShape.getTarget());
 
@@ -881,7 +881,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     private void generateHttpBindingDeserializer(GenerationContext context, Shape shape) {
         SymbolProvider symbolProvider = context.getSymbolProvider();
         Model model = context.getModel();
-        GoWriter writer = context.getWriter();
+        GoWriter writer = context.getWriter().get();
 
         HttpBindingIndex bindingIndex = model.getKnowledge(HttpBindingIndex.class);
         List<HttpBinding> bindings = bindingIndex.getResponseBindings(shape).values().stream()
@@ -1281,7 +1281,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     protected abstract void generateDocumentBodyShapeDeserializers(GenerationContext context, Set<Shape> shapes);
 
     private void generateErrorDeserializer(GenerationContext context, StructureShape shape) {
-        GoWriter writer = context.getWriter();
+        GoWriter writer = context.getWriter().get();
         String functionName = ProtocolGenerator.getErrorDeserFunctionName(
                 shape, context.getService(), context.getProtocolName());
         Symbol responseType = getApplicationProtocol().getResponseType();

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -66,7 +66,7 @@ public final class HttpProtocolGeneratorUtils {
             Consumer<GenerationContext> errorMessageCodeGenerator,
             BiFunction<GenerationContext, OperationShape, Map<String, ShapeId>> operationErrorsToShapes
     ) {
-        GoWriter writer = context.getWriter();
+        GoWriter writer = context.getWriter().get();
         ServiceShape service = context.getService();
         String protocolName = context.getProtocolName();
         Set<StructureShape> errorShapes = new TreeSet<>();

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolTestGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolTestGenerator.java
@@ -81,7 +81,7 @@ public class HttpProtocolTestGenerator {
         this.service = context.getService();
         this.protocolName = context.getProtocolName();
         this.symbolProvider = context.getSymbolProvider();
-        this.writer = context.getWriter();
+        this.writer = context.getWriter().get();
         this.delegator = context.getDelegator();
 
         this.requestTestBuilder = requestTestBuilder;

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
@@ -91,13 +91,13 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         Symbol inputSymbol = symbolProvider.toSymbol(inputShape);
         ApplicationProtocol applicationProtocol = getApplicationProtocol();
         Symbol requestType = applicationProtocol.getRequestType();
-        GoWriter writer = context.getWriter();
+        GoWriter writer = context.getWriter().get();
 
         GoStackStepMiddlewareGenerator middleware = GoStackStepMiddlewareGenerator.createSerializeStepMiddleware(
                 ProtocolGenerator.getSerializeMiddlewareName(operation.getId(), service, getProtocolName()),
                 ProtocolUtils.OPERATION_SERIALIZER_MIDDLEWARE_ID);
 
-        middleware.writeMiddleware(context.getWriter(), (generator, w) -> {
+        middleware.writeMiddleware(context.getWriter().get(), (generator, w) -> {
             writer.addUseImports(SmithyGoDependency.SMITHY);
             writer.addUseImports(SmithyGoDependency.FMT);
             writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_BINDING);
@@ -232,7 +232,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
     private void generateOperationDeserializer(GenerationContext context, OperationShape operation) {
         SymbolProvider symbolProvider = context.getSymbolProvider();
         Model model = context.getModel();
-        GoWriter writer = context.getWriter();
+        GoWriter writer = context.getWriter().get();
         ServiceShape service = context.getService();
         StructureShape outputShape = ProtocolUtils.expectOutput(context.getModel(), operation);
         Symbol outputSymbol = symbolProvider.toSymbol(outputShape);
@@ -311,7 +311,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
     protected abstract void deserializeOutputDocument(GenerationContext context, OperationShape operation);
 
     private void generateErrorDeserializer(GenerationContext context, StructureShape shape) {
-        GoWriter writer = context.getWriter();
+        GoWriter writer = context.getWriter().get();
         String functionName = ProtocolGenerator.getErrorDeserFunctionName(
                 shape, context.getService(), context.getProtocolName());
         Symbol responseType = getApplicationProtocol().getResponseType();

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
@@ -268,22 +268,122 @@ public interface ProtocolGenerator {
         return HttpProtocolGeneratorUtils.getOperationErrors(context, operation);
     }
 
+    /**
+     * Generates the UnmarshalSmithyDocument function body of the service's internal documentMarshaler type.
+     * <p>
+     * The document marshaler type is expected to handle user provided Go types and convert them to protocol documents.
+     * <p>
+     * The default implementation will throw a {@code CodegenException} if not implemented.
+     *
+     * <pre>{@code
+     * type documentMarshaler struct {
+     *     value interface{}
+     * }
+     *
+     * // ...
+     *
+     * func (m *documentMarshaler) UnmarshalSmithyDocument(v interface{}) error {
+     *      // Generated code from generateProtocolDocumentMarshalerUnmarshalDocument
+     * }
+     * }</pre>
+     *
+     * @param context the generation context.
+     */
     default void generateProtocolDocumentMarshalerUnmarshalDocument(GenerationContext context) {
-        throw new CodegenException("document types not implemented for protocol");
+        throw new CodegenException("document types not implemented for " + this.getProtocolName() + " protocol");
     }
 
+    /**
+     * Generates the UnmarshalSmithyDocument function body of the service's internal documentMarshaler type.
+     * <p>
+     * The document marshaler type is expected to handle user provided Go types and convert them to protocol documents.
+     * <p>
+     * The default implementation will throw a {@code CodegenException} if not implemented.
+     *
+     * <pre>{@code
+     * type documentMarshaler struct {
+     *     value interface{}
+     * }
+     *
+     * // ...
+     *
+     * func (m *documentMarshaler) MarshalSmithyDocument() ([]byte, error) {
+     *      // Generated code from generateProtocolDocumentMarshalerMarshalDocument
+     * }
+     * }</pre>
+     *
+     * @param context the generation context.
+     */
     default void generateProtocolDocumentMarshalerMarshalDocument(GenerationContext context) {
-        throw new CodegenException("document types not implemented for protocol");
+        throw new CodegenException("document types not implemented for " + this.getProtocolName() + " protocol");
     }
 
+    /**
+     * Generates the UnmarshalSmithyDocument function body of the service's internal documentUnmarshaler type.
+     * <p>
+     * The document unmarshaler type is expected to handle protocol documents received from the service and provide the
+     * ability to unmarshal or round-trip the document.
+     * <p>
+     * The default implementation will throw a {@code CodegenException} if not implemented.
+     *
+     * <pre>{@code
+     * type documentUnmarshaler struct {
+     *     value interface{}
+     * }
+     *
+     * // ...
+     *
+     * func (m *documentUnmarshaler) UnmarshalSmithyDocument(v interface{}) error {
+     *      // Generated code from generateProtocolDocumentUnmarshalerUnmarshalDocument
+     * }
+     * }</pre>
+     *
+     * @param context the generation context.
+     */
     default void generateProtocolDocumentUnmarshalerUnmarshalDocument(GenerationContext context) {
-        throw new CodegenException("document types not implemented for protocol");
+        throw new CodegenException("document types not implemented for " + this.getProtocolName() + " protocol");
     }
 
+    /**
+     * Generates the MarshalSmithyDocument function body of the service's internal documentUnmarshaler type.
+     * <p>
+     * The document unmarshaler type is expected to handle protocol documents received from the service and provide the
+     * ability to unmarshal or round-trip the document.
+     * <p>
+     * The default implementation will throw a {@code CodegenException} if not implemented.
+     *
+     * <pre>{@code
+     * type documentUnmarshaler struct {
+     *     value interface{}
+     * }
+     *
+     * // ...
+     *
+     * func (m *documentUnmarshaler) MarshalSmithyDocument() ([]byte, error) {
+     *      // Generated code from generateProtocolDocumentUnmarshalerMarshalDocument
+     * }
+     * }</pre>
+     *
+     * @param context the generation context.
+     */
     default void generateProtocolDocumentUnmarshalerMarshalDocument(GenerationContext context) {
-        throw new CodegenException("document types not implemented for protocol");
+        throw new CodegenException("document types not implemented for " + this.getProtocolName() + " protocol");
     }
 
+    /**
+     * Generate the internal constructor function body for the service's internal documentMarshaler type.
+     *
+     * <pre>{@code
+     * func NewDocumentMarshaler(v interface{}) Interface {
+     *     return &documentMarshaler{
+     *         value: v,
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param context         the generation context.
+     * @param marshalerSymbol the symbol for the {@code documentMarshaler} type.
+     */
     default void generateNewDocumentMarshaler(GenerationContext context, Symbol marshalerSymbol) {
         GoWriter writer = context.getWriter().get();
         writer.openBlock("return &$T{", "}", marshalerSymbol, () -> {
@@ -291,6 +391,20 @@ public interface ProtocolGenerator {
         });
     }
 
+    /**
+     * Generate the internal constructor function body for the service's internal documentUnmarshaler type.
+     *
+     * <pre>{@code
+     * func NewDocumentUnmarshaler(v interface{}) Interface {
+     *     return &documentUnmarshaler{
+     *         value: v,
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param context           the generation context.
+     * @param unmarshalerSymbol the symbol for the {@code documentUnmarshaler} type.
+     */
     default void generateNewDocumentUnmarshaler(GenerationContext context, Symbol unmarshalerSymbol) {
         GoWriter writer = context.getWriter().get();
         writer.openBlock("return &$T{", "}", unmarshalerSymbol, () -> {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
@@ -15,11 +15,14 @@
 
 package software.amazon.smithy.go.codegen.integration;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.go.codegen.ApplicationProtocol;
 import software.amazon.smithy.go.codegen.GoDelegator;
@@ -36,6 +39,7 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.CaseUtils;
+import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
@@ -166,6 +170,7 @@ public interface ProtocolGenerator {
      * Generates the name of a serializer function for shapes of a service.
      *
      * @param shape    The shape the serializer function is being generated for.
+     * @param service  The service shape.
      * @param protocol Name of the protocol being generated.
      * @return Returns the generated function name.
      */
@@ -179,6 +184,7 @@ public interface ProtocolGenerator {
      * Generates the name of a deserializer function for shapes of a service.
      *
      * @param shape    The shape the deserializer function is being generated for.
+     * @param service  The service shape.
      * @param protocol Name of the protocol being generated.
      * @return Returns the generated function name.
      */
@@ -229,8 +235,8 @@ public interface ProtocolGenerator {
     /**
      * Generates the name of an error deserializer function for shapes of a service.
      *
-     * @param shape The error structure shape for which deserializer name is being generated.
-     * @param service The service enclosing the service shape.
+     * @param shape    The error structure shape for which deserializer name is being generated.
+     * @param service  The service enclosing the service shape.
      * @param protocol Name of the protocol being generated.
      * @return Returns the generated function name.
      */
@@ -254,12 +260,42 @@ public interface ProtocolGenerator {
     /**
      * Returns a map of error names to their {@link ShapeId}.
      *
-     * @param context the generation context
+     * @param context   the generation context
      * @param operation the operation shape to retrieve errors for
      * @return map of error names to {@link ShapeId}
      */
     default Map<String, ShapeId> getOperationErrors(GenerationContext context, OperationShape operation) {
         return HttpProtocolGeneratorUtils.getOperationErrors(context, operation);
+    }
+
+    default void generateProtocolDocumentMarshalerUnmarshalDocument(GenerationContext context) {
+        throw new CodegenException("document types not implemented for protocol");
+    }
+
+    default void generateProtocolDocumentMarshalerMarshalDocument(GenerationContext context) {
+        throw new CodegenException("document types not implemented for protocol");
+    }
+
+    default void generateProtocolDocumentUnmarshalerUnmarshalDocument(GenerationContext context) {
+        throw new CodegenException("document types not implemented for protocol");
+    }
+
+    default void generateProtocolDocumentUnmarshalerMarshalDocument(GenerationContext context) {
+        throw new CodegenException("document types not implemented for protocol");
+    }
+
+    default void generateNewDocumentMarshaler(GenerationContext context, Symbol marshalerSymbol) {
+        GoWriter writer = context.getWriter().get();
+        writer.openBlock("return &$T{", "}", marshalerSymbol, () -> {
+            writer.write("value: v,");
+        });
+    }
+
+    default void generateNewDocumentUnmarshaler(GenerationContext context, Symbol unmarshalerSymbol) {
+        GoWriter writer = context.getWriter().get();
+        writer.openBlock("return &$T{", "}", unmarshalerSymbol, () -> {
+            writer.write("value: v,");
+        });
     }
 
     /**
@@ -279,78 +315,129 @@ public interface ProtocolGenerator {
      * Context object used for service serialization and deserialization.
      */
     class GenerationContext {
-        private GoSettings settings;
-        private Model model;
-        private ServiceShape service;
-        private SymbolProvider symbolProvider;
-        private GoWriter writer;
-        private List<GoIntegration> integrations;
-        private String protocolName;
-        private GoDelegator delegator;
+        private final GoSettings settings;
+        private final Model model;
+        private final ServiceShape service;
+        private final SymbolProvider symbolProvider;
+        private final GoWriter writer;
+        private final List<GoIntegration> integrations;
+        private final String protocolName;
+        private final GoDelegator delegator;
+
+        private GenerationContext(Builder builder) {
+            this.settings = SmithyBuilder.requiredState("settings", builder.settings);
+            this.model = SmithyBuilder.requiredState("model", builder.model);
+            this.service = SmithyBuilder.requiredState("service", builder.service);
+            this.symbolProvider = SmithyBuilder.requiredState("symbolProvider", builder.symbolProvider);
+            this.writer = builder.writer;
+            this.integrations = SmithyBuilder.requiredState("integrations", builder.integrations);
+            this.protocolName = SmithyBuilder.requiredState("protocolName", builder.protocolName);
+            this.delegator = SmithyBuilder.requiredState("delegator", builder.delegator);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public Builder toBuilder() {
+            return builder()
+                    .settings(this.settings)
+                    .model(this.model)
+                    .service(this.service)
+                    .symbolProvider(this.symbolProvider)
+                    .writer(this.writer)
+                    .integrations(this.integrations)
+                    .protocolName(this.protocolName)
+                    .delegator(this.delegator);
+        }
 
         public GoSettings getSettings() {
             return settings;
-        }
-
-        public void setSettings(GoSettings settings) {
-            this.settings = settings;
         }
 
         public Model getModel() {
             return model;
         }
 
-        public void setModel(Model model) {
-            this.model = model;
-        }
-
         public ServiceShape getService() {
             return service;
-        }
-
-        public void setService(ServiceShape service) {
-            this.service = service;
         }
 
         public SymbolProvider getSymbolProvider() {
             return symbolProvider;
         }
 
-        public void setSymbolProvider(SymbolProvider symbolProvider) {
-            this.symbolProvider = symbolProvider;
-        }
-
-        public GoWriter getWriter() {
-            return writer;
-        }
-
-        public void setWriter(GoWriter writer) {
-            this.writer = writer;
+        public Optional<GoWriter> getWriter() {
+            return Optional.ofNullable(writer);
         }
 
         public GoDelegator getDelegator() {
             return delegator;
         }
 
-        public void setDelegator(GoDelegator delegator) {
-            this.delegator = delegator;
-        }
-
         public List<GoIntegration> getIntegrations() {
             return integrations;
-        }
-
-        public void setIntegrations(List<GoIntegration> integrations) {
-            this.integrations = integrations;
         }
 
         public String getProtocolName() {
             return protocolName;
         }
 
-        // TODO change to shape id of protocol shape id
-        public void setProtocolName(String protocolName) {
-            this.protocolName = protocolName;
+        public static class Builder implements SmithyBuilder<GenerationContext> {
+            private GoSettings settings;
+            private Model model;
+            private ServiceShape service;
+            private SymbolProvider symbolProvider;
+            private GoWriter writer;
+            private final List<GoIntegration> integrations = new ArrayList<>();
+            private String protocolName;
+            private GoDelegator delegator;
+
+            public Builder settings(GoSettings settings) {
+                this.settings = settings;
+                return this;
+            }
+
+            public Builder model(Model model) {
+                this.model = model;
+                return this;
+            }
+
+            public Builder service(ServiceShape service) {
+                this.service = service;
+                return this;
+            }
+
+            public Builder symbolProvider(SymbolProvider symbolProvider) {
+                this.symbolProvider = symbolProvider;
+                return this;
+            }
+
+            public Builder writer(GoWriter writer) {
+                this.writer = writer;
+                return this;
+            }
+
+            public Builder integrations(Collection<GoIntegration> integrations) {
+                this.integrations.clear();
+                this.integrations.addAll(integrations);
+                return this;
+            }
+
+            public Builder protocolName(String protocolName) {
+                this.protocolName = protocolName;
+                return this;
+            }
+
+            public Builder delegator(GoDelegator delegator) {
+                this.delegator = delegator;
+                return this;
+            }
+
+            @Override
+            public GenerationContext build() {
+                return new GenerationContext(this);
+            }
         }
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
@@ -210,8 +210,4 @@ public final class ProtocolUtils {
 
         lambda.accept(acceptVar);
     }
-
-    public static void writeDocumentInterfaceCheck(GenerationContext context, GoWriter writer) {
-
-    }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
@@ -210,4 +210,8 @@ public final class ProtocolUtils {
 
         lambda.accept(acceptVar);
     }
+
+    public static void writeDocumentInterfaceCheck(GenerationContext context, GoWriter writer) {
+
+    }
 }

--- a/codegen/smithy-go-codegen/src/main/resources/software/amazon/smithy/go/codegen/document_doc.go.template
+++ b/codegen/smithy-go-codegen/src/main/resources/software/amazon/smithy/go/codegen/document_doc.go.template
@@ -1,0 +1,63 @@
+Package document implements encoding and decoding of open-content that has a JSON-like data model.
+This data-model allows for UTF-8 strings, arbitrary precision numbers, booleans, nulls, a list of these values, and a
+map of UTF-8 strings to these values.
+
+Interface defines the semantics for how a document type is marshalled and unmarshalled for requests and responses
+for the service. To send a document as input to the service you use NewLazyDocument and pass it the Go type to be
+sent to the service. NewLazyDocument returns a document Interface type that encodes the provided Go type during
+the request serialization step after you have invoked an API client operation that uses the document type.
+
+The following examples show how you can create document types using basic Go types.
+
+  NewLazyDocument(map[string]interface{}{
+      "favoriteNumber": 42,
+      "fruits":         []string{"apple", "orange"},
+      "capitals":       map[string]interface{}{
+          "Washington": "Olympia",
+          "Oregon":     "Salem",
+      },
+      "skyIsBlue":      true,
+  })
+
+  NewLazyDocument(3.14159)
+
+  NewLazyDocument([]interface{"One", 2, 3, 3.5, "four"})
+
+  NewLazyDocument(true)
+
+Services can send document types as part of their API responses. To retrieve the content of a response document
+you use the UnmarshalSmithyDocument method on the response document. When calling UnmarshalSmithyDocument you pass
+a reference to the Go type that you want to unmarshal and map the response to.
+
+For example, if you expect to receive key/value map from the service response:
+
+  var kv map[string]interface{}
+  if err := outputDocument.UnmarshalSmithyDocument(&kv); err != nil {
+      // handle error
+  }
+
+If a service can return one or more data-types in the response, you can use an empty interface and type switch to
+dynamically handle the response type.
+
+  var v interface{}
+  if err := outputDocument.UnmarshalSmithyDocument(&v); err != nil {
+     // handle error
+  }
+
+  switch vv := v.(type) {
+  case map[string]interface{}:
+      // handle key/value map
+  case []interface{}:
+      // handle array of values
+  case bool:
+      // handle boolean
+  case document.Number:
+      // handle an arbitrary precision number
+  case string:
+     // handle string
+  default:
+     // handle unknown case
+  }
+
+The mapping of Go types to document types is covered in more depth in https://pkg.go.dev/github.com/aws/smithy-go/document
+including more in depth examples that cover user-defined structure types.

--- a/document/doc.go
+++ b/document/doc.go
@@ -1,0 +1,12 @@
+// Package document provides interface definitions and error types for document types.
+//
+// A document is a protocol-agnostic type which supports a JSON-like data-model. You can use this type to send
+// UTF-8 strings, arbitrary precision numbers, booleans, nulls, a list of these values, and a map of UTF-8
+// strings to these values.
+//
+// API Clients expose document constructors in their respective client document packages which must be used to
+// Marshal and Unmarshal Go types to and from their respective protocol representations.
+//
+// See the Marshaler and Unmarshaler type documentation for more details on how to Go types can be converted to and from
+// document types.
+package document

--- a/document/document.go
+++ b/document/document.go
@@ -1,0 +1,71 @@
+package document
+
+import (
+	"strconv"
+)
+
+type SmithyDocumentMarshaler interface {
+	MarshalSmithyDocument() ([]byte, error)
+}
+
+type SmithyDocumentUnmarshaler interface {
+	UnmarshalSmithyDocument(interface{}) error
+}
+
+type noSerde interface {
+	noSmithyDocumentSerde()
+}
+
+// NoSerde is a sentinel value to indicate that a given type should not be marshaled or unmarshalled
+// into a protocol document.
+type NoSerde struct{}
+
+func (n NoSerde) noSmithyDocumentSerde() {}
+
+var _ noSerde = (*NoSerde)(nil)
+
+// IsNoSerde returns whether the given type implements the no smithy document serde interface.
+func IsNoSerde(x interface{}) bool {
+	_, ok := x.(noSerde)
+	return ok
+}
+
+// Number is a arbitrary precision numerical value
+type Number string
+
+// Int64 returns the number as a string.
+func (n Number) String() string {
+	return string(n)
+}
+
+// Int64 returns the number as an int64.
+func (n Number) Int64() (int64, error) {
+	return n.intOfBitSize(64)
+}
+
+func (n Number) intOfBitSize(bitSize int) (int64, error) {
+	return strconv.ParseInt(string(n), 10, bitSize)
+}
+
+func (n Number) Uint64() (uint64, error) {
+	return n.uintOfBitSize(64)
+}
+
+func (n Number) uintOfBitSize(bitSize int) (uint64, error) {
+	return strconv.ParseUint(string(n), 10, bitSize)
+}
+
+// Float32 returns the number parsed as a 32-bit float, returns a float64.
+func (n Number) Float32() (float64, error) {
+	return n.floatOfBitSize(32)
+}
+
+// Float64 returns the number as a float64.
+func (n Number) Float64() (float64, error) {
+	return n.floatOfBitSize(64)
+}
+
+// Float64 returns the number as a float64.
+func (n Number) floatOfBitSize(bitSize int) (float64, error) {
+	return strconv.ParseFloat(string(n), bitSize)
+}

--- a/document/document.go
+++ b/document/document.go
@@ -1,15 +1,78 @@
 package document
 
 import (
+	"fmt"
+	"math/big"
 	"strconv"
 )
 
-type SmithyDocumentMarshaler interface {
+// Marshaler is an interface for a type that marshals a document to its protocol-specific byte representation and
+// returns the resulting bytes. A non-nil error will be returned if an error is encountered during marshaling.
+//
+// Marshal supports basic scalars (int,uint,float,bool,string), big.Int, and big.Float, maps, slices, and structs.
+// Anonymous nested types are flattened based on Go anonymous type visibility.
+//
+// When defining struct types. the `document` struct tag can be used to control how the value will be
+// marshaled into the resulting protocol document.
+//
+//		// Field is ignored
+//		Field int `document:"-"`
+//
+//		// Field object of key "myName"
+//		Field int `document:"myName"`
+//
+//		// Field object key of key "myName", and
+//		// Field is omitted if the field is a zero value for the type.
+//		Field int `document:"myName,omitempty"`
+//
+//		// Field object key of "Field", and
+//		// Field is omitted if the field is a zero value for the type.
+//		Field int `document:",omitempty"`
+//
+// All struct fields, including anonymous fields, are marshaled unless the
+// any of the following conditions are meet.
+//
+//		- the field is not exported
+//		- document field tag is "-"
+//		- document field tag specifies "omitempty", and is a zero value.
+//
+// Pointer and interfaces values are encoded as the value pointed to or
+// contained in the interface. A nil value encodes as a null
+// value unless `omitempty` struct tag is provided.
+//
+// Channel, complex, and function values are not encoded and will be skipped
+// when walking the value to be marshaled.
+//
+// time.Time is not supported and will cause the Marshaler to return an error. These values should be represented
+// by your application as a string or numerical representation.
+//
+// Errors that occur when marshaling will stop the marshaller, and return the error.
+//
+// Marshal cannot represent cyclic data structures and will not handle them.
+// Passing cyclic structures to Marshal will result in an infinite recursion.
+type Marshaler interface {
 	MarshalSmithyDocument() ([]byte, error)
 }
 
-type SmithyDocumentUnmarshaler interface {
-	UnmarshalSmithyDocument(interface{}) error
+// Unmarshaler is an interface for a type that unmarshalls a document from its protocol-specific representation, and
+// stores the result into the value pointed by v. If v is nil or not a pointer then InvalidUnmarshalError will be
+// returned.
+//
+// Unmarshaler supports the same encodings produced by a document Marshaler. This includes support for the `document`
+// struct field tag for controlling how struct fields are unmarshalled.
+//
+// Both generic interface{} and concrete types are valid unmarshal destination types. When unmarshalling a document
+// into an empty interface the Unmarshaler will store one of these values:
+//   bool,                   for boolean values
+//   document.Number,        for arbitrary-precision numbers (int64, float64, big.Int, big.Float)
+//   string,                 for string values
+//   []interface{},          for array values
+//   map[string]interface{}, for objects
+//   nil,                    for null values
+//
+// When unmarshalling, any error that occurs will halt the unmarshal and return the error.
+type Unmarshaler interface {
+	UnmarshalSmithyDocument(v interface{}) error
 }
 
 type noSerde interface {
@@ -47,6 +110,7 @@ func (n Number) intOfBitSize(bitSize int) (int64, error) {
 	return strconv.ParseInt(string(n), 10, bitSize)
 }
 
+// Uint64 returns the number as an uint64.
 func (n Number) Uint64() (uint64, error) {
 	return n.uintOfBitSize(64)
 }
@@ -68,4 +132,22 @@ func (n Number) Float64() (float64, error) {
 // Float64 returns the number as a float64.
 func (n Number) floatOfBitSize(bitSize int) (float64, error) {
 	return strconv.ParseFloat(string(n), bitSize)
+}
+
+// BigFloat attempts to convert the number to a big.Float, returns an error if the operation fails.
+func (n Number) BigFloat() (*big.Float, error) {
+	f, ok := (&big.Float{}).SetString(string(n))
+	if !ok {
+		return nil, fmt.Errorf("failed to convert to big.Float")
+	}
+	return f, nil
+}
+
+// BigInt attempts to convert the number to a big.Int, returns an error if the operation fails.
+func (n Number) BigInt() (*big.Int, error) {
+	f, ok := (&big.Int{}).SetString(string(n), 10)
+	if !ok {
+		return nil, fmt.Errorf("failed to convert to big.Float")
+	}
+	return f, nil
 }

--- a/document/errors.go
+++ b/document/errors.go
@@ -6,7 +6,8 @@ import (
 )
 
 // UnmarshalTypeError is an error type representing aa error
-// unmarshalling a Smithy document to a Go value type.
+// unmarshalling a Smithy document to a Go value type. This is different
+// from UnmarshalError in that it does not wrap an underlying error type.
 type UnmarshalTypeError struct {
 	Value string
 	Type  reflect.Type
@@ -49,7 +50,7 @@ type UnmarshalError struct {
 	Type  reflect.Type
 }
 
-// Unwrap returnbs the underlying unmarshalling error
+// Unwrap returns the underlying unmarshalling error
 func (e *UnmarshalError) Unwrap() error {
 	return e.Err
 }
@@ -62,7 +63,7 @@ func (e *UnmarshalError) Error() string {
 }
 
 // An InvalidMarshalError is an error type representing an error
-// occurring when marshaling a Go value type to an AttributeValue.
+// occurring when marshaling a Go value type.
 type InvalidMarshalError struct {
 	Message string
 }

--- a/document/errors.go
+++ b/document/errors.go
@@ -1,0 +1,74 @@
+package document
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// UnmarshalTypeError is an error type representing aa error
+// unmarshalling a Smithy document to a Go value type.
+type UnmarshalTypeError struct {
+	Value string
+	Type  reflect.Type
+}
+
+// Error returns the string representation of the error.
+// satisfying the error interface
+func (e *UnmarshalTypeError) Error() string {
+	return fmt.Sprintf("unmarshal failed, cannot unmarshal %s into Go value type %s",
+		e.Value, e.Type.String())
+}
+
+// An InvalidUnmarshalError is an error type representing an invalid type
+// encountered while unmarshalling a Smithy document to a Go value type.
+type InvalidUnmarshalError struct {
+	Type reflect.Type
+}
+
+// Error returns the string representation of the error.
+// satisfying the error interface
+func (e *InvalidUnmarshalError) Error() string {
+	var msg string
+	if e.Type == nil {
+		msg = "cannot unmarshal to nil value"
+	} else if e.Type.Kind() != reflect.Ptr {
+		msg = fmt.Sprintf("cannot unmarshal to non-pointer value, got %s", e.Type.String())
+	} else {
+		msg = fmt.Sprintf("cannot unmarshal to nil value, %s", e.Type.String())
+	}
+
+	return fmt.Sprintf("unmarshal failed, %s", msg)
+}
+
+// An UnmarshalError wraps an error that occurred while unmarshalling a
+// Smithy document into a Go type. This is different from
+// UnmarshalTypeError in that it wraps the underlying error that occurred.
+type UnmarshalError struct {
+	Err   error
+	Value string
+	Type  reflect.Type
+}
+
+// Unwrap returnbs the underlying unmarshalling error
+func (e *UnmarshalError) Unwrap() error {
+	return e.Err
+}
+
+// Error returns the string representation of the error satisfying the error
+// interface.
+func (e *UnmarshalError) Error() string {
+	return fmt.Sprintf("unmarshal failed, cannot unmarshal %q into %s, %v",
+		e.Value, e.Type.String(), e.Err)
+}
+
+// An InvalidMarshalError is an error type representing an error
+// occurring when marshaling a Go value type to an AttributeValue.
+type InvalidMarshalError struct {
+	Message string
+}
+
+// Error returns the string representation of the error.
+// satisfying the error interface
+func (e *InvalidMarshalError) Error() string {
+	return fmt.Sprintf("marshal failed, %s", e.Message)
+}

--- a/document/internal/serde/field.go
+++ b/document/internal/serde/field.go
@@ -7,6 +7,7 @@ import (
 
 const tagKey = "document"
 
+// Field is represents a struct field, tag, type, and index.
 type Field struct {
 	Tag
 

--- a/document/internal/serde/field.go
+++ b/document/internal/serde/field.go
@@ -1,0 +1,292 @@
+package serde
+
+import (
+	"reflect"
+	"sort"
+)
+
+const tagKey = "document"
+
+type Field struct {
+	Tag
+
+	Name        string
+	NameFromTag bool
+
+	Index []int
+	Type  reflect.Type
+}
+
+func buildField(pIdx []int, i int, sf reflect.StructField, fieldTag Tag) Field {
+	f := Field{
+		Name: sf.Name,
+		Type: sf.Type,
+		Tag:  fieldTag,
+	}
+
+	if len(fieldTag.Name) != 0 {
+		f.NameFromTag = true
+		f.Name = fieldTag.Name
+	}
+
+	f.Index = make([]int, len(pIdx)+1)
+	copy(f.Index, pIdx)
+	f.Index[len(pIdx)] = i
+
+	return f
+}
+
+// GetStructFields returns a list of fields for the given type. Type info is cached
+// to avoid repeated calls into the reflect package
+func GetStructFields(t reflect.Type) *CachedFields {
+	if cached, ok := fieldCache.Load(t); ok {
+		return cached
+	}
+
+	f := enumFields(t)
+	sort.Sort(fieldsByName(f))
+	f = visibleFields(f)
+
+	fs := &CachedFields{
+		fields:       f,
+		fieldsByName: make(map[string]int, len(f)),
+	}
+	for i, f := range fs.fields {
+		fs.fieldsByName[f.Name] = i
+	}
+
+	cached, _ := fieldCache.LoadOrStore(t, fs)
+	return cached
+}
+
+// enumFields will recursively iterate through a structure and its nested
+// anonymous fields.
+//
+// Based on the enoding/json struct field enumeration of the Go Stdlib
+// https://golang.org/src/encoding/json/encode.go typeField func.
+func enumFields(t reflect.Type) []Field {
+	// Fields to explore
+	current := []Field{}
+	next := []Field{{Type: t}}
+
+	// count of queued names
+	count := map[reflect.Type]int{}
+	nextCount := map[reflect.Type]int{}
+
+	visited := map[reflect.Type]struct{}{}
+	fields := []Field{}
+
+	for len(next) > 0 {
+		current, next = next, current[:0]
+		count, nextCount = nextCount, map[reflect.Type]int{}
+
+		for _, f := range current {
+			if _, ok := visited[f.Type]; ok {
+				continue
+			}
+			visited[f.Type] = struct{}{}
+
+			for i := 0; i < f.Type.NumField(); i++ {
+				sf := f.Type.Field(i)
+				if sf.PkgPath != "" && !sf.Anonymous {
+					// Ignore unexported and non-anonymous fields
+					// unexported but anonymous field may still be used if
+					// the type has exported nested fields
+					continue
+				}
+
+				fieldTag := ParseTag(sf.Tag.Get(tagKey))
+
+				if fieldTag.Ignore {
+					continue
+				}
+
+				ft := sf.Type
+				if ft.Name() == "" && ft.Kind() == reflect.Ptr {
+					ft = ft.Elem()
+				}
+
+				structField := buildField(f.Index, i, sf, fieldTag)
+				structField.Type = ft
+
+				if !sf.Anonymous || ft.Kind() != reflect.Struct {
+					fields = append(fields, structField)
+					if count[f.Type] > 1 {
+						// If there were multiple instances, add a second,
+						// so that the annihilation code will see a duplicate.
+						// It only cares about the distinction between 1 or 2,
+						// so don't bother generating any more copies.
+						fields = append(fields, structField)
+					}
+					continue
+				}
+
+				// Record new anon struct to explore next round
+				nextCount[ft]++
+				if nextCount[ft] == 1 {
+					next = append(next, structField)
+				}
+			}
+		}
+	}
+
+	return fields
+}
+
+// visibleFields will return a slice of fields which are visible based on
+// Go's standard visiblity rules with the exception of ties being broken
+// by depth and struct tag naming.
+//
+// Based on the enoding/json field filtering of the Go Stdlib
+// https://golang.org/src/encoding/json/encode.go typeField func.
+func visibleFields(fields []Field) []Field {
+	// Delete all fields that are hidden by the Go rules for embedded fields,
+	// except that fields with JSON tags are promoted.
+
+	// The fields are sorted in primary order of name, secondary order
+	// of field index length. Loop over names; for each name, delete
+	// hidden fields by choosing the one dominant field that survives.
+	out := fields[:0]
+	for advance, i := 0, 0; i < len(fields); i += advance {
+		// One iteration per name.
+		// Find the sequence of fields with the name of this first field.
+		fi := fields[i]
+		name := fi.Name
+		for advance = 1; i+advance < len(fields); advance++ {
+			fj := fields[i+advance]
+			if fj.Name != name {
+				break
+			}
+		}
+		if advance == 1 { // Only one field with this name
+			out = append(out, fi)
+			continue
+		}
+		dominant, ok := dominantField(fields[i : i+advance])
+		if ok {
+			out = append(out, dominant)
+		}
+	}
+
+	fields = out
+	sort.Sort(fieldsByIndex(fields))
+
+	return fields
+}
+
+// dominantField looks through the fields, all of which are known to
+// have the same name, to find the single field that dominates the
+// others using Go's embedding rules, modified by the presence of
+// JSON tags. If there are multiple top-level fields, the boolean
+// will be false: This condition is an error in Go and we skip all
+// the fields.
+//
+// Based on the enoding/json field filtering of the Go Stdlib
+// https://golang.org/src/encoding/json/encode.go dominantField func.
+func dominantField(fields []Field) (Field, bool) {
+	// The fields are sorted in increasing index-length order. The winner
+	// must therefore be one with the shortest index length. Drop all
+	// longer entries, which is easy: just truncate the slice.
+	length := len(fields[0].Index)
+	tagged := -1 // Index of first tagged field.
+	for i, f := range fields {
+		if len(f.Index) > length {
+			fields = fields[:i]
+			break
+		}
+		if f.NameFromTag {
+			if tagged >= 0 {
+				// Multiple tagged fields at the same level: conflict.
+				// Return no field.
+				return Field{}, false
+			}
+			tagged = i
+		}
+	}
+	if tagged >= 0 {
+		return fields[tagged], true
+	}
+	// All remaining fields have the same length. If there's more than one,
+	// we have a conflict (two fields named "X" at the same level) and we
+	// return no field.
+	if len(fields) > 1 {
+		return Field{}, false
+	}
+	return fields[0], true
+}
+
+// fieldsByName sorts field by name, breaking ties with depth,
+// then breaking ties with "name came from json tag", then
+// breaking ties with index sequence.
+//
+// Based on the enoding/json field filtering of the Go Stdlib
+// https://golang.org/src/encoding/json/encode.go fieldsByName type.
+type fieldsByName []Field
+
+func (x fieldsByName) Len() int { return len(x) }
+
+func (x fieldsByName) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
+
+func (x fieldsByName) Less(i, j int) bool {
+	if x[i].Name != x[j].Name {
+		return x[i].Name < x[j].Name
+	}
+	if len(x[i].Index) != len(x[j].Index) {
+		return len(x[i].Index) < len(x[j].Index)
+	}
+	if x[i].NameFromTag != x[j].NameFromTag {
+		return x[i].NameFromTag
+	}
+	return fieldsByIndex(x).Less(i, j)
+}
+
+// fieldsByIndex sorts field by index sequence.
+//
+// Based on the enoding/json field filtering of the Go Stdlib
+// https://golang.org/src/encoding/json/encode.go fieldsByIndex type.
+type fieldsByIndex []Field
+
+func (x fieldsByIndex) Len() int { return len(x) }
+
+func (x fieldsByIndex) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
+
+func (x fieldsByIndex) Less(i, j int) bool {
+	for k, xik := range x[i].Index {
+		if k >= len(x[j].Index) {
+			return false
+		}
+		if xik != x[j].Index[k] {
+			return xik < x[j].Index[k]
+		}
+	}
+	return len(x[i].Index) < len(x[j].Index)
+}
+
+// DecoderFieldByIndex finds the field with the provided nested index, allocating
+// embedded parent structs if needed
+func DecoderFieldByIndex(v reflect.Value, index []int) reflect.Value {
+	for i, x := range index {
+		if i > 0 && v.Kind() == reflect.Ptr && v.Type().Elem().Kind() == reflect.Struct {
+			if v.IsNil() {
+				v.Set(reflect.New(v.Type().Elem()))
+			}
+			v = v.Elem()
+		}
+		v = v.Field(x)
+	}
+	return v
+}
+
+// EncoderFieldByIndex finds the field with the provided nested index
+func EncoderFieldByIndex(v reflect.Value, index []int) (reflect.Value, bool) {
+	for i, x := range index {
+		if i > 0 && v.Kind() == reflect.Ptr && v.Type().Elem().Kind() == reflect.Struct {
+			if v.IsNil() {
+				return reflect.Value{}, false
+			}
+			v = v.Elem()
+		}
+		v = v.Field(x)
+	}
+	return v, true
+}

--- a/document/internal/serde/field_cache.go
+++ b/document/internal/serde/field_cache.go
@@ -1,0 +1,45 @@
+package serde
+
+import (
+	"strings"
+	"sync"
+)
+
+var fieldCache fieldCacher
+
+type fieldCacher struct {
+	cache sync.Map
+}
+
+func (c *fieldCacher) Load(t interface{}) (*CachedFields, bool) {
+	if v, ok := c.cache.Load(t); ok {
+		return v.(*CachedFields), true
+	}
+	return nil, false
+}
+
+func (c *fieldCacher) LoadOrStore(t interface{}, fs *CachedFields) (*CachedFields, bool) {
+	v, ok := c.cache.LoadOrStore(t, fs)
+	return v.(*CachedFields), ok
+}
+
+type CachedFields struct {
+	fields       []Field
+	fieldsByName map[string]int
+}
+
+func (f *CachedFields) All() []Field {
+	return f.fields
+}
+
+func (f *CachedFields) FieldByName(name string) (Field, bool) {
+	if i, ok := f.fieldsByName[name]; ok {
+		return f.fields[i], ok
+	}
+	for _, f := range f.fields {
+		if strings.EqualFold(f.Name, name) {
+			return f, true
+		}
+	}
+	return Field{}, false
+}

--- a/document/internal/serde/field_cache.go
+++ b/document/internal/serde/field_cache.go
@@ -23,15 +23,18 @@ func (c *fieldCacher) LoadOrStore(t interface{}, fs *CachedFields) (*CachedField
 	return v.(*CachedFields), ok
 }
 
+// CachedFields is a cache entry for a type's fields.
 type CachedFields struct {
 	fields       []Field
 	fieldsByName map[string]int
 }
 
+// All returns all the fields for the cached type.
 func (f *CachedFields) All() []Field {
 	return f.fields
 }
 
+// FieldByName retrieves a field by name.
 func (f *CachedFields) FieldByName(name string) (Field, bool) {
 	if i, ok := f.fieldsByName[name]; ok {
 		return f.fields[i], ok

--- a/document/internal/serde/field_test.go
+++ b/document/internal/serde/field_test.go
@@ -1,0 +1,128 @@
+package serde
+
+import (
+	"reflect"
+	"testing"
+)
+
+type testUnionValues struct {
+	Name  string
+	Value interface{}
+}
+
+type unionSimple struct {
+	A int
+	B string
+	C []string
+}
+
+type unionComplex struct {
+	unionSimple
+	A int
+}
+
+type unionTagged struct {
+	A int `json:"A"`
+}
+
+type unionTaggedComplex struct {
+	unionSimple
+	unionTagged
+	B string
+}
+
+func TestGetStructFields(t *testing.T) {
+	var cases = []struct {
+		in     interface{}
+		expect []testUnionValues
+	}{
+		{
+			in: unionSimple{1, "2", []string{"abc"}},
+			expect: []testUnionValues{
+				{"A", 1},
+				{"B", "2"},
+				{"C", []string{"abc"}},
+			},
+		},
+		{
+			in: unionComplex{
+				unionSimple: unionSimple{1, "2", []string{"abc"}},
+				A:           2,
+			},
+			expect: []testUnionValues{
+				{"B", "2"},
+				{"C", []string{"abc"}},
+				{"A", 2},
+			},
+		},
+		{
+			in: unionTaggedComplex{
+				unionSimple: unionSimple{1, "2", []string{"abc"}},
+				unionTagged: unionTagged{3},
+				B:           "3",
+			},
+			expect: []testUnionValues{
+				{"C", []string{"abc"}},
+				{"A", 3},
+				{"B", "3"},
+			},
+		},
+	}
+
+	for i, c := range cases {
+		v := reflect.ValueOf(c.in)
+
+		fields := GetStructFields(v.Type())
+		for j, f := range fields.All() {
+			expected := c.expect[j]
+			if e, a := expected.Name, f.Name; e != a {
+				t.Errorf("%d:%d expect %v, got %v", i, j, e, f)
+			}
+			actual := v.FieldByIndex(f.Index).Interface()
+			if e, a := expected.Value, actual; !reflect.DeepEqual(e, a) {
+				t.Errorf("%d:%d expect %v, got %v", i, j, e, f)
+			}
+		}
+	}
+}
+
+func TestCachedFields(t *testing.T) {
+	type myStruct struct {
+		Dog  int
+		CAT  string
+		bird bool
+	}
+
+	fields := GetStructFields(reflect.TypeOf(myStruct{}))
+
+	const expectedNumFields = 2
+	if numFields := len(fields.All()); numFields != expectedNumFields {
+		t.Errorf("expected number of fields to be %d but got %d", expectedNumFields, numFields)
+	}
+
+	cases := []struct {
+		Name      string
+		FieldName string
+		Found     bool
+	}{
+		{"Dog", "Dog", true},
+		{"dog", "Dog", true},
+		{"DOG", "Dog", true},
+		{"Yorkie", "", false},
+		{"Cat", "CAT", true},
+		{"cat", "CAT", true},
+		{"CAT", "CAT", true},
+		{"tiger", "", false},
+		{"bird", "", false},
+	}
+
+	for _, c := range cases {
+		f, found := fields.FieldByName(c.Name)
+		if found != c.Found {
+			t.Errorf("expected found to be %v but got %v", c.Found, found)
+		}
+		if found && f.Name != c.FieldName {
+			t.Errorf("expected field name to be %s but got %s", c.FieldName, f.Name)
+		}
+	}
+}

--- a/document/internal/serde/field_test.go
+++ b/document/internal/serde/field_test.go
@@ -22,7 +22,7 @@ type unionComplex struct {
 }
 
 type unionTagged struct {
-	A int `json:"A"`
+	A int `document:"A"`
 }
 
 type unionTaggedComplex struct {

--- a/document/internal/serde/reflect.go
+++ b/document/internal/serde/reflect.go
@@ -1,0 +1,22 @@
+package serde
+
+import (
+	"github.com/aws/smithy-go/document"
+	"math/big"
+	"reflect"
+	"time"
+)
+
+var ReflectTypeOf = struct {
+	BigFloat             reflect.Type
+	BigInt               reflect.Type
+	DocumentNumber       reflect.Type
+	MapStringToInterface reflect.Type
+	Time                 reflect.Type
+}{
+	BigFloat:             reflect.TypeOf((*big.Float)(nil)).Elem(),
+	BigInt:               reflect.TypeOf((*big.Int)(nil)).Elem(),
+	DocumentNumber:       reflect.TypeOf((*document.Number)(nil)).Elem(),
+	MapStringToInterface: reflect.TypeOf((map[string]interface{})(nil)),
+	Time:                 reflect.TypeOf((*time.Time)(nil)).Elem(),
+}

--- a/document/internal/serde/reflect.go
+++ b/document/internal/serde/reflect.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+// ReflectTypeOf is a structure containing various reflect.Type members that are useful
+// to document Marshaler or Unmarshaler implementations.
 var ReflectTypeOf = struct {
 	BigFloat             reflect.Type
 	BigInt               reflect.Type

--- a/document/internal/serde/serde.go
+++ b/document/internal/serde/serde.go
@@ -1,0 +1,97 @@
+package serde
+
+import (
+	"reflect"
+)
+
+// Indirect will walk a value's interface or pointer value types. Returning
+// the final value or the value a unmarshaler is defined on.
+//
+// Based on the enoding/json type reflect value type indirection in Go Stdlib
+// https://golang.org/src/encoding/json/decode.go Indirect func.
+func Indirect(v reflect.Value, decodingNull bool) reflect.Value {
+	v0 := v
+	haveAddr := false
+
+	if v.Kind() != reflect.Ptr && v.Type().Name() != "" && v.CanAddr() {
+		v = v.Addr()
+		haveAddr = true
+	}
+	for {
+		if v.Kind() == reflect.Interface && !v.IsNil() {
+			e := v.Elem()
+			if e.Kind() == reflect.Ptr && !e.IsNil() && (!decodingNull || e.Elem().Kind() == reflect.Ptr) {
+				haveAddr = false
+				v = e
+				continue
+			}
+		}
+		if v.Kind() != reflect.Ptr {
+			break
+		}
+		if v.Elem().Kind() != reflect.Ptr && decodingNull && v.CanSet() {
+			break
+		}
+		if v.IsNil() {
+			v.Set(reflect.New(v.Type().Elem()))
+		}
+
+		if haveAddr {
+			v = v0
+			haveAddr = false
+		} else {
+			v = v.Elem()
+		}
+	}
+
+	return v
+}
+
+func PtrToValue(in interface{}) interface{} {
+	v := reflect.ValueOf(in)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	if !v.IsValid() {
+		return nil
+	}
+	if v.Kind() == reflect.Ptr {
+		return PtrToValue(v.Interface())
+	}
+	return v.Interface()
+}
+
+func IsZeroValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Invalid:
+		return true
+	case reflect.Array:
+		return v.Len() == 0
+	case reflect.Map, reflect.Slice:
+		return v.IsNil()
+	case reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}
+
+func ValueElem(v reflect.Value) reflect.Value {
+	switch v.Kind() {
+	case reflect.Interface, reflect.Ptr:
+		for v.Kind() == reflect.Interface || v.Kind() == reflect.Ptr {
+			v = v.Elem()
+		}
+	}
+
+	return v
+}

--- a/document/internal/serde/serde.go
+++ b/document/internal/serde/serde.go
@@ -47,6 +47,7 @@ func Indirect(v reflect.Value, decodingNull bool) reflect.Value {
 	return v
 }
 
+// PtrToValue given the input value will dereference pointers and returning the element pointed to.
 func PtrToValue(in interface{}) interface{} {
 	v := reflect.ValueOf(in)
 	if v.Kind() == reflect.Ptr {
@@ -61,6 +62,7 @@ func PtrToValue(in interface{}) interface{} {
 	return v.Interface()
 }
 
+// IsZeroValue returns whether v is the zero-value for its type.
 func IsZeroValue(v reflect.Value) bool {
 	switch v.Kind() {
 	case reflect.Invalid:
@@ -85,6 +87,7 @@ func IsZeroValue(v reflect.Value) bool {
 	return false
 }
 
+// ValueElem walks interface and pointer types and returns the underlying element.
 func ValueElem(v reflect.Value) reflect.Value {
 	switch v.Kind() {
 	case reflect.Interface, reflect.Ptr:

--- a/document/internal/serde/tags.go
+++ b/document/internal/serde/tags.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 )
 
+// Tag represents the `document` struct field tag and associated options
 type Tag struct {
 	Name      string
 	Ignore    bool

--- a/document/internal/serde/tags.go
+++ b/document/internal/serde/tags.go
@@ -1,0 +1,37 @@
+package serde
+
+import (
+	"strings"
+)
+
+type Tag struct {
+	Name      string
+	Ignore    bool
+	OmitEmpty bool
+}
+
+// ParseTag splits a struct field tag into its name and
+// comma-separated options.
+func ParseTag(tagStr string) (tag Tag) {
+	parts := strings.Split(tagStr, ",")
+	if len(parts) == 0 {
+		return tag
+	}
+
+	if name := parts[0]; name == "-" {
+		tag.Name = ""
+		tag.Ignore = true
+	} else {
+		tag.Name = name
+		tag.Ignore = false
+	}
+
+	for _, opt := range parts[1:] {
+		switch opt {
+		case "omitempty":
+			tag.OmitEmpty = true
+		}
+	}
+
+	return tag
+}

--- a/document/json/decoder.go
+++ b/document/json/decoder.go
@@ -1,0 +1,333 @@
+package json
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"reflect"
+
+	"github.com/aws/smithy-go/document"
+	"github.com/aws/smithy-go/document/internal/serde"
+)
+
+type DecoderOptions struct{}
+
+type Decoder struct {
+	options DecoderOptions
+}
+
+func (d *Decoder) DecodeJSONInterface(json interface{}, value interface{}) error {
+	if document.IsNoSerde(value) {
+		return fmt.Errorf("unsupported type: %T", value)
+	}
+
+	v := reflect.ValueOf(value)
+
+	if v.Kind() != reflect.Ptr || v.IsNil() || !v.IsValid() {
+		return &document.InvalidUnmarshalError{Type: reflect.TypeOf(value)}
+	}
+
+	return d.decode(json, v, serde.Tag{})
+}
+
+func (d *Decoder) decode(jv interface{}, rv reflect.Value, tag serde.Tag) error {
+	if jv == nil {
+		rv := serde.Indirect(rv, true)
+		return d.decodeJSONNull(rv)
+	}
+
+	rv = serde.Indirect(rv, false)
+
+	if err := d.unsupportedType(jv, rv); err != nil {
+		return err
+	}
+
+	switch tv := jv.(type) {
+	case bool:
+		return d.decodeJSONBoolean(tv, rv)
+	case json.Number:
+		return d.decodeJSONNumber(tv, rv)
+	case float64:
+		return d.decodeJSONFloat64(tv, rv)
+	case string:
+		return d.decodeJSONString(tv, rv)
+	case []interface{}:
+		return d.decodeJSONArray(tv, rv)
+	case map[string]interface{}:
+		return d.decodeJSONObject(tv, rv)
+	default:
+		return fmt.Errorf("unsupported json type, %T", tv)
+	}
+}
+
+func (d *Decoder) decodeJSONNull(rv reflect.Value) error {
+	if rv.IsValid() && rv.CanSet() {
+		rv.Set(reflect.Zero(rv.Type()))
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeJSONBoolean(tv bool, rv reflect.Value) error {
+	switch rv.Kind() {
+	case reflect.Bool, reflect.Interface:
+		rv.Set(reflect.ValueOf(tv).Convert(rv.Type()))
+	default:
+		return &document.UnmarshalTypeError{Value: "bool", Type: rv.Type()}
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeJSONNumber(tv json.Number, rv reflect.Value) error {
+	switch rv.Kind() {
+	case reflect.Interface:
+		rv.Set(reflect.ValueOf(document.Number(tv)))
+	case reflect.String:
+		// covers document.Number
+		rv.SetString(tv.String())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		i, err := tv.Int64()
+		if err != nil {
+			return err
+		}
+		if rv.OverflowInt(i) {
+			return &document.UnmarshalTypeError{
+				Value: fmt.Sprintf("number overflow, %s", tv.String()),
+				Type:  rv.Type(),
+			}
+		}
+		rv.SetInt(i)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		u, err := document.Number(tv).Uint64()
+		if err != nil {
+			return err
+		}
+		if rv.OverflowUint(u) {
+			return &document.UnmarshalTypeError{
+				Value: fmt.Sprintf("number overflow, %s", tv.String()),
+				Type:  rv.Type(),
+			}
+		}
+		rv.SetUint(u)
+	case reflect.Float32:
+		f, err := document.Number(tv).Float32()
+		if err != nil {
+			return err
+		}
+		if rv.OverflowFloat(f) {
+			return &document.UnmarshalTypeError{
+				Value: fmt.Sprintf("float overflow, %s", tv.String()),
+				Type:  rv.Type(),
+			}
+		}
+		rv.SetFloat(f)
+	case reflect.Float64:
+		f, err := document.Number(tv).Float64()
+		if err != nil {
+			return err
+		}
+		if rv.OverflowFloat(f) {
+			return &document.UnmarshalTypeError{
+				Value: fmt.Sprintf("float overflow, %s", tv.String()),
+				Type:  rv.Type(),
+			}
+		}
+		rv.SetFloat(f)
+	default:
+		rvt := rv.Type()
+		switch {
+		case rvt.ConvertibleTo(serde.ReflectTypeOf.BigFloat):
+			sv := tv.String()
+			f, ok := (&big.Float{}).SetString(sv)
+			if !ok {
+				return &document.UnmarshalTypeError{
+					Value: fmt.Sprintf("invalid number format, %s", sv),
+					Type:  rv.Type(),
+				}
+			}
+			rv.Set(reflect.ValueOf(*f).Convert(rvt))
+		case rvt.ConvertibleTo(serde.ReflectTypeOf.BigInt):
+			sv := tv.String()
+			i, ok := (&big.Int{}).SetString(sv, 10)
+			if !ok {
+				return &document.UnmarshalTypeError{
+					Value: fmt.Sprintf("invalid number format, %s", sv),
+					Type:  rv.Type(),
+				}
+			}
+			rv.Set(reflect.ValueOf(*i).Convert(rvt))
+		default:
+			return &document.UnmarshalTypeError{Value: "number", Type: rv.Type()}
+		}
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeJSONFloat64(tv float64, rv reflect.Value) error {
+	switch rv.Kind() {
+	case reflect.Interface:
+		if rv.NumMethod() != 0 {
+			return &document.UnmarshalTypeError{Value: "number", Type: rv.Type()}
+		}
+		rv.Set(reflect.ValueOf(tv))
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		i, accuracy := big.NewFloat(tv).Int64()
+		if accuracy != big.Exact || rv.OverflowInt(i) {
+			return &document.UnmarshalTypeError{
+				Value: fmt.Sprintf("number overflow, %e", tv),
+				Type:  rv.Type(),
+			}
+		}
+		rv.SetInt(i)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		u, accuracy := big.NewFloat(tv).Uint64()
+		if accuracy != big.Exact || rv.OverflowUint(u) {
+			return &document.UnmarshalTypeError{
+				Value: fmt.Sprintf("number overflow, %e", tv),
+				Type:  rv.Type(),
+			}
+		}
+		rv.SetUint(u)
+	case reflect.Float32, reflect.Float64:
+		if rv.OverflowFloat(tv) {
+			return &document.UnmarshalTypeError{
+				Value: fmt.Sprintf("float overflow, %e", tv),
+				Type:  rv.Type(),
+			}
+		}
+		rv.SetFloat(tv)
+	default:
+		rvt := rv.Type()
+		switch {
+		case rvt.ConvertibleTo(serde.ReflectTypeOf.BigFloat):
+			f := big.NewFloat(tv)
+			rv.Set(reflect.ValueOf(*f).Convert(rvt))
+		case rvt.ConvertibleTo(serde.ReflectTypeOf.BigInt):
+			i, accuracy := big.NewFloat(tv).Int(nil)
+			if accuracy != big.Exact {
+				return &document.UnmarshalTypeError{
+					Value: fmt.Sprintf("int overflow, %e", tv),
+					Type:  rv.Type(),
+				}
+			}
+			rv.Set(reflect.ValueOf(*i).Convert(rvt))
+		default:
+			return &document.UnmarshalTypeError{Value: "number", Type: rv.Type()}
+		}
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeJSONArray(tv []interface{}, rv reflect.Value) error {
+	var isArray bool
+
+	switch rv.Kind() {
+	case reflect.Slice:
+		// Make room for the slice elements if needed
+		if rv.IsNil() || rv.Cap() < len(tv) {
+			rv.Set(reflect.MakeSlice(rv.Type(), 0, len(tv)))
+		}
+	case reflect.Array:
+		// Limited to capacity of existing array.
+		isArray = true
+	case reflect.Interface:
+		s := make([]interface{}, len(tv))
+		for i, av := range tv {
+			if err := d.decode(av, reflect.ValueOf(&s[i]).Elem(), serde.Tag{}); err != nil {
+				return err
+			}
+		}
+		rv.Set(reflect.ValueOf(s))
+		return nil
+	default:
+		return &document.UnmarshalTypeError{Value: "list", Type: rv.Type()}
+	}
+
+	// If rv is not a slice, array
+	for i := 0; i < rv.Cap() && i < len(tv); i++ {
+		if !isArray {
+			rv.SetLen(i + 1)
+		}
+		if err := d.decode(tv[i], rv.Index(i), serde.Tag{}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeJSONString(tv string, rv reflect.Value) error {
+	switch rv.Kind() {
+	case reflect.String:
+		rv.SetString(tv)
+	case reflect.Interface:
+		// Ensure type aliasing is handled properly
+		rv.Set(reflect.ValueOf(tv).Convert(rv.Type()))
+	default:
+		return &document.UnmarshalTypeError{Value: "string", Type: rv.Type()}
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeJSONObject(tv map[string]interface{}, rv reflect.Value) error {
+	switch rv.Kind() {
+	case reflect.Map:
+		t := rv.Type()
+		if t.Key().Kind() != reflect.String {
+			return &document.UnmarshalTypeError{Value: "map string key", Type: t.Key()}
+		}
+		if rv.IsNil() {
+			rv.Set(reflect.MakeMap(t))
+		}
+	case reflect.Struct:
+		if rv.CanInterface() && document.IsNoSerde(rv.Interface()) {
+			return &document.UnmarshalTypeError{
+				Value: fmt.Sprintf("unsupported type"),
+				Type:  rv.Type(),
+			}
+		}
+	case reflect.Interface:
+		rv.Set(reflect.MakeMap(serde.ReflectTypeOf.MapStringToInterface))
+		rv = rv.Elem()
+	default:
+		return &document.UnmarshalTypeError{Value: "map", Type: rv.Type()}
+	}
+
+	if rv.Kind() == reflect.Map {
+		for k, kv := range tv {
+			key := reflect.New(rv.Type().Key()).Elem()
+			key.SetString(k)
+			elem := reflect.New(rv.Type().Elem()).Elem()
+			if err := d.decode(kv, elem, serde.Tag{}); err != nil {
+				return err
+			}
+			rv.SetMapIndex(key, elem)
+		}
+	} else if rv.Kind() == reflect.Struct {
+		fields := serde.GetStructFields(rv.Type())
+		for k, kv := range tv {
+			if f, ok := fields.FieldByName(k); ok {
+				fv := serde.DecoderFieldByIndex(rv, f.Index)
+				if err := d.decode(kv, fv, f.Tag); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (d *Decoder) unsupportedType(jv interface{}, rv reflect.Value) error {
+	if rv.Type().ConvertibleTo(serde.ReflectTypeOf.Time) {
+		return &document.UnmarshalTypeError{
+			Type:  rv.Type(),
+			Value: fmt.Sprintf("time value: %v", jv),
+		}
+	}
+	return nil
+}

--- a/document/json/decoder_test.go
+++ b/document/json/decoder_test.go
@@ -1,0 +1,630 @@
+package json_test
+
+import (
+	"bytes"
+	stdjson "encoding/json"
+	"math"
+	"math/big"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/aws/smithy-go/document"
+	"github.com/aws/smithy-go/document/internal/serde"
+	"github.com/aws/smithy-go/document/json"
+	"github.com/aws/smithy-go/ptr"
+	"github.com/google/go-cmp/cmp"
+)
+
+type StructA struct {
+	FieldName    string
+	FieldPtrName *string
+
+	FieldRename  string `document:"field_rename"`
+	FieldIgnored string `document:"-"`
+
+	FieldOmitEmpty    string  `document:",omitempty"`
+	FieldPtrOmitEmpty *string `document:",omitempty"`
+
+	FieldRenameOmitEmpty string `document:"field_rename_omit_empty,omitempty"`
+
+	FieldNestedStruct          *StructA `document:"field_nested_struct"`
+	FieldNestedStructOmitEmpty *StructA `document:"field_nested_struct_omit_empty,omitempty"`
+
+	fieldUnexported string
+
+	StructB
+}
+
+type StructB struct {
+	FieldName string `document:"field_name"`
+}
+
+type testCase struct {
+	decoderOptions    json.DecoderOptions
+	encoderOptions    json.EncoderOptions
+	disableJSONNumber bool
+	json              []byte
+	actual, want      interface{}
+	wantErr           bool
+}
+
+var sharedStringTests = map[string]testCase{
+	"string": {
+		json: []byte(`"foo"`),
+		actual: func() interface{} {
+			var v string
+			return &v
+		}(),
+		want: "foo",
+	},
+	"interface{}": {
+		json: []byte(`"foo"`),
+		actual: func() interface{} {
+			var v interface{}
+			return &v
+		}(),
+		want: "foo",
+	},
+}
+
+var sharedObjectTests = map[string]testCase{
+	"null for pointer type": {
+		json: []byte(`null`),
+		actual: func() interface{} {
+			var v *StructA
+			return &v
+		}(),
+	},
+	"zero value": {
+		json: []byte(`{
+  "FieldName": "",
+  "FieldPtrName": null,
+  "field_name": "",
+  "field_nested_struct": null,
+  "field_rename": ""
+}`),
+		actual: func() interface{} {
+			var v StructA
+			return &v
+		}(),
+		want: StructA{},
+	},
+	"filled json structure": {
+		json: []byte(`{
+  "FieldName": "a",
+  "FieldPtrName": "b",
+  "field_rename": "c",
+  "FieldOmitEmpty": "d",
+  "FieldPtrOmitEmpty": "e",
+  "field_rename_omit_empty": "f",
+  "field_nested_struct": {
+    "FieldName": "a",
+    "FieldPtrName": null,
+    "field_name": "",
+    "field_nested_struct": null,
+    "field_rename": ""
+  },
+  "field_nested_struct_omit_empty": {
+    "FieldName": "a",
+    "FieldPtrName": null,
+    "field_name": "",
+    "field_nested_struct": null,
+    "field_rename": ""
+  },
+  "field_name": "A"
+}`),
+		actual: func() interface{} {
+			var v *StructA
+			return &v
+		}(),
+		want: &StructA{
+			FieldName:            "a",
+			FieldPtrName:         ptr.String("b"),
+			FieldRename:          "c",
+			FieldOmitEmpty:       "d",
+			FieldPtrOmitEmpty:    ptr.String("e"),
+			FieldRenameOmitEmpty: "f",
+			FieldNestedStruct: &StructA{
+				FieldName: "a",
+			},
+			FieldNestedStructOmitEmpty: &StructA{
+				FieldName: "a",
+			},
+			StructB: StructB{
+				FieldName: "A",
+			},
+		},
+	},
+}
+
+var decodeArrayTestCases = map[string]testCase{
+	"array not enough capacity": {
+		json: []byte(`["foo", "bar", "baz"]`),
+		actual: func() interface{} {
+			var v [2]string
+			return &v
+		}(),
+		want: [2]string{"foo", "bar"},
+	},
+}
+
+var sharedArrayTestCases = map[string]testCase{
+	"slice": {
+		json: []byte(`["foo", "bar", "baz"]`),
+		actual: func() interface{} {
+			var v []string
+			return &v
+		}(),
+		want: []string{"foo", "bar", "baz"},
+	},
+	"array": {
+		json: []byte(`["foo", "bar", "baz"]`),
+		actual: func() interface{} {
+			var v [3]string
+			return &v
+		}(),
+		want: [3]string{"foo", "bar", "baz"},
+	},
+
+	"interface{}": {
+		json: []byte(`["foo", "bar", "baz"]`),
+		actual: func() interface{} {
+			var v interface{}
+			return &v
+		}(),
+		want: []interface{}{"foo", "bar", "baz"},
+	},
+}
+
+var sharedNumberTestCases = map[string]testCase{
+	"json.Number to interface{}": {
+		json: []byte(`3.14159`),
+		actual: func() interface{} {
+			var v interface{}
+			return &v
+		}(),
+		want: ptrNumber("3.14159"),
+	},
+
+	"json float64 to interface{}": {
+		json: []byte(`3.14159`),
+		actual: func() interface{} {
+			var v interface{}
+			return &v
+		}(),
+		want:              ptr.Float64(3.14159),
+		disableJSONNumber: true,
+	},
+
+	"json.Number to document.Number": {
+		json: []byte(`3.14159`),
+		actual: func() interface{} {
+			var v document.Number
+			return &v
+		}(),
+		want: document.Number("3.14159"),
+	},
+
+	"json.Number to *document.Number": {
+		json: []byte(`3.14159`),
+		actual: func() interface{} {
+			var v *document.Number
+			return &v
+		}(),
+		want: document.Number("3.14159"),
+	},
+
+	/*
+		int, int16, int32, int64
+	*/
+	"json.Number to int": {
+		json: []byte(`2147483647`),
+		actual: func() interface{} {
+			var x int
+			return &x
+		}(),
+		want: ptr.Int(2147483647),
+	},
+	"json float64 to int": {
+		json: []byte(`2147483647`),
+		actual: func() interface{} {
+			var x int
+			return &x
+		}(),
+		want:              ptr.Int(2147483647),
+		disableJSONNumber: true,
+	},
+	"json.Number to int8": {
+		json: []byte(`127`),
+		actual: func() interface{} {
+			var x int8
+			return &x
+		}(),
+		want: ptr.Int8(127),
+	},
+	"json float64 to int8": {
+		json: []byte(`127`),
+		actual: func() interface{} {
+			var x int8
+			return &x
+		}(),
+		want:              ptr.Int8(127),
+		disableJSONNumber: true,
+	},
+	"json.Number to int16": {
+		json: []byte(`32767`),
+		actual: func() interface{} {
+			var x int16
+			return &x
+		}(),
+		want: ptr.Int16(32767),
+	},
+	"json float64 to int16": {
+		json: []byte(`32767`),
+		actual: func() interface{} {
+			var x int16
+			return &x
+		}(),
+		want:              ptr.Int16(32767),
+		disableJSONNumber: true,
+	},
+	"json.Number to int32": {
+		json: []byte(`2147483647`),
+		actual: func() interface{} {
+			var x int32
+			return &x
+		}(),
+		want: ptr.Int32(2147483647),
+	},
+	"json float64 to int32": {
+		json: []byte(`2147483647`),
+		actual: func() interface{} {
+			var x int32
+			return &x
+		}(),
+		want:              ptr.Int32(2147483647),
+		disableJSONNumber: true,
+	},
+	"json.Number to int64": {
+		json: []byte("9223372036854775807"),
+		actual: func() interface{} {
+			var x int64
+			return &x
+		}(),
+		want: ptr.Int64(9223372036854775807),
+	},
+	"json float64 to int64": {
+		json: []byte("2147483648"),
+		actual: func() interface{} {
+			var x int64
+			return &x
+		}(),
+		want:              ptr.Int64(2147483648),
+		disableJSONNumber: true,
+	},
+
+	/*
+		uint, uint16, uint32, uint64
+	*/
+	"json.Number to uint": {
+		json: []byte(`4294967295`),
+		actual: func() interface{} {
+			var x uint
+			return &x
+		}(),
+		want: ptr.Uint(4294967295),
+	},
+	"json float64 to uint": {
+		json: []byte(`4294967295`),
+		actual: func() interface{} {
+			var x uint
+			return &x
+		}(),
+		want:              ptr.Uint(4294967295),
+		disableJSONNumber: true,
+	},
+	"json.Number to uint8": {
+		json: []byte(`255`),
+		actual: func() interface{} {
+			var x uint8
+			return &x
+		}(),
+		want: ptr.Uint8(255),
+	},
+	"json float64 to uint8": {
+		json: []byte(`255`),
+		actual: func() interface{} {
+			var x uint8
+			return &x
+		}(),
+		want:              ptr.Uint8(255),
+		disableJSONNumber: true,
+	},
+	"json.Number to uint16": {
+		json: []byte(`65535`),
+		actual: func() interface{} {
+			var x uint16
+			return &x
+		}(),
+		want: ptr.Uint16(65535),
+	},
+	"json float64 to uint16": {
+		json: []byte(`65535`),
+		actual: func() interface{} {
+			var x uint16
+			return &x
+		}(),
+		want:              ptr.Uint16(65535),
+		disableJSONNumber: true,
+	},
+	"json.Number to uint32": {
+		json: []byte(`4294967295`),
+		actual: func() interface{} {
+			var x uint32
+			return &x
+		}(),
+		want: ptr.Uint32(4294967295),
+	},
+	"json float64 to uint32": {
+		json: []byte(`4294967295`),
+		actual: func() interface{} {
+			var x uint32
+			return &x
+		}(),
+		want:              ptr.Uint32(4294967295),
+		disableJSONNumber: true,
+	},
+	"json.Number to uint64": {
+		json: []byte("18446744073709551615"),
+		actual: func() interface{} {
+			var x uint64
+			return &x
+		}(),
+		want: ptr.Uint64(18446744073709551615),
+	},
+	"json float64 to uint64": {
+		json: []byte("4294967295"),
+		actual: func() interface{} {
+			var x uint64
+			return &x
+		}(),
+		want:              ptr.Uint64(4294967295),
+		disableJSONNumber: true,
+	},
+
+	/*
+		float32, float64
+	*/
+	"json.Number to float32": {
+		json: []byte(strconv.FormatFloat(math.MaxFloat32, 'e', -1, 32)),
+		actual: func() interface{} {
+			var x float32
+			return &x
+		}(),
+		want: ptr.Float32(math.MaxFloat32),
+	},
+	"json float64 to float32": {
+		json: []byte(strconv.FormatFloat(3.14159, 'e', -1, 32)),
+		actual: func() interface{} {
+			var x float32
+			return &x
+		}(),
+		want:              ptr.Float32(3.14159),
+		disableJSONNumber: true,
+	},
+	"json.Number to float64": {
+		json: []byte(strconv.FormatFloat(math.MaxFloat64, 'e', -1, 64)),
+		actual: func() interface{} {
+			var x float64
+			return &x
+		}(),
+		want: ptr.Float64(math.MaxFloat64),
+	},
+	"json float64 to float64": {
+		json: []byte(strconv.FormatFloat(3.14159, 'e', -1, 64)),
+		actual: func() interface{} {
+			var x float64
+			return &x
+		}(),
+		want:              ptr.Float64(3.14159),
+		disableJSONNumber: true,
+	},
+
+	/*
+		Arbitrary Number Sizes
+	*/
+	"json.Number to big.Float": {
+		json: []byte(strconv.FormatFloat(math.MaxFloat64, 'e', -1, 64)),
+		actual: func() interface{} {
+			var x big.Float
+			return &x
+		}(),
+		want: func() *big.Float {
+			return big.NewFloat(math.MaxFloat64)
+		}(),
+	},
+	"float64 to big.Float": {
+		json: []byte(strconv.FormatFloat(math.MaxFloat64, 'e', -1, 64)),
+		actual: func() interface{} {
+			var x big.Float
+			return &x
+		}(),
+		want: func() *big.Float {
+			return big.NewFloat(math.MaxFloat64)
+		}(),
+		disableJSONNumber: true,
+	},
+	"json.Number to big.Int": {
+		json: []byte(strconv.FormatInt(math.MaxInt64, 10)),
+		actual: func() interface{} {
+			var x big.Int
+			return &x
+		}(),
+		want: func() *big.Int {
+			return big.NewInt(math.MaxInt64)
+		}(),
+	},
+	"float64 to big.Int": {
+		json: []byte(strconv.FormatInt(math.MaxInt32, 10)),
+		actual: func() interface{} {
+			var x big.Int
+			return &x
+		}(),
+		want: func() *big.Int {
+			return big.NewInt(math.MaxInt32)
+		}(),
+		disableJSONNumber: true,
+	},
+}
+
+func MustJSONUnmarshal(v []byte, useJSONNumber bool) interface{} {
+	var jv interface{}
+	decoder := stdjson.NewDecoder(bytes.NewReader(v))
+	if useJSONNumber {
+		decoder.UseNumber()
+	}
+	if err := decoder.Decode(&jv); err != nil {
+		panic(err)
+	}
+	return jv
+}
+
+func ptrNumber(number document.Number) *document.Number {
+	return &number
+}
+
+func TestDecoder_DecodeJSONInterface(t *testing.T) {
+	t.Run("Object", func(t *testing.T) {
+		for name, tt := range sharedObjectTests {
+			t.Run(name, func(t *testing.T) {
+				testDecodeJSONInterface(t, tt)
+			})
+		}
+	})
+	t.Run("Array", func(t *testing.T) {
+		for name, tt := range sharedArrayTestCases {
+			t.Run(name, func(t *testing.T) {
+				testDecodeJSONInterface(t, tt)
+			})
+		}
+	})
+	t.Run("Number", func(t *testing.T) {
+		for name, tt := range sharedNumberTestCases {
+			t.Run(name, func(t *testing.T) {
+				testDecodeJSONInterface(t, tt)
+			})
+		}
+	})
+	t.Run("String", func(t *testing.T) {
+		for name, tt := range sharedStringTests {
+			t.Run(name, func(t *testing.T) {
+				testDecodeJSONInterface(t, tt)
+			})
+		}
+	})
+}
+
+func TestNoSerde(t *testing.T) {
+	type noSerde = document.NoSerde
+	type InvalidType struct {
+		FieldName string
+		noSerde
+	}
+	var v InvalidType
+
+	err := json.NewDecoder().DecodeJSONInterface(MustJSONUnmarshal([]byte(`{
+  "FieldName": "value"
+}`), true), &v)
+	if err == nil {
+		t.Fatalf("expect error, got nil")
+	}
+
+	type EmbedInvalidType struct {
+		FieldName string
+		TypeField InvalidType
+	}
+
+	var ev EmbedInvalidType
+
+	err = json.NewDecoder().DecodeJSONInterface(MustJSONUnmarshal([]byte(`{
+  "FieldName": "value",
+  "TypeField": {
+    "FieldName": "value"
+  }
+}`), true), &ev)
+	if err == nil {
+		t.Fatalf("expect error, got nil")
+	}
+}
+
+func TestNewDecoderUnsupportedTypes(t *testing.T) {
+	cases := []struct {
+		input             []byte
+		value             interface{}
+		disableJSONNumber bool
+	}{
+		{
+			input: []byte(`1000000000`),
+			value: func() interface{} {
+				var t time.Time
+				return &t
+			}(),
+		},
+		{
+			input: []byte(`1000000000`),
+			value: func() interface{} {
+				var t time.Time
+				return &t
+			}(),
+			disableJSONNumber: true,
+		},
+		{
+			input: []byte(`{}`),
+			value: func() interface{} {
+				var t time.Time
+				return &t
+			}(),
+		},
+	}
+
+	decoder := json.NewDecoder()
+	for _, tt := range cases {
+		err := decoder.DecodeJSONInterface(MustJSONUnmarshal(tt.input, !tt.disableJSONNumber), tt.value)
+		if err == nil {
+			t.Errorf("expect error, got nil")
+		}
+	}
+}
+
+func testDecodeJSONInterface(t *testing.T, tt testCase) {
+	t.Helper()
+
+	d := json.NewDecoder(func(options *json.DecoderOptions) {
+		*options = tt.decoderOptions
+	})
+	if err := d.DecodeJSONInterface(MustJSONUnmarshal(tt.json, !tt.disableJSONNumber), tt.actual); (err != nil) != tt.wantErr {
+		t.Errorf("DecodeJSONInterface() error = %v, wantErr %v", err, tt.wantErr)
+	}
+	if diff := cmp.Diff(
+		serde.PtrToValue(tt.want),
+		serde.PtrToValue(tt.actual),
+		cmp.AllowUnexported(StructA{}, StructB{}),
+		cmp.Comparer(cmpBigFloat()),
+		cmp.Comparer(cmpBigInt()),
+	); len(diff) > 0 {
+		t.Error(diff)
+	}
+}
+
+func cmpBigFloat() func(x big.Float, y big.Float) bool {
+	return func(x, y big.Float) bool {
+		return x.String() == y.String()
+	}
+}
+
+func cmpBigInt() func(x big.Int, y big.Int) bool {
+	return func(x, y big.Int) bool {
+		return x.String() == y.String()
+	}
+}

--- a/document/json/decoder_test.go
+++ b/document/json/decoder_test.go
@@ -1,142 +1,15 @@
 package json_test
 
 import (
-	"bytes"
-	stdjson "encoding/json"
-	"math"
 	"math/big"
-	"strconv"
 	"testing"
 	"time"
 
 	"github.com/aws/smithy-go/document"
 	"github.com/aws/smithy-go/document/internal/serde"
 	"github.com/aws/smithy-go/document/json"
-	"github.com/aws/smithy-go/ptr"
 	"github.com/google/go-cmp/cmp"
 )
-
-type StructA struct {
-	FieldName    string
-	FieldPtrName *string
-
-	FieldRename  string `document:"field_rename"`
-	FieldIgnored string `document:"-"`
-
-	FieldOmitEmpty    string  `document:",omitempty"`
-	FieldPtrOmitEmpty *string `document:",omitempty"`
-
-	FieldRenameOmitEmpty string `document:"field_rename_omit_empty,omitempty"`
-
-	FieldNestedStruct          *StructA `document:"field_nested_struct"`
-	FieldNestedStructOmitEmpty *StructA `document:"field_nested_struct_omit_empty,omitempty"`
-
-	fieldUnexported string
-
-	StructB
-}
-
-type StructB struct {
-	FieldName string `document:"field_name"`
-}
-
-type testCase struct {
-	decoderOptions    json.DecoderOptions
-	encoderOptions    json.EncoderOptions
-	disableJSONNumber bool
-	json              []byte
-	actual, want      interface{}
-	wantErr           bool
-}
-
-var sharedStringTests = map[string]testCase{
-	"string": {
-		json: []byte(`"foo"`),
-		actual: func() interface{} {
-			var v string
-			return &v
-		}(),
-		want: "foo",
-	},
-	"interface{}": {
-		json: []byte(`"foo"`),
-		actual: func() interface{} {
-			var v interface{}
-			return &v
-		}(),
-		want: "foo",
-	},
-}
-
-var sharedObjectTests = map[string]testCase{
-	"null for pointer type": {
-		json: []byte(`null`),
-		actual: func() interface{} {
-			var v *StructA
-			return &v
-		}(),
-	},
-	"zero value": {
-		json: []byte(`{
-  "FieldName": "",
-  "FieldPtrName": null,
-  "field_name": "",
-  "field_nested_struct": null,
-  "field_rename": ""
-}`),
-		actual: func() interface{} {
-			var v StructA
-			return &v
-		}(),
-		want: StructA{},
-	},
-	"filled json structure": {
-		json: []byte(`{
-  "FieldName": "a",
-  "FieldPtrName": "b",
-  "field_rename": "c",
-  "FieldOmitEmpty": "d",
-  "FieldPtrOmitEmpty": "e",
-  "field_rename_omit_empty": "f",
-  "field_nested_struct": {
-    "FieldName": "a",
-    "FieldPtrName": null,
-    "field_name": "",
-    "field_nested_struct": null,
-    "field_rename": ""
-  },
-  "field_nested_struct_omit_empty": {
-    "FieldName": "a",
-    "FieldPtrName": null,
-    "field_name": "",
-    "field_nested_struct": null,
-    "field_rename": ""
-  },
-  "field_name": "A"
-}`),
-		actual: func() interface{} {
-			var v *StructA
-			return &v
-		}(),
-		want: &StructA{
-			FieldName:            "a",
-			FieldPtrName:         ptr.String("b"),
-			FieldRename:          "c",
-			FieldOmitEmpty:       "d",
-			FieldPtrOmitEmpty:    ptr.String("e"),
-			FieldRenameOmitEmpty: "f",
-			FieldNestedStruct: &StructA{
-				FieldName: "a",
-			},
-			FieldNestedStructOmitEmpty: &StructA{
-				FieldName: "a",
-			},
-			StructB: StructB{
-				FieldName: "A",
-			},
-		},
-	},
-}
 
 var decodeArrayTestCases = map[string]testCase{
 	"array not enough capacity": {
@@ -149,380 +22,44 @@ var decodeArrayTestCases = map[string]testCase{
 	},
 }
 
-var sharedArrayTestCases = map[string]testCase{
-	"slice": {
-		json: []byte(`["foo", "bar", "baz"]`),
-		actual: func() interface{} {
-			var v []string
-			return &v
-		}(),
-		want: []string{"foo", "bar", "baz"},
-	},
-	"array": {
-		json: []byte(`["foo", "bar", "baz"]`),
-		actual: func() interface{} {
-			var v [3]string
-			return &v
-		}(),
-		want: [3]string{"foo", "bar", "baz"},
-	},
-
-	"interface{}": {
-		json: []byte(`["foo", "bar", "baz"]`),
-		actual: func() interface{} {
-			var v interface{}
-			return &v
-		}(),
-		want: []interface{}{"foo", "bar", "baz"},
-	},
-}
-
-var sharedNumberTestCases = map[string]testCase{
-	"json.Number to interface{}": {
-		json: []byte(`3.14159`),
-		actual: func() interface{} {
-			var v interface{}
-			return &v
-		}(),
-		want: ptrNumber("3.14159"),
-	},
-
-	"json float64 to interface{}": {
-		json: []byte(`3.14159`),
-		actual: func() interface{} {
-			var v interface{}
-			return &v
-		}(),
-		want:              ptr.Float64(3.14159),
-		disableJSONNumber: true,
-	},
-
-	"json.Number to document.Number": {
-		json: []byte(`3.14159`),
-		actual: func() interface{} {
-			var v document.Number
-			return &v
-		}(),
-		want: document.Number("3.14159"),
-	},
-
-	"json.Number to *document.Number": {
-		json: []byte(`3.14159`),
-		actual: func() interface{} {
-			var v *document.Number
-			return &v
-		}(),
-		want: document.Number("3.14159"),
-	},
-
-	/*
-		int, int16, int32, int64
-	*/
-	"json.Number to int": {
-		json: []byte(`2147483647`),
-		actual: func() interface{} {
-			var x int
-			return &x
-		}(),
-		want: ptr.Int(2147483647),
-	},
-	"json float64 to int": {
-		json: []byte(`2147483647`),
-		actual: func() interface{} {
-			var x int
-			return &x
-		}(),
-		want:              ptr.Int(2147483647),
-		disableJSONNumber: true,
-	},
-	"json.Number to int8": {
-		json: []byte(`127`),
-		actual: func() interface{} {
-			var x int8
-			return &x
-		}(),
-		want: ptr.Int8(127),
-	},
-	"json float64 to int8": {
-		json: []byte(`127`),
-		actual: func() interface{} {
-			var x int8
-			return &x
-		}(),
-		want:              ptr.Int8(127),
-		disableJSONNumber: true,
-	},
-	"json.Number to int16": {
-		json: []byte(`32767`),
-		actual: func() interface{} {
-			var x int16
-			return &x
-		}(),
-		want: ptr.Int16(32767),
-	},
-	"json float64 to int16": {
-		json: []byte(`32767`),
-		actual: func() interface{} {
-			var x int16
-			return &x
-		}(),
-		want:              ptr.Int16(32767),
-		disableJSONNumber: true,
-	},
-	"json.Number to int32": {
-		json: []byte(`2147483647`),
-		actual: func() interface{} {
-			var x int32
-			return &x
-		}(),
-		want: ptr.Int32(2147483647),
-	},
-	"json float64 to int32": {
-		json: []byte(`2147483647`),
-		actual: func() interface{} {
-			var x int32
-			return &x
-		}(),
-		want:              ptr.Int32(2147483647),
-		disableJSONNumber: true,
-	},
-	"json.Number to int64": {
-		json: []byte("9223372036854775807"),
-		actual: func() interface{} {
-			var x int64
-			return &x
-		}(),
-		want: ptr.Int64(9223372036854775807),
-	},
-	"json float64 to int64": {
-		json: []byte("2147483648"),
-		actual: func() interface{} {
-			var x int64
-			return &x
-		}(),
-		want:              ptr.Int64(2147483648),
-		disableJSONNumber: true,
-	},
-
-	/*
-		uint, uint16, uint32, uint64
-	*/
-	"json.Number to uint": {
-		json: []byte(`4294967295`),
-		actual: func() interface{} {
-			var x uint
-			return &x
-		}(),
-		want: ptr.Uint(4294967295),
-	},
-	"json float64 to uint": {
-		json: []byte(`4294967295`),
-		actual: func() interface{} {
-			var x uint
-			return &x
-		}(),
-		want:              ptr.Uint(4294967295),
-		disableJSONNumber: true,
-	},
-	"json.Number to uint8": {
-		json: []byte(`255`),
-		actual: func() interface{} {
-			var x uint8
-			return &x
-		}(),
-		want: ptr.Uint8(255),
-	},
-	"json float64 to uint8": {
-		json: []byte(`255`),
-		actual: func() interface{} {
-			var x uint8
-			return &x
-		}(),
-		want:              ptr.Uint8(255),
-		disableJSONNumber: true,
-	},
-	"json.Number to uint16": {
-		json: []byte(`65535`),
-		actual: func() interface{} {
-			var x uint16
-			return &x
-		}(),
-		want: ptr.Uint16(65535),
-	},
-	"json float64 to uint16": {
-		json: []byte(`65535`),
-		actual: func() interface{} {
-			var x uint16
-			return &x
-		}(),
-		want:              ptr.Uint16(65535),
-		disableJSONNumber: true,
-	},
-	"json.Number to uint32": {
-		json: []byte(`4294967295`),
-		actual: func() interface{} {
-			var x uint32
-			return &x
-		}(),
-		want: ptr.Uint32(4294967295),
-	},
-	"json float64 to uint32": {
-		json: []byte(`4294967295`),
-		actual: func() interface{} {
-			var x uint32
-			return &x
-		}(),
-		want:              ptr.Uint32(4294967295),
-		disableJSONNumber: true,
-	},
-	"json.Number to uint64": {
-		json: []byte("18446744073709551615"),
-		actual: func() interface{} {
-			var x uint64
-			return &x
-		}(),
-		want: ptr.Uint64(18446744073709551615),
-	},
-	"json float64 to uint64": {
-		json: []byte("4294967295"),
-		actual: func() interface{} {
-			var x uint64
-			return &x
-		}(),
-		want:              ptr.Uint64(4294967295),
-		disableJSONNumber: true,
-	},
-
-	/*
-		float32, float64
-	*/
-	"json.Number to float32": {
-		json: []byte(strconv.FormatFloat(math.MaxFloat32, 'e', -1, 32)),
-		actual: func() interface{} {
-			var x float32
-			return &x
-		}(),
-		want: ptr.Float32(math.MaxFloat32),
-	},
-	"json float64 to float32": {
-		json: []byte(strconv.FormatFloat(3.14159, 'e', -1, 32)),
-		actual: func() interface{} {
-			var x float32
-			return &x
-		}(),
-		want:              ptr.Float32(3.14159),
-		disableJSONNumber: true,
-	},
-	"json.Number to float64": {
-		json: []byte(strconv.FormatFloat(math.MaxFloat64, 'e', -1, 64)),
-		actual: func() interface{} {
-			var x float64
-			return &x
-		}(),
-		want: ptr.Float64(math.MaxFloat64),
-	},
-	"json float64 to float64": {
-		json: []byte(strconv.FormatFloat(3.14159, 'e', -1, 64)),
-		actual: func() interface{} {
-			var x float64
-			return &x
-		}(),
-		want:              ptr.Float64(3.14159),
-		disableJSONNumber: true,
-	},
-
-	/*
-		Arbitrary Number Sizes
-	*/
-	"json.Number to big.Float": {
-		json: []byte(strconv.FormatFloat(math.MaxFloat64, 'e', -1, 64)),
-		actual: func() interface{} {
-			var x big.Float
-			return &x
-		}(),
-		want: func() *big.Float {
-			return big.NewFloat(math.MaxFloat64)
-		}(),
-	},
-	"float64 to big.Float": {
-		json: []byte(strconv.FormatFloat(math.MaxFloat64, 'e', -1, 64)),
-		actual: func() interface{} {
-			var x big.Float
-			return &x
-		}(),
-		want: func() *big.Float {
-			return big.NewFloat(math.MaxFloat64)
-		}(),
-		disableJSONNumber: true,
-	},
-	"json.Number to big.Int": {
-		json: []byte(strconv.FormatInt(math.MaxInt64, 10)),
-		actual: func() interface{} {
-			var x big.Int
-			return &x
-		}(),
-		want: func() *big.Int {
-			return big.NewInt(math.MaxInt64)
-		}(),
-	},
-	"float64 to big.Int": {
-		json: []byte(strconv.FormatInt(math.MaxInt32, 10)),
-		actual: func() interface{} {
-			var x big.Int
-			return &x
-		}(),
-		want: func() *big.Int {
-			return big.NewInt(math.MaxInt32)
-		}(),
-		disableJSONNumber: true,
-	},
-}
-
-func MustJSONUnmarshal(v []byte, useJSONNumber bool) interface{} {
-	var jv interface{}
-	decoder := stdjson.NewDecoder(bytes.NewReader(v))
-	if useJSONNumber {
-		decoder.UseNumber()
-	}
-	if err := decoder.Decode(&jv); err != nil {
-		panic(err)
-	}
-	return jv
-}
-
-func ptrNumber(number document.Number) *document.Number {
-	return &number
-}
-
 func TestDecoder_DecodeJSONInterface(t *testing.T) {
-	t.Run("Object", func(t *testing.T) {
-		for name, tt := range sharedObjectTests {
+	t.Run("Shared", func(t *testing.T) {
+		t.Run("Object", func(t *testing.T) {
+			for name, tt := range sharedObjectTests {
+				t.Run(name, func(t *testing.T) {
+					testDecodeJSONInterface(t, tt)
+				})
+			}
+		})
+		t.Run("Array", func(t *testing.T) {
+			for name, tt := range sharedArrayTestCases {
+				t.Run(name, func(t *testing.T) {
+					testDecodeJSONInterface(t, tt)
+				})
+			}
+		})
+		t.Run("Number", func(t *testing.T) {
+			for name, tt := range sharedNumberTestCases {
+				t.Run(name, func(t *testing.T) {
+					testDecodeJSONInterface(t, tt)
+				})
+			}
+		})
+		t.Run("String", func(t *testing.T) {
+			for name, tt := range sharedStringTests {
+				t.Run(name, func(t *testing.T) {
+					testDecodeJSONInterface(t, tt)
+				})
+			}
+		})
+	})
+	for name, tt := range decodeArrayTestCases {
+		t.Run("Array", func(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				testDecodeJSONInterface(t, tt)
 			})
-		}
-	})
-	t.Run("Array", func(t *testing.T) {
-		for name, tt := range sharedArrayTestCases {
-			t.Run(name, func(t *testing.T) {
-				testDecodeJSONInterface(t, tt)
-			})
-		}
-	})
-	t.Run("Number", func(t *testing.T) {
-		for name, tt := range sharedNumberTestCases {
-			t.Run(name, func(t *testing.T) {
-				testDecodeJSONInterface(t, tt)
-			})
-		}
-	})
-	t.Run("String", func(t *testing.T) {
-		for name, tt := range sharedStringTests {
-			t.Run(name, func(t *testing.T) {
-				testDecodeJSONInterface(t, tt)
-			})
-		}
-	})
+		})
+	}
 }
 
 func TestNoSerde(t *testing.T) {
@@ -584,6 +121,16 @@ func TestNewDecoderUnsupportedTypes(t *testing.T) {
 			value: func() interface{} {
 				var t time.Time
 				return &t
+			}(),
+		},
+		{
+			input: []byte(`{}`),
+			value: func() interface{} {
+				type def interface {
+					String()
+				}
+				var i def
+				return &i
 			}(),
 		},
 	}

--- a/document/json/doc.go
+++ b/document/json/doc.go
@@ -1,0 +1,8 @@
+// Package json provides a document Encoder and Decoder implementation that is used to implement Smithy document types
+// for JSON based protocols. The Encoder and Decoder implement the document.Marshaler and document.Unmarshaler
+// interfaces respectively.
+//
+// This package handles protocol specific implementation details about documents, and can not be used to construct
+// a document type for a service client. To construct a document type see each service clients respective document
+// package and NewLazyDocument function.
+package json

--- a/document/json/encoder.go
+++ b/document/json/encoder.go
@@ -1,0 +1,318 @@
+package json
+
+import (
+	"fmt"
+	"math/big"
+	"reflect"
+
+	"github.com/aws/smithy-go/document"
+	"github.com/aws/smithy-go/document/internal/serde"
+	smithyjson "github.com/aws/smithy-go/encoding/json"
+)
+
+type EncoderOptions struct{}
+
+type Encoder struct {
+	options EncoderOptions
+}
+
+func (e *Encoder) Encode(v interface{}) ([]byte, error) {
+	if document.IsNoSerde(v) {
+		return nil, fmt.Errorf("unsupported type: %v", v)
+	}
+
+	encoder := smithyjson.NewEncoder()
+
+	if err := e.encode(jsonValueProvider(encoder.Value), reflect.ValueOf(v), serde.Tag{}); err != nil {
+		return nil, err
+	}
+
+	encodedBytes := encoder.Bytes()
+
+	if len(encodedBytes) == 0 {
+		return nil, nil
+	}
+
+	return encodedBytes, nil
+}
+
+type jsonValueProvider smithyjson.Value
+
+func (p jsonValueProvider) GetValue() smithyjson.Value {
+	return smithyjson.Value(p)
+}
+
+type valueProvider interface {
+	GetValue() smithyjson.Value
+}
+
+type jsonObjectKeyProvider struct {
+	Object *smithyjson.Object
+	Key    string
+}
+
+type jsonArrayProvider struct {
+	Array *smithyjson.Array
+}
+
+func (p jsonArrayProvider) GetValue() smithyjson.Value {
+	return p.Array.Value()
+}
+
+func (p jsonObjectKeyProvider) GetValue() smithyjson.Value {
+	return p.Object.Key(p.Key)
+}
+
+func (e *Encoder) encode(vp valueProvider, rv reflect.Value, tag serde.Tag) error {
+	// Zero values are serialized as null, or skipped if omitEmpty.
+	if serde.IsZeroValue(rv) {
+		if tag.OmitEmpty {
+			return nil
+		}
+		return e.encodeZeroValue(vp, rv)
+	}
+
+	// Handle both pointers and interface conversion into types
+	rv = serde.ValueElem(rv)
+
+	switch rv.Kind() {
+	case reflect.Invalid:
+		if tag.OmitEmpty {
+			return nil
+		}
+		vp.GetValue().Null()
+		return nil
+
+	case reflect.Struct:
+		return e.encodeStruct(vp, rv)
+
+	case reflect.Map:
+		return e.encodeMap(vp, rv)
+
+	case reflect.Slice, reflect.Array:
+		return e.encodeSlice(vp, rv)
+
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		// skip unsupported types
+		return nil
+
+	default:
+		return e.encodeScalar(vp, rv)
+	}
+}
+
+func (e *Encoder) encodeZeroValue(vp valueProvider, rv reflect.Value) error {
+	switch rv.Kind() {
+	case reflect.Invalid:
+		vp.GetValue().Null()
+	case reflect.Array:
+		vp.GetValue().Array().Close()
+	case reflect.Map, reflect.Slice:
+		vp.GetValue().Null()
+	case reflect.String:
+		vp.GetValue().String("")
+	case reflect.Bool:
+		vp.GetValue().Boolean(false)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		vp.GetValue().Long(0)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		vp.GetValue().ULong(0)
+	case reflect.Float32, reflect.Float64:
+		vp.GetValue().Double(0)
+	case reflect.Interface, reflect.Ptr:
+		vp.GetValue().Null()
+	default:
+		return &document.InvalidMarshalError{Message: fmt.Sprintf("unknown value type: %s", rv.String())}
+	}
+
+	return nil
+}
+
+func (e *Encoder) encodeStruct(vp valueProvider, rv reflect.Value) error {
+	switch {
+	case rv.Type().ConvertibleTo(serde.ReflectTypeOf.Time):
+		return &document.InvalidMarshalError{
+			Message: fmt.Sprintf("unsupported type %s", rv.Type().String()),
+		}
+	case rv.Type().ConvertibleTo(serde.ReflectTypeOf.BigFloat):
+		fallthrough
+	case rv.Type().ConvertibleTo(serde.ReflectTypeOf.BigInt):
+		return e.encodeNumber(vp, rv)
+	}
+
+	object := vp.GetValue().Object()
+	defer object.Close()
+
+	fields := serde.GetStructFields(rv.Type())
+	for _, f := range fields.All() {
+		if f.Name == "" {
+			return &document.InvalidMarshalError{Message: "map key cannot be empty"}
+		}
+
+		fv, found := serde.EncoderFieldByIndex(rv, f.Index)
+		if !found {
+			continue
+		}
+
+		err := e.encode(jsonObjectKeyProvider{
+			Object: object,
+			Key:    f.Name,
+		}, fv, f.Tag)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (e *Encoder) encodeMap(vp valueProvider, rv reflect.Value) error {
+	object := vp.GetValue().Object()
+	defer object.Close()
+
+	for _, key := range rv.MapKeys() {
+		keyName := fmt.Sprint(key.Interface())
+		if keyName == "" {
+			return &document.InvalidMarshalError{Message: "map key cannot be empty"}
+		}
+
+		ev := rv.MapIndex(key)
+		err := e.encode(jsonObjectKeyProvider{
+			Object: object,
+			Key:    keyName,
+		}, ev, serde.Tag{})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (e *Encoder) encodeSlice(value valueProvider, rv reflect.Value) error {
+	array := value.GetValue().Array()
+	defer array.Close()
+
+	for i := 0; i < rv.Len(); i++ {
+		err := e.encode(jsonArrayProvider{Array: array}, rv.Index(i), serde.Tag{})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (e *Encoder) encodeScalar(vp valueProvider, rv reflect.Value) error {
+	if rv.Type() == serde.ReflectTypeOf.DocumentNumber {
+		number := rv.Interface().(document.Number)
+		if !isValidJSONNumber(number.String()) {
+			return &document.InvalidMarshalError{Message: fmt.Sprintf("invalid number literal: %s", number)}
+		}
+		vp.GetValue().Write([]byte(number))
+	}
+
+	switch rv.Kind() {
+	case reflect.Bool:
+		vp.GetValue().Boolean(rv.Bool())
+	case reflect.String:
+		vp.GetValue().String(rv.String())
+	default:
+		// Fallback to encoding numbers, will return invalid type if not supported
+		err := e.encodeNumber(vp, rv)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (e *Encoder) encodeNumber(vp valueProvider, rv reflect.Value) error {
+	switch rv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		vp.GetValue().Long(rv.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		vp.GetValue().ULong(rv.Uint())
+	case reflect.Float32:
+		vp.GetValue().Float(float32(rv.Float()))
+	case reflect.Float64:
+		vp.GetValue().Double(rv.Float())
+	default:
+		rvt := rv.Type()
+		switch {
+		case rvt.ConvertibleTo(serde.ReflectTypeOf.BigInt):
+			bi := rv.Convert(serde.ReflectTypeOf.BigInt).Interface().(big.Int)
+			vp.GetValue().BigInteger(&bi)
+		case rvt.ConvertibleTo(serde.ReflectTypeOf.BigFloat):
+			bf := rv.Convert(serde.ReflectTypeOf.BigFloat).Interface().(big.Float)
+			vp.GetValue().BigDecimal(&bf)
+		default:
+			return &document.InvalidMarshalError{Message: fmt.Sprintf("incompatible type: %s", rvt.String())}
+		}
+	}
+
+	return nil
+}
+
+// isValidJSONNumber reports whether s is a valid JSON number literal.
+// From https://golang.org/src/encoding/json/encode.go#L652 isValidNumber
+// Copyright 2010 The Go Authors.
+func isValidJSONNumber(s string) bool {
+	// This function implements the JSON numbers grammar.
+	// See https://tools.ietf.org/html/rfc7159#section-6
+	// and https://www.json.org/img/number.png
+
+	if s == "" {
+		return false
+	}
+
+	// Optional -
+	if s[0] == '-' {
+		s = s[1:]
+		if s == "" {
+			return false
+		}
+	}
+
+	// Digits
+	switch {
+	default:
+		return false
+
+	case s[0] == '0':
+		s = s[1:]
+
+	case '1' <= s[0] && s[0] <= '9':
+		s = s[1:]
+		for len(s) > 0 && '0' <= s[0] && s[0] <= '9' {
+			s = s[1:]
+		}
+	}
+
+	// . followed by 1 or more digits.
+	if len(s) >= 2 && s[0] == '.' && '0' <= s[1] && s[1] <= '9' {
+		s = s[2:]
+		for len(s) > 0 && '0' <= s[0] && s[0] <= '9' {
+			s = s[1:]
+		}
+	}
+
+	// e or E followed by an optional - or + and
+	// 1 or more digits.
+	if len(s) >= 2 && (s[0] == 'e' || s[0] == 'E') {
+		s = s[1:]
+		if s[0] == '+' || s[0] == '-' {
+			s = s[1:]
+			if s == "" {
+				return false
+			}
+		}
+		for len(s) > 0 && '0' <= s[0] && s[0] <= '9' {
+			s = s[1:]
+		}
+	}
+
+	// Make sure we are at the end.
+	return s == ""
+}

--- a/document/json/encoder_test.go
+++ b/document/json/encoder_test.go
@@ -1,0 +1,82 @@
+package json_test
+
+import (
+	"github.com/aws/smithy-go/document/internal/serde"
+	"github.com/aws/smithy-go/document/json"
+	"github.com/google/go-cmp/cmp"
+	"testing"
+	"time"
+)
+
+func TestEncoder_Encode(t *testing.T) {
+	t.Run("Object", func(t *testing.T) {
+		for name, tt := range sharedObjectTests {
+			t.Run(name, func(t *testing.T) {
+				testEncode(t, tt)
+			})
+		}
+	})
+	t.Run("Array", func(t *testing.T) {
+		for name, tt := range sharedArrayTestCases {
+			t.Run(name, func(t *testing.T) {
+				testEncode(t, tt)
+			})
+		}
+	})
+	t.Run("Number", func(t *testing.T) {
+		for name, tt := range sharedNumberTestCases {
+			t.Run(name, func(t *testing.T) {
+				testEncode(t, tt)
+			})
+		}
+	})
+	t.Run("String", func(t *testing.T) {
+		for name, tt := range sharedStringTests {
+			t.Run(name, func(t *testing.T) {
+				testEncode(t, tt)
+			})
+		}
+	})
+}
+
+func TestNewEncoderUnsupportedTypes(t *testing.T) {
+	type customTime time.Time
+
+	cases := []interface{}{
+		time.Now().UTC(),
+		customTime(time.Now().UTC()),
+	}
+
+	encoder := json.NewEncoder()
+	for _, tt := range cases {
+		_, err := encoder.Encode(tt)
+		if err == nil {
+			t.Errorf("expect error, got nil")
+		}
+	}
+}
+
+func testEncode(t *testing.T, tt testCase) {
+	t.Helper()
+
+	e := json.NewEncoder(func(options *json.EncoderOptions) {
+		*options = tt.encoderOptions
+	})
+
+	encodeBytes, err := e.Encode(tt.actual)
+	if (err != nil) != tt.wantErr {
+		t.Errorf("Encode() error = %v, wantErr %v", err, tt.wantErr)
+	}
+
+	got := MustJSONUnmarshal(encodeBytes, !tt.disableJSONNumber)
+
+	if diff := cmp.Diff(
+		serde.PtrToValue(MustJSONUnmarshal(tt.json, !tt.disableJSONNumber)),
+		serde.PtrToValue(got),
+		cmp.AllowUnexported(StructA{}, StructB{}),
+		cmp.Comparer(cmpBigFloat()),
+		cmp.Comparer(cmpBigInt()),
+	); len(diff) > 0 {
+		t.Error(diff)
+	}
+}

--- a/document/json/json.go
+++ b/document/json/json.go
@@ -1,5 +1,6 @@
 package json
 
+// NewEncoder returns an Encoder for serializing Smithy documents for JSON based protocols.
 func NewEncoder(optFns ...func(options *EncoderOptions)) *Encoder {
 	o := EncoderOptions{}
 
@@ -12,6 +13,7 @@ func NewEncoder(optFns ...func(options *EncoderOptions)) *Encoder {
 	}
 }
 
+// NewDecoder returns a Decoder for deserializing Smithy documents for JSON based protocols.
 func NewDecoder(optFns ...func(*DecoderOptions)) *Decoder {
 	o := DecoderOptions{}
 

--- a/document/json/json.go
+++ b/document/json/json.go
@@ -1,0 +1,25 @@
+package json
+
+func NewEncoder(optFns ...func(options *EncoderOptions)) *Encoder {
+	o := EncoderOptions{}
+
+	for _, fn := range optFns {
+		fn(&o)
+	}
+
+	return &Encoder{
+		options: o,
+	}
+}
+
+func NewDecoder(optFns ...func(*DecoderOptions)) *Decoder {
+	o := DecoderOptions{}
+
+	for _, fn := range optFns {
+		fn(&o)
+	}
+
+	return &Decoder{
+		options: o,
+	}
+}

--- a/document/json/shared_test.go
+++ b/document/json/shared_test.go
@@ -1,0 +1,481 @@
+package json_test
+
+import (
+	"bytes"
+	json2 "encoding/json"
+	"math"
+	"math/big"
+	"strconv"
+
+	"github.com/aws/smithy-go/document"
+	"github.com/aws/smithy-go/document/json"
+	"github.com/aws/smithy-go/ptr"
+)
+
+type StructA struct {
+	FieldName    string
+	FieldPtrName *string
+
+	FieldRename  string `document:"field_rename"`
+	FieldIgnored string `document:"-"`
+
+	FieldOmitEmpty    string  `document:",omitempty"`
+	FieldPtrOmitEmpty *string `document:",omitempty"`
+
+	FieldRenameOmitEmpty string `document:"field_rename_omit_empty,omitempty"`
+
+	FieldNestedStruct          *StructA `document:"field_nested_struct"`
+	FieldNestedStructOmitEmpty *StructA `document:"field_nested_struct_omit_empty,omitempty"`
+
+	fieldUnexported string
+
+	StructB
+}
+
+type StructB struct {
+	FieldName string `document:"field_name"`
+}
+
+type testCase struct {
+	decoderOptions    json.DecoderOptions
+	encoderOptions    json.EncoderOptions
+	disableJSONNumber bool
+	json              []byte
+	actual, want      interface{}
+	wantErr           bool
+}
+
+var sharedStringTests = map[string]testCase{
+	"string": {
+		json: []byte(`"foo"`),
+		actual: func() interface{} {
+			var v string
+			return &v
+		}(),
+		want: "foo",
+	},
+	"interface{}": {
+		json: []byte(`"foo"`),
+		actual: func() interface{} {
+			var v interface{}
+			return &v
+		}(),
+		want: "foo",
+	},
+}
+
+var sharedObjectTests = map[string]testCase{
+	"null for pointer type": {
+		json: []byte(`null`),
+		actual: func() interface{} {
+			var v *StructA
+			return &v
+		}(),
+	},
+	"zero value": {
+		json: []byte(`{
+  "FieldName": "",
+  "FieldPtrName": null,
+  "field_name": "",
+  "field_nested_struct": null,
+  "field_rename": ""
+}`),
+		actual: func() interface{} {
+			var v StructA
+			return &v
+		}(),
+		want: StructA{},
+	},
+	"filled json structure": {
+		json: []byte(`{
+  "FieldName": "a",
+  "FieldPtrName": "b",
+  "field_rename": "c",
+  "FieldOmitEmpty": "d",
+  "FieldPtrOmitEmpty": "e",
+  "field_rename_omit_empty": "f",
+  "field_nested_struct": {
+    "FieldName": "a",
+    "FieldPtrName": null,
+    "field_name": "",
+    "field_nested_struct": null,
+    "field_rename": ""
+  },
+  "field_nested_struct_omit_empty": {
+    "FieldName": "a",
+    "FieldPtrName": null,
+    "field_name": "",
+    "field_nested_struct": null,
+    "field_rename": ""
+  },
+  "field_name": "A"
+}`),
+		actual: func() interface{} {
+			var v *StructA
+			return &v
+		}(),
+		want: &StructA{
+			FieldName:            "a",
+			FieldPtrName:         ptr.String("b"),
+			FieldRename:          "c",
+			FieldOmitEmpty:       "d",
+			FieldPtrOmitEmpty:    ptr.String("e"),
+			FieldRenameOmitEmpty: "f",
+			FieldNestedStruct: &StructA{
+				FieldName: "a",
+			},
+			FieldNestedStructOmitEmpty: &StructA{
+				FieldName: "a",
+			},
+			StructB: StructB{
+				FieldName: "A",
+			},
+		},
+	},
+}
+
+var sharedArrayTestCases = map[string]testCase{
+	"slice": {
+		json: []byte(`["foo", "bar", "baz"]`),
+		actual: func() interface{} {
+			var v []string
+			return &v
+		}(),
+		want: []string{"foo", "bar", "baz"},
+	},
+	"array": {
+		json: []byte(`["foo", "bar", "baz"]`),
+		actual: func() interface{} {
+			var v [3]string
+			return &v
+		}(),
+		want: [3]string{"foo", "bar", "baz"},
+	},
+
+	"interface{}": {
+		json: []byte(`["foo", "bar", "baz"]`),
+		actual: func() interface{} {
+			var v interface{}
+			return &v
+		}(),
+		want: []interface{}{"foo", "bar", "baz"},
+	},
+}
+
+var sharedNumberTestCases = map[string]testCase{
+	"json.Number to interface{}": {
+		json: []byte(`3.14159`),
+		actual: func() interface{} {
+			var v interface{}
+			return &v
+		}(),
+		want: ptrNumber("3.14159"),
+	},
+
+	"json float64 to interface{}": {
+		json: []byte(`3.14159`),
+		actual: func() interface{} {
+			var v interface{}
+			return &v
+		}(),
+		want:              ptr.Float64(3.14159),
+		disableJSONNumber: true,
+	},
+
+	"json.Number to document.Number": {
+		json: []byte(`3.14159`),
+		actual: func() interface{} {
+			var v document.Number
+			return &v
+		}(),
+		want: document.Number("3.14159"),
+	},
+
+	"json.Number to *document.Number": {
+		json: []byte(`3.14159`),
+		actual: func() interface{} {
+			var v *document.Number
+			return &v
+		}(),
+		want: document.Number("3.14159"),
+	},
+
+	/*
+		int, int16, int32, int64
+	*/
+	"json.Number to int": {
+		json: []byte(`2147483647`),
+		actual: func() interface{} {
+			var x int
+			return &x
+		}(),
+		want: ptr.Int(2147483647),
+	},
+	"json float64 to int": {
+		json: []byte(`2147483647`),
+		actual: func() interface{} {
+			var x int
+			return &x
+		}(),
+		want:              ptr.Int(2147483647),
+		disableJSONNumber: true,
+	},
+	"json.Number to int8": {
+		json: []byte(`127`),
+		actual: func() interface{} {
+			var x int8
+			return &x
+		}(),
+		want: ptr.Int8(127),
+	},
+	"json float64 to int8": {
+		json: []byte(`127`),
+		actual: func() interface{} {
+			var x int8
+			return &x
+		}(),
+		want:              ptr.Int8(127),
+		disableJSONNumber: true,
+	},
+	"json.Number to int16": {
+		json: []byte(`32767`),
+		actual: func() interface{} {
+			var x int16
+			return &x
+		}(),
+		want: ptr.Int16(32767),
+	},
+	"json float64 to int16": {
+		json: []byte(`32767`),
+		actual: func() interface{} {
+			var x int16
+			return &x
+		}(),
+		want:              ptr.Int16(32767),
+		disableJSONNumber: true,
+	},
+	"json.Number to int32": {
+		json: []byte(`2147483647`),
+		actual: func() interface{} {
+			var x int32
+			return &x
+		}(),
+		want: ptr.Int32(2147483647),
+	},
+	"json float64 to int32": {
+		json: []byte(`2147483647`),
+		actual: func() interface{} {
+			var x int32
+			return &x
+		}(),
+		want:              ptr.Int32(2147483647),
+		disableJSONNumber: true,
+	},
+	"json.Number to int64": {
+		json: []byte("9223372036854775807"),
+		actual: func() interface{} {
+			var x int64
+			return &x
+		}(),
+		want: ptr.Int64(9223372036854775807),
+	},
+	"json float64 to int64": {
+		json: []byte("2147483648"),
+		actual: func() interface{} {
+			var x int64
+			return &x
+		}(),
+		want:              ptr.Int64(2147483648),
+		disableJSONNumber: true,
+	},
+
+	/*
+		uint, uint16, uint32, uint64
+	*/
+	"json.Number to uint": {
+		json: []byte(`4294967295`),
+		actual: func() interface{} {
+			var x uint
+			return &x
+		}(),
+		want: ptr.Uint(4294967295),
+	},
+	"json float64 to uint": {
+		json: []byte(`4294967295`),
+		actual: func() interface{} {
+			var x uint
+			return &x
+		}(),
+		want:              ptr.Uint(4294967295),
+		disableJSONNumber: true,
+	},
+	"json.Number to uint8": {
+		json: []byte(`255`),
+		actual: func() interface{} {
+			var x uint8
+			return &x
+		}(),
+		want: ptr.Uint8(255),
+	},
+	"json float64 to uint8": {
+		json: []byte(`255`),
+		actual: func() interface{} {
+			var x uint8
+			return &x
+		}(),
+		want:              ptr.Uint8(255),
+		disableJSONNumber: true,
+	},
+	"json.Number to uint16": {
+		json: []byte(`65535`),
+		actual: func() interface{} {
+			var x uint16
+			return &x
+		}(),
+		want: ptr.Uint16(65535),
+	},
+	"json float64 to uint16": {
+		json: []byte(`65535`),
+		actual: func() interface{} {
+			var x uint16
+			return &x
+		}(),
+		want:              ptr.Uint16(65535),
+		disableJSONNumber: true,
+	},
+	"json.Number to uint32": {
+		json: []byte(`4294967295`),
+		actual: func() interface{} {
+			var x uint32
+			return &x
+		}(),
+		want: ptr.Uint32(4294967295),
+	},
+	"json float64 to uint32": {
+		json: []byte(`4294967295`),
+		actual: func() interface{} {
+			var x uint32
+			return &x
+		}(),
+		want:              ptr.Uint32(4294967295),
+		disableJSONNumber: true,
+	},
+	"json.Number to uint64": {
+		json: []byte("18446744073709551615"),
+		actual: func() interface{} {
+			var x uint64
+			return &x
+		}(),
+		want: ptr.Uint64(18446744073709551615),
+	},
+	"json float64 to uint64": {
+		json: []byte("4294967295"),
+		actual: func() interface{} {
+			var x uint64
+			return &x
+		}(),
+		want:              ptr.Uint64(4294967295),
+		disableJSONNumber: true,
+	},
+
+	/*
+		float32, float64
+	*/
+	"json.Number to float32": {
+		json: []byte(strconv.FormatFloat(math.MaxFloat32, 'e', -1, 32)),
+		actual: func() interface{} {
+			var x float32
+			return &x
+		}(),
+		want: ptr.Float32(math.MaxFloat32),
+	},
+	"json float64 to float32": {
+		json: []byte(strconv.FormatFloat(3.14159, 'e', -1, 32)),
+		actual: func() interface{} {
+			var x float32
+			return &x
+		}(),
+		want:              ptr.Float32(3.14159),
+		disableJSONNumber: true,
+	},
+	"json.Number to float64": {
+		json: []byte(strconv.FormatFloat(math.MaxFloat64, 'e', -1, 64)),
+		actual: func() interface{} {
+			var x float64
+			return &x
+		}(),
+		want: ptr.Float64(math.MaxFloat64),
+	},
+	"json float64 to float64": {
+		json: []byte(strconv.FormatFloat(3.14159, 'e', -1, 64)),
+		actual: func() interface{} {
+			var x float64
+			return &x
+		}(),
+		want:              ptr.Float64(3.14159),
+		disableJSONNumber: true,
+	},
+
+	/*
+		Arbitrary Number Sizes
+	*/
+	"json.Number to big.Float": {
+		json: []byte(strconv.FormatFloat(math.MaxFloat64, 'e', -1, 64)),
+		actual: func() interface{} {
+			var x big.Float
+			return &x
+		}(),
+		want: func() *big.Float {
+			return big.NewFloat(math.MaxFloat64)
+		}(),
+	},
+	"float64 to big.Float": {
+		json: []byte(strconv.FormatFloat(math.MaxFloat64, 'e', -1, 64)),
+		actual: func() interface{} {
+			var x big.Float
+			return &x
+		}(),
+		want: func() *big.Float {
+			return big.NewFloat(math.MaxFloat64)
+		}(),
+		disableJSONNumber: true,
+	},
+	"json.Number to big.Int": {
+		json: []byte(strconv.FormatInt(math.MaxInt64, 10)),
+		actual: func() interface{} {
+			var x big.Int
+			return &x
+		}(),
+		want: func() *big.Int {
+			return big.NewInt(math.MaxInt64)
+		}(),
+	},
+	"float64 to big.Int": {
+		json: []byte(strconv.FormatInt(math.MaxInt32, 10)),
+		actual: func() interface{} {
+			var x big.Int
+			return &x
+		}(),
+		want: func() *big.Int {
+			return big.NewInt(math.MaxInt32)
+		}(),
+		disableJSONNumber: true,
+	},
+}
+
+func ptrNumber(number document.Number) *document.Number {
+	return &number
+}
+
+func MustJSONUnmarshal(v []byte, useJSONNumber bool) interface{} {
+	var jv interface{}
+	decoder := json2.NewDecoder(bytes.NewReader(v))
+	if useJSONNumber {
+		decoder.UseNumber()
+	}
+	if err := decoder.Decode(&jv); err != nil {
+		panic(err)
+	}
+	return jv
+}
+

--- a/encoding/json/value.go
+++ b/encoding/json/value.go
@@ -47,6 +47,12 @@ func (jv Value) Long(v int64) {
 	jv.w.Write(*jv.scratch)
 }
 
+// ULong encodes v as a JSON number
+func (jv Value) ULong(v uint64) {
+	*jv.scratch = strconv.AppendUint((*jv.scratch)[:0], v, 10)
+	jv.w.Write(*jv.scratch)
+}
+
 // Float encodes v as a JSON number
 func (jv Value) Float(v float32) {
 	jv.float(float64(v), 32)

--- a/testing/struct.go
+++ b/testing/struct.go
@@ -42,8 +42,8 @@ func CompareValues(expect, actual interface{}, opts ...cmp.Option) error {
 }
 
 type documentInterface interface {
-	document.SmithyDocumentMarshaler
-	document.SmithyDocumentUnmarshaler
+	document.Marshaler
+	document.Unmarshaler
 }
 
 func compareDocumentTypes(x documentInterface, y documentInterface) bool {


### PR DESCRIPTION
Adds support for Smithy Document shapes and supporting types for protocols to implement support.

AWS Protocol Support: https://github.com/aws/aws-sdk-go-v2/pull/1320

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
