### PR TITLE
Remove use of the term whitelist

### DIFF
--- a/codegen/smithy-go-codegen/build.gradle.kts
+++ b/codegen/smithy-go-codegen/build.gradle.kts
@@ -21,6 +21,6 @@ dependencies {
     api("software.amazon.smithy:smithy-codegen-core:[1.3.0,2.0.0[")
     implementation("software.amazon.smithy:smithy-waiters:[1.4.0,2.0.0[")
     compile("com.atlassian.commonmark:commonmark:0.15.2")
-    api("org.jsoup:jsoup:1.13.1")
+    api("org.jsoup:jsoup:1.14.1")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.3.0,2.0.0[")
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/DocumentationConverter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/DocumentationConverter.java
@@ -27,7 +27,7 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Node;
 import org.jsoup.nodes.TextNode;
-import org.jsoup.safety.Whitelist;
+import org.jsoup.safety.Safelist;
 import org.jsoup.select.NodeTraversor;
 import org.jsoup.select.NodeVisitor;
 import software.amazon.smithy.utils.CodeWriter;
@@ -39,9 +39,9 @@ import software.amazon.smithy.utils.StringUtils;
  */
 public final class DocumentationConverter {
     // godoc only supports text blocks, root-level non-inline code blocks, headers, and links.
-    // This whitelist strips out anything we can't reasonably convert, vastly simplifying the
+    // This allowlist strips out anything we can't reasonably convert, vastly simplifying the
     // node tree we end up having to crawl through.
-    private static final Whitelist GODOC_WHITELIST = new Whitelist()
+    private static final Safelist GODOC_ALLOWLIST = new Safelist()
             .addTags("code", "pre", "ul", "ol", "li", "a", "br", "h1", "h2", "h3", "h4", "h5", "h6")
             .addAttributes("a", "href")
             .addProtocols("a", "href", "http", "https", "mailto");
@@ -69,7 +69,7 @@ public final class DocumentationConverter {
         String htmlDocs = HtmlRenderer.builder().escapeHtml(false).build().render(MARKDOWN_PARSER.parse(docs));
 
         // Strip out tags and attributes we can't reasonably convert to godoc.
-        htmlDocs = Jsoup.clean(htmlDocs, GODOC_WHITELIST);
+        htmlDocs = Jsoup.clean(htmlDocs, GODOC_ALLOWLIST);
 
         // Now we parse the html and visit the resultant nodes to render the godoc.
         FormattingVisitor formatter = new FormattingVisitor();


### PR DESCRIPTION
This updates to avoid the term whitelist in the code base. ~~jsoup has a `Whitelist` class that we need to use, unfortunately, so that is the remaining usage. This is being deprecated in jsoup 1.14 but that [hasn't been released yet](https://github.com/jhy/jsoup/issues/1481).~~ Update: they released! PR updated


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
