### PR TITLE
Upgrade to Gradle 7.2

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java-version: ['11', '8']
+        java-version: ['16']
         go-version: [1.17]
     env:
       JAVA_TOOL_OPTIONS: "-Xmx2g"

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     signing
     checkstyle
     jacoco
-    id("com.github.spotbugs") version "1.6.10"
+    id("com.github.spotbugs") version "4.7.4"
     id("io.codearte.nexus-staging") version "0.21.0"
 }
 
@@ -72,8 +72,8 @@ subprojects {
         apply(plugin = "java-library")
 
         java {
-            sourceCompatibility = JavaVersion.VERSION_1_8
-            targetCompatibility = JavaVersion.VERSION_1_8
+            sourceCompatibility = JavaVersion.VERSION_16
+            targetCompatibility = JavaVersion.VERSION_16
         }
 
         tasks.withType<JavaCompile> {
@@ -87,10 +87,10 @@ subprojects {
 
         // Apply junit 5 and hamcrest test dependencies to all java projects.
         dependencies {
-            testCompile("org.junit.jupiter:junit-jupiter-api:5.4.0")
-            testRuntime("org.junit.jupiter:junit-jupiter-engine:5.4.0")
-            testCompile("org.junit.jupiter:junit-jupiter-params:5.4.0")
-            testCompile("org.hamcrest:hamcrest:2.1")
+            testImplementation("org.junit.jupiter:junit-jupiter-api:5.4.0")
+            testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.0")
+            testImplementation("org.junit.jupiter:junit-jupiter-params:5.4.0")
+            testImplementation("org.hamcrest:hamcrest:2.1")
         }
 
         // Reusable license copySpec
@@ -229,9 +229,9 @@ subprojects {
         // Configure jacoco to generate an HTML report.
         tasks.jacocoTestReport {
             reports {
-                xml.isEnabled = false
-                csv.isEnabled = false
-                html.destination = file("$buildDir/reports/jacoco")
+                xml.required.set(false)
+                csv.required.set(false)
+                html.outputLocation.set(file("$buildDir/reports/jacoco"))
             }
         }
 
@@ -245,13 +245,11 @@ subprojects {
         tasks["spotbugsTest"].enabled = false
 
         // Configure the bug filter for spotbugs.
-        tasks.withType<com.github.spotbugs.SpotBugsTask> {
-            effort = "max"
-            excludeFilterConfig = project.resources.text.fromFile("${project.rootDir}/config/spotbugs/filter.xml")
-            reports {
-                xml.setEnabled(false)
-                html.setEnabled(true)
-            }
+        tasks.withType<com.github.spotbugs.snom.SpotBugsTask>().configureEach {
+            effort.set(com.github.spotbugs.snom.Effort.MAX)
+            excludeFilter.set(file("${project.rootDir}/config/spotbugs/filter.xml"))
+            reports.maybeCreate("xml").isEnabled = false
+            reports.maybeCreate("html").isEnabled = true
         }
     }
 }

--- a/codegen/config/checkstyle/checkstyle.xml
+++ b/codegen/config/checkstyle/checkstyle.xml
@@ -46,17 +46,17 @@
         <property name="message" value="Line has trailing spaces."/>
     </module>
 
+    <!-- Checks for Size Violations.                    -->
+    <!-- See http://checkstyle.sf.net/config_sizes.html -->
+    <module name="LineLength">
+        <property name="max" value="${checkstyle.linelength}" default="120"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
+
     <module name="TreeWalker">
         <!-- Make comments and annotations available for the suppression comment filter. -->
         <module name="SuppressWarningsHolder"/>
         <module name="SuppressionCommentFilter"/>
-
-        <!-- Checks for Size Violations.                    -->
-        <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="LineLength">
-            <property name="max" value="${checkstyle.linelength}" default="120"/>
-            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
-        </module>
 
         <!-- Checks for imports                              -->
         <!-- See http://checkstyle.sf.net/config_import.html -->
@@ -79,12 +79,14 @@
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
+            <property name="validateThrows" value="false"/>
             <property name="allowMissingReturnTag" value="true"/>
-            <property name="minLineCount" value="2"/>
             <property name="allowedAnnotations" value="Override, Test"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
-            <property name="allowMissingJavadoc" value="true"/>
+        </module>
+        <module name="MissingJavadocMethod">
+            <property name="scope" value="public"/>
+            <property name="minLineCount" value="2"/>
+            <property name="tokens" value="METHOD_DEF"/>
         </module>
         <module name="JavadocStyle"/>
         <module name="NonEmptyAtclauseDescription"/>

--- a/codegen/config/spotbugs/filter.xml
+++ b/codegen/config/spotbugs/filter.xml
@@ -22,6 +22,6 @@
 
     <!-- Exceptions aren't going to be serialized. -->
     <Match>
-        <Bug pattern="SE_NO_SERIALVERSIONID,SE_BAD_FIELD"/>
+        <Bug pattern="SE_NO_SERIALVERSIONID,SE_BAD_FIELD,EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
     </Match>
 </FindBugsFilter>

--- a/codegen/gradle/wrapper/gradle-wrapper.properties
+++ b/codegen/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/codegen/smithy-go-codegen/build.gradle.kts
+++ b/codegen/smithy-go-codegen/build.gradle.kts
@@ -20,7 +20,7 @@ extra["moduleName"] = "software.amazon.smithy.go.codegen"
 dependencies {
     api("software.amazon.smithy:smithy-codegen-core:[1.3.0,2.0.0[")
     implementation("software.amazon.smithy:smithy-waiters:[1.4.0,2.0.0[")
-    compile("com.atlassian.commonmark:commonmark:0.15.2")
+    implementation("com.atlassian.commonmark:commonmark:0.15.2")
     api("org.jsoup:jsoup:1.14.1")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.3.0,2.0.0[")
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/AddOperationShapes.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/AddOperationShapes.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.go.codegen;
 
 import java.util.TreeSet;
 import java.util.logging.Logger;
-
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.AbstractShapeBuilder;

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/DocumentationConverter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/DocumentationConverter.java
@@ -55,7 +55,8 @@ public final class DocumentationConverter {
                     BlockQuote.class, ListBlock.class))
             .build();
 
-    private DocumentationConverter() {}
+    private DocumentationConverter() {
+    }
 
     /**
      * Converts a commonmark formatted string into a godoc formatted string.

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoSettings.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoSettings.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.go.codegen;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Set;
-
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.ServiceIndex;

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStackStepMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStackStepMiddlewareGenerator.java
@@ -118,7 +118,7 @@ public final class GoStackStepMiddlewareGenerator {
      * Generates a new step middleware generator.
      *
      * @param name              the name of the middleware type.
-     * @param id   the unique ID for the middleware.
+     * @param id                the unique ID for the middleware.
      * @param handlerMethodName method name to be implemented.
      * @param inputType         the middleware input type.
      * @param outputType        the middleware output type.

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/MiddlewareIdentifier.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/MiddlewareIdentifier.java
@@ -65,6 +65,11 @@ public final class MiddlewareIdentifier {
     }
 
 
+    /**
+     * Writes the middleware identifier inline using the provided writer.
+     *
+     * @param writer the {@link GoWriter}
+     */
     public void writeInline(GoWriter writer) {
         if (getSymbol().isPresent()) {
             writer.writeInline("$T", getSymbol().get());

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ProtocolDocumentGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ProtocolDocumentGenerator.java
@@ -16,7 +16,6 @@
 package software.amazon.smithy.go.codegen;
 
 import java.util.function.Consumer;
-
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator.GenerationContext;

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/IdempotencyTokenMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/IdempotencyTokenMiddlewareGenerator.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.go.codegen.integration;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -178,7 +179,7 @@ public class IdempotencyTokenMiddlewareGenerator implements GoIntegration {
 
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
-        return runtimeClientPlugins;
+        return Collections.unmodifiableList(runtimeClientPlugins);
     }
 
     /**

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
@@ -69,6 +69,11 @@ public interface ProtocolGenerator {
      */
     ShapeId getProtocol();
 
+    /**
+     * Gets the protocol name.
+     *
+     * @return the protocol name
+     */
     default String getProtocolName() {
         ShapeId protocol = getProtocol();
         String prefix = protocol.getNamespace();
@@ -245,12 +250,28 @@ public interface ProtocolGenerator {
         return protocol + "_deserializeError" + StringUtils.capitalize(name);
     }
 
+    /**
+     * Generates the name of a serializer middleware for the service.
+     *
+     * @param operationShapeId The operation's {@link ShapeId}.
+     * @param service          The service enclosing the shape.
+     * @param protocol         Name of the protocol being generated.
+     * @return Returns the generated function name.
+     */
     static String getSerializeMiddlewareName(ShapeId operationShapeId, ServiceShape service, String protocol) {
         return protocol
                 + "_serializeOp"
                 + operationShapeId.getName(service);
     }
 
+    /**
+     * Generates the name of a deserializer middleware for the service.
+     *
+     * @param operationShapeId The operation's {@link ShapeId}.
+     * @param service          The service enclosing the shape.
+     * @param protocol         Name of the protocol being generated.
+     * @return Returns the generated function name.
+     */
     static String getDeserializeMiddlewareName(ShapeId operationShapeId, ServiceShape service, String protocol) {
         return protocol
                 + "_deserializeOp"
@@ -415,7 +436,7 @@ public interface ProtocolGenerator {
     /**
      * Returns an error code for an error shape. Defaults to error shape name as error code.
      *
-     * @param service the service enclosure for the error shape.
+     * @param service    the service enclosure for the error shape.
      * @param errorShape the error shape for which error code is retrieved.
      * @return the error code associated with the provided shape.
      * @throws ExpectationNotMetException if provided shape is not modeled with an {@link ErrorTrait}.


### PR DESCRIPTION
Upgrades to Gradle 7.2 and updates target JVM version to Java 1.16, this will be updated to 1.17 once GitHub actions has been updated to support the new LTS version.