### PR TITLE
Updates smithy-go for Go 1.17

### DIFF
--- a/.github/workflows/api_diff_check.yml
+++ b/.github/workflows/api_diff_check.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: ^1.16
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         java-version: ['11', '8']
-        go-version: [1.16]
+        go-version: [1.17]
     env:
       JAVA_TOOL_OPTIONS: "-Xmx2g"
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: [1.16, 1.15]
+        go-version: [1.17, 1.16, 1.15]
     steps:
     - uses: actions/checkout@v2
 

--- a/document/json/shared_test.go
+++ b/document/json/shared_test.go
@@ -478,4 +478,3 @@ func MustJSONUnmarshal(v []byte, useJSONNumber bool) interface{} {
 	}
 	return jv
 }
-

--- a/ptr/gen_scalars.go
+++ b/ptr/gen_scalars.go
@@ -1,3 +1,4 @@
+//go:build codegen
 // +build codegen
 
 package ptr

--- a/ptr/generate.go
+++ b/ptr/generate.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main


### PR DESCRIPTION
* Updates smithy-go's `build` tags to use go 1.17's formatting style of `// go:build ...`.
* Updates CI for Go 1.17.