### PR TITLE
middleware: Add Clone to Metadata

### DIFF
--- a/middleware/metadata.go
+++ b/middleware/metadata.go
@@ -25,6 +25,19 @@ func (m Metadata) Get(key interface{}) interface{} {
 	return m.values[key]
 }
 
+// Clone creates a shallow copy of Metadata entries, returning a new Metadata
+// value with the original entries copied into it.
+func (m Metadata) Clone() Metadata {
+	vs := make(map[interface{}]interface{}, len(m.values))
+	for k, v := range m.values {
+		vs[k] = v
+	}
+
+	return Metadata{
+		values: vs,
+	}
+}
+
 // Set stores the value pointed to by the key. If a value already exists at
 // that key it will be replaced with the new value.
 //

--- a/middleware/metadata_test.go
+++ b/middleware/metadata_test.go
@@ -1,0 +1,30 @@
+package middleware
+
+import "testing"
+
+func TestMetadataClone(t *testing.T) {
+	original := map[interface{}]interface{}{
+		"abc": 123,
+		"efg": "hij",
+	}
+
+	var m Metadata
+	for k, v := range original {
+		m.Set(k, v)
+	}
+
+	o := m.Clone()
+	o.Set("unique", "value")
+	for k := range original {
+		if !o.Has(k) {
+			t.Errorf("expect %v to be in cloned metadata", k)
+		}
+	}
+
+	if !o.Has("unique") {
+		t.Errorf("expect cloned metadata to have new entry")
+	}
+	if m.Has("unique") {
+		t.Errorf("expect cloned metadata to not leak in to original")
+	}
+}


### PR DESCRIPTION
Adds a new Clone method to the middleware Metadata type. This provides a shallow clone of the entries in the Metadata.

Used by https://github.com/aws/aws-sdk-go-v2/pull/1345 to clone attempt result metadata
