### PR TITLE
Add Dependabot CI integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+


### PR DESCRIPTION
Adds CI integration with dependabot.

related to https://github.com/aws/aws-sdk-go-v2/pull/1321