### PR TITLE
add support for go-integrations overriding error code for error types

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -213,7 +213,6 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
             });
         }
 
-
         LOGGER.fine("Flushing go writers");
         List<SymbolDependency> dependencies = writers.getDependencies();
         writers.flushWriters();
@@ -234,7 +233,7 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
         }
         Symbol symbol = symbolProvider.toSymbol(shape);
         writers.useShapeWriter(shape, writer -> new StructureGenerator(
-                model, symbolProvider, writer, service, shape, symbol).run());
+                model, symbolProvider, writer, service, shape, symbol, protocolGenerator).run());
         return null;
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -124,14 +124,14 @@ public final class OperationGenerator implements Runnable {
 
         // Write out the input and output structures. These are written out here to prevent naming conflicts with other
         // shapes in the model.
-        new StructureGenerator(model, symbolProvider, writer, service, inputShape, inputSymbol)
+        new StructureGenerator(model, symbolProvider, writer, service, inputShape, inputSymbol, protocolGenerator)
                 .renderStructure(() -> {
                 }, true);
 
         // The output structure gets a metadata member added.
         Symbol metadataSymbol = SymbolUtils.createValueSymbolBuilder("Metadata", SmithyGoDependency.SMITHY_MIDDLEWARE)
                 .build();
-        new StructureGenerator(model, symbolProvider, writer, service, outputShape, outputSymbol)
+        new StructureGenerator(model, symbolProvider, writer, service, outputShape, outputSymbol, protocolGenerator)
                 .renderStructure(() -> {
                     if (outputShape.getMemberNames().size() != 0) {
                         writer.write("");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
@@ -27,11 +27,13 @@ import software.amazon.smithy.go.codegen.GoSettings;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.SyntheticClone;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.ExpectationNotMetException;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.CaseUtils;
 import software.amazon.smithy.utils.StringUtils;
@@ -258,6 +260,19 @@ public interface ProtocolGenerator {
      */
     default Map<String, ShapeId> getOperationErrors(GenerationContext context, OperationShape operation) {
         return HttpProtocolGeneratorUtils.getOperationErrors(context, operation);
+    }
+
+    /**
+     * Returns an error code for an error shape. Defaults to error shape name as error code.
+     *
+     * @param service the service enclosure for the error shape.
+     * @param errorShape the error shape for which error code is retrieved.
+     * @return the error code associated with the provided shape.
+     * @throws ExpectationNotMetException if provided shape is not modeled with an {@link ErrorTrait}.
+     */
+    default String getErrorCode(ServiceShape service, StructureShape errorShape) {
+        errorShape.expectTrait(ErrorTrait.class);
+        return errorShape.getId().getName(service);
     }
 
     /**


### PR DESCRIPTION
`AwsQueryError` trait overrides the error code for an error type. 

https://awslabs.github.io/smithy/1.0/spec/aws/aws-query-protocol.html#aws-protocols-awsqueryerror-trait

 This change allows us to override errorCode for a protocol generator, defaulting to error shape name as error code. 