### PR TITLE
Add support for event streaming in protocols

### DIFF
--- a/codegen/config/spotbugs/filter.xml
+++ b/codegen/config/spotbugs/filter.xml
@@ -22,6 +22,6 @@
 
     <!-- Exceptions aren't going to be serialized. -->
     <Match>
-        <Bug pattern="SE_NO_SERIALVERSIONID,SE_BAD_FIELD,EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
+        <Bug pattern="SE_NO_SERIALVERSIONID,SE_BAD_FIELD,EI_EXPOSE_REP,EI_EXPOSE_REP2,VA_FORMAT_STRING_USES_NEWLINE"/>
     </Match>
 </FindBugsFilter>

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/EventStreamGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/EventStreamGenerator.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen;
+
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Consumer;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.EventStreamIndex;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ToShapeId;
+import software.amazon.smithy.utils.StringUtils;
+
+public final class EventStreamGenerator {
+    private static final String EVENT_STREAM_FILE = "eventstream.go";
+
+    private final GoSettings settings;
+    private final Model model;
+    private final GoDelegator writers;
+    private final ServiceShape serviceShape;
+    private final EventStreamIndex streamIndex;
+    private final SymbolProvider symbolProvider;
+
+    public EventStreamGenerator(
+            GoSettings settings,
+            Model model,
+            GoDelegator writers,
+            SymbolProvider symbolProvider,
+            ServiceShape serviceShape
+    ) {
+        this.settings = settings;
+        this.model = model;
+        this.writers = writers;
+        this.symbolProvider = symbolProvider;
+        this.serviceShape = serviceShape;
+        this.streamIndex = EventStreamIndex.of(this.model);
+    }
+
+    public void generateEventStreamInterfaces() {
+        if (!hasEventStreamOperations()) {
+            return;
+        }
+
+        final Set<ShapeId> inputEvents = new TreeSet<>();
+        final Set<ShapeId> outputEvents = new TreeSet<>();
+
+        TopDownIndex.of(model).getContainedOperations(serviceShape).forEach(operationShape -> {
+            streamIndex.getInputInfo(operationShape).ifPresent(eventStreamInfo ->
+                    inputEvents.add(eventStreamInfo.getEventStreamMember().getTarget()));
+            streamIndex.getOutputInfo(operationShape).ifPresent(eventStreamInfo ->
+                    outputEvents.add(eventStreamInfo.getEventStreamMember().getTarget()));
+        });
+
+        Symbol context = SymbolUtils.createValueSymbolBuilder("Context",
+                SmithyGoDependency.CONTEXT).build();
+
+        writers.useFileWriter(EVENT_STREAM_FILE, settings.getModuleName(), writer -> {
+            inputEvents.forEach(shapeId -> {
+                Shape shape = model.expectShape(shapeId);
+                String writerInterfaceName = getEventStreamWriterInterfaceName(serviceShape, shape);
+                writer.writeDocs(String.format("%s provides the interface for writing events to a stream.",
+                                writerInterfaceName))
+                        .writeDocs("")
+                        .writeDocs("The writer's Close method must allow multiple concurrent calls.");
+                writer.openBlock("type $L interface {", "}", writerInterfaceName, () -> {
+                    writer.write("Send($T, $T) error", context, symbolProvider.toSymbol(shape));
+                    writer.write("Close() error");
+                    writer.write("Err() error");
+                });
+            });
+            outputEvents.forEach(shapeId -> {
+                Shape shape = model.expectShape(shapeId);
+                String readerInterfaceName = getEventStreamReaderInterfaceName(serviceShape, shape);
+                writer.writeDocs(String.format("%s provides the interface for reading events from a stream.",
+                                readerInterfaceName))
+                        .writeDocs("")
+                        .writeDocs("The writer's Close method must allow multiple concurrent calls.");
+                writer.openBlock("type $L interface {", "}", readerInterfaceName, () -> {
+                    writer.write("Events() <-chan $T", symbolProvider.toSymbol(shape));
+                    writer.write("Close() error");
+                    writer.write("Err() error");
+                });
+            });
+        });
+    }
+
+    public boolean hasEventStreamOperations() {
+        return hasEventStreamOperations(model, serviceShape, streamIndex);
+    }
+
+    public static boolean hasEventStreamOperations(Model model, ServiceShape serviceShape) {
+        EventStreamIndex index = EventStreamIndex.of(model);
+        return hasEventStreamOperations(model, serviceShape, index);
+    }
+
+    private static boolean hasEventStreamOperations(Model model, ServiceShape serviceShape, EventStreamIndex index) {
+        return TopDownIndex.of(model).getContainedOperations(serviceShape).stream()
+                .anyMatch(operationShape -> hasEventStream(model, operationShape, index));
+    }
+
+    public void writeEventStreamImplementation(Consumer<GoWriter> goWriterConsumer) {
+        writers.useFileWriter(EVENT_STREAM_FILE, settings.getModuleName(), goWriterConsumer);
+    }
+
+    public boolean hasEventStream(OperationShape operationShape) {
+        EventStreamIndex index = EventStreamIndex.of(model);
+        return hasEventStreamOperations(model, serviceShape, index);
+    }
+
+    public static boolean hasEventStream(Model model, OperationShape operationShape) {
+        EventStreamIndex index = EventStreamIndex.of(model);
+        return hasEventStream(model, operationShape, index);
+    }
+
+    private static boolean hasEventStream(Model model, OperationShape operationShape, EventStreamIndex index) {
+        return index.getInputInfo(operationShape).isPresent() || index.getOutputInfo(operationShape).isPresent();
+    }
+
+    public void generateOperationEventStreamStructure(OperationShape operationShape) {
+        if (!hasEventStream(model, operationShape)) {
+            return;
+        }
+        writers.useShapeWriter(operationShape, writer -> generateOperationEventStreamStructure(writer, operationShape));
+    }
+
+    private void generateOperationEventStreamStructure(GoWriter writer, OperationShape operationShape) {
+        var opEventStreamStructure = getEventStreamOperationStructureSymbol(serviceShape, operationShape);
+        var constructor = getEventStreamOperationStructureConstructor(serviceShape, operationShape);
+
+        var inputInfo = streamIndex.getInputInfo(operationShape);
+        var outputInfo = streamIndex.getOutputInfo(operationShape);
+
+
+        writer.write("""
+                     // $T provides the event stream handling for the $L operation.
+                     //
+                     // For testing and mocking the event stream this type should be initialized via
+                     // the $T constructor function. Using the functional options
+                     // to pass in nested mock behavior.""", opEventStreamStructure, operationShape.getId().getName(),
+                constructor
+                );
+        writer.openBlock("type $T struct {", "}", opEventStreamStructure, () -> {
+            inputInfo.ifPresent(eventStreamInfo -> {
+                var eventStreamTarget = eventStreamInfo.getEventStreamTarget();
+                var writerInterfaceName = getEventStreamWriterInterfaceName(serviceShape, eventStreamTarget);
+
+                writer.writeDocs(String.format("%s is the EventStream writer for the %s events. This value is "
+                                               + "automatically set by the SDK when the API call is made Use this "
+                                               + "member when unit testing your code with the SDK to mock out the "
+                                               + "EventStream Writer.",
+                                writerInterfaceName, eventStreamTarget.getId().getName(serviceShape)))
+                        .writeDocs("")
+                        .writeDocs("Must not be nil.")
+                        .write("Writer $L", writerInterfaceName).write("");
+            });
+
+            outputInfo.ifPresent(eventStreamInfo -> {
+                var eventStreamTarget = eventStreamInfo.getEventStreamTarget();
+                var readerInterfaceName = getEventStreamReaderInterfaceName(serviceShape, eventStreamTarget);
+
+                writer.writeDocs(String.format("%s is the EventStream reader for the %s events. This value is "
+                                               + "automatically set by the SDK when the API call is made Use this "
+                                               + "member when unit testing your code with the SDK to mock out the "
+                                               + "EventStream Reader.",
+                                readerInterfaceName, eventStreamTarget.getId().getName(serviceShape)))
+                        .writeDocs("")
+                        .writeDocs("Must not be nil.")
+                        .write("Reader $L", readerInterfaceName).write("");
+            });
+
+            writer.write("done chan struct{}")
+                    .write("closeOnce $T", SymbolUtils.createValueSymbolBuilder("Once", SmithyGoDependency.SYNC)
+                            .build())
+                    .write("err $P", SymbolUtils.createPointableSymbolBuilder("OnceErr",
+                            SmithyGoDependency.SMITHY_SYNC).build());
+        }).write("");
+
+        writer.write("""
+                     // $T initializes an $T.
+                     // This function should only be used for testing and mocking the $T
+                     // stream within your application.""", constructor, opEventStreamStructure,
+                opEventStreamStructure);
+        if (inputInfo.isPresent()) {
+            writer.write("""
+                         //
+                         // The Writer member must be set before writing events to the stream.""");
+        }
+        if (outputInfo.isPresent()) {
+            writer.write("""
+                         //
+                         // The Reader member must be set before writing events to the stream.""");
+        }
+        writer.openBlock("func $T(optFns ...func($P)) $P {", "}", constructor,
+                opEventStreamStructure, opEventStreamStructure, () -> writer
+                        .openBlock("es := &$L{", "}", opEventStreamStructure, () -> writer
+                                .write("done: make(chan struct{}),")
+                                .write("err: $T(),", SymbolUtils.createValueSymbolBuilder("NewOnceErr",
+                                        SmithyGoDependency.SMITHY_SYNC).build()))
+                        .openBlock("for _, fn := range optFns {", "}", () -> writer
+                                .write("fn(es)"))
+                        .write("return es")).write("");
+
+        if (inputInfo.isPresent()) {
+            writer.write("""
+                         // Send writes the event to the stream blocking until the event is written.
+                         // Returns an error if the event was not written.
+                         func (es $P) Send(ctx $P, event $P) error {
+                             return es.Writer.Send(ctx, event)
+                         }
+                         """, opEventStreamStructure, SymbolUtils.createValueSymbolBuilder("Context",
+                            SmithyGoDependency.CONTEXT).build(),
+                    symbolProvider.toSymbol(inputInfo.get().getEventStreamTarget()));
+        }
+
+        if (outputInfo.isPresent()) {
+            writer.write("""
+                         // Events returns a channel to read events from.
+                         func (es $P) Events() <-chan $P {
+                             return es.Reader.Events()
+                         }
+                         """, opEventStreamStructure, symbolProvider.toSymbol(outputInfo.get().getEventStreamTarget()));
+        }
+
+        writer.write("""
+                     // Close closes the stream. This will also cause the stream to be closed.
+                     // Close must be called when done using the stream API. Not calling Close
+                     // may result in resource leaks.
+                     //
+                     // Will close the underlying EventStream writer and reader, and no more events can be
+                     // sent or received.
+                     func (es $P) Close() error {
+                         es.closeOnce.Do(es.safeClose)
+                         return es.Err()
+                     }
+                     """, opEventStreamStructure);
+
+        writer.openBlock("func (es $P) safeClose() {", "}",
+                opEventStreamStructure, () -> {
+                    writer.write("""
+                                 if es.done != nil {
+                                     close(es.done)
+                                 }
+                                 """);
+
+                    if (inputInfo.isPresent()) {
+                        var newTicker = SymbolUtils.createValueSymbolBuilder("NewTicker",
+                                SmithyGoDependency.TIME).build();
+                        var second = SymbolUtils.createValueSymbolBuilder("Second",
+                                SmithyGoDependency.TIME).build();
+                        writer.write("""
+                                     t := $T($T)
+                                     defer t.Stop()
+                                     writeCloseDone := make(chan error)
+                                     go func() {
+                                         if err := es.Writer.Close(); err != nil {
+                                             es.err.SetError(err)
+                                         }
+                                         close(writeCloseDone)
+                                     }()
+                                     select {
+                                     case <-t.C:
+                                     case <-writeCloseDone:
+                                     }
+                                      """, newTicker, second);
+                    }
+
+                    if (outputInfo.isPresent()) {
+                        writer.write("es.Reader.Close()");
+                    }
+                }).write("");
+
+        writer.writeDocs("""
+                         Err returns any error that occurred while reading or writing EventStream
+                         Events from the service API's response. Returns nil if there were no errors.""");
+        writer.openBlock("func (es $P) Err() error {", "}",
+                opEventStreamStructure, () -> {
+                    writer.write("""
+                                 if err := es.err.Err(); err != nil {
+                                     return err
+                                 }
+                                 """);
+
+                    if (inputInfo.isPresent()) {
+                        writer.write("""
+                                     if err := es.Writer.Err(); err != nil {
+                                         return err
+                                     }
+                                     """);
+                    }
+
+                    if (outputInfo.isPresent()) {
+                        writer.write("""
+                                     if err := es.Reader.Err(); err != nil {
+                                         return err
+                                     }
+                                     """);
+                    }
+
+                    writer.write("return nil");
+                }).write("");
+
+        writer.openBlock("func (es $P) waitStreamClose() {", "}", opEventStreamStructure,
+                () -> {
+                    writer.write("""
+                                 if es.done == nil {
+                                     return
+                                 }
+
+                                 type errorSet interface {
+                                     ErrorSet() <-chan struct{}
+                                 }
+                                 """);
+
+                    if (inputInfo.isPresent()) {
+                        writer.write("""
+                                     var inputErrCh <-chan struct{}
+                                     if v, ok := es.Writer.(errorSet); ok {
+                                         inputErrCh = v.ErrorSet()
+                                     }
+                                     """);
+                    }
+
+                    if (outputInfo.isPresent()) {
+                        writer.write("""
+                                     var outputErrCh <-chan struct{}
+                                     if v, ok := es.Reader.(errorSet); ok {
+                                         outputErrCh = v.ErrorSet()
+                                     }
+                                     var outputClosedCh <-chan struct{}
+                                     if v, ok := es.Reader.(interface{ Closed() <-chan struct{} }); ok {
+                                         outputClosedCh = v.Closed()
+                                     }
+                                     """);
+                    }
+
+                    writer.openBlock("select {", "}", () -> {
+                        writer.write("case <-es.done:");
+                        if (inputInfo.isPresent()) {
+                            writer.write("""
+                                         case <-inputErrCh:
+                                             es.err.SetError(es.Writer.Err())
+                                             es.Close()
+                                         """);
+                        }
+                        if (outputInfo.isPresent()) {
+                            writer.write("""
+                                         case <-outputErrCh:
+                                             es.err.SetError(es.Reader.Err())
+                                             es.Close()
+
+                                         case <-outputClosedCh:
+                                             if err := es.Reader.Err(); err != nil {
+                                                 es.err.SetError(es.Reader.Err())
+                                             }
+                                             es.Close()
+                                         """);
+                        }
+                    });
+
+                }).write("");
+    }
+
+
+    public static Symbol getEventStreamOperationStructureConstructor(
+            ServiceShape serviceShape,
+            OperationShape operationShape
+    ) {
+        var symbol = getEventStreamOperationStructureSymbol(serviceShape, operationShape);
+        return SymbolUtils.createValueSymbolBuilder("New" + symbol.getName()).build();
+    }
+
+    public static Symbol getEventStreamOperationStructureSymbol(
+            ServiceShape serviceShape,
+            OperationShape operationShape
+    ) {
+        String name = StringUtils.capitalize(operationShape.getId().getName(serviceShape));
+        return SymbolUtils.createPointableSymbolBuilder(name + "EventStream")
+                .build();
+    }
+
+    public static String getEventStreamWriterInterfaceName(ServiceShape serviceShape, ToShapeId shape) {
+        String name = StringUtils.capitalize(shape.toShapeId().getName(serviceShape));
+        return name + "Writer";
+    }
+
+    public static String getEventStreamReaderInterfaceName(ServiceShape serviceShape, ToShapeId shape) {
+        String name = StringUtils.capitalize(shape.toShapeId().getName(serviceShape));
+        return name + "Reader";
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/EventStreamGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/EventStreamGenerator.java
@@ -163,10 +163,11 @@ public final class EventStreamGenerator {
                 var eventStreamTarget = eventStreamInfo.getEventStreamTarget();
                 var writerInterfaceName = getEventStreamWriterInterfaceName(serviceShape, eventStreamTarget);
 
-                writer.writeDocs(String.format("%s is the EventStream writer for the %s events. This value is "
-                                               + "automatically set by the SDK when the API call is made Use this "
-                                               + "member when unit testing your code with the SDK to mock out the "
-                                               + "EventStream Writer.",
+                writer.writeDocs(String.format("""
+                                               %s is the EventStream writer for the %s events. This value is
+                                               automatically set by the SDK when the API call is made Use this
+                                               member when unit testing your code with the SDK to mock out the
+                                               EventStream Writer.""",
                                 writerInterfaceName, eventStreamTarget.getId().getName(serviceShape)))
                         .writeDocs("")
                         .writeDocs("Must not be nil.")
@@ -177,10 +178,11 @@ public final class EventStreamGenerator {
                 var eventStreamTarget = eventStreamInfo.getEventStreamTarget();
                 var readerInterfaceName = getEventStreamReaderInterfaceName(serviceShape, eventStreamTarget);
 
-                writer.writeDocs(String.format("%s is the EventStream reader for the %s events. This value is "
-                                               + "automatically set by the SDK when the API call is made Use this "
-                                               + "member when unit testing your code with the SDK to mock out the "
-                                               + "EventStream Reader.",
+                writer.writeDocs(String.format("""
+                                               %s is the EventStream reader for the %s events. This value is
+                                               automatically set by the SDK when the API call is made Use this
+                                               member when unit testing your code with the SDK to mock out the
+                                               EventStream Reader.""",
                                 readerInterfaceName, eventStreamTarget.getId().getName(serviceShape)))
                         .writeDocs("")
                         .writeDocs("Must not be nil.")
@@ -200,14 +202,12 @@ public final class EventStreamGenerator {
                      // stream within your application.""", constructor, opEventStreamStructure,
                 opEventStreamStructure);
         if (inputInfo.isPresent()) {
-            writer.write("""
-                         //
-                         // The Writer member must be set before writing events to the stream.""");
+            writer.writeDocs("");
+            writer.writeDocs("The Writer member must be set before writing events to the stream.");
         }
         if (outputInfo.isPresent()) {
-            writer.write("""
-                         //
-                         // The Reader member must be set before writing events to the stream.""");
+            writer.writeDocs("");
+            writer.writeDocs("The Reader member must be set before reading events from the stream.");
         }
         writer.openBlock("func $T(optFns ...func($P)) $P {", "}", constructor,
                 opEventStreamStructure, opEventStreamStructure, () -> writer
@@ -256,9 +256,7 @@ public final class EventStreamGenerator {
         writer.openBlock("func (es $P) safeClose() {", "}",
                 opEventStreamStructure, () -> {
                     writer.write("""
-                                 if es.done != nil {
-                                     close(es.done)
-                                 }
+                                 close(es.done)
                                  """);
 
                     if (inputInfo.isPresent()) {
@@ -321,10 +319,6 @@ public final class EventStreamGenerator {
         writer.openBlock("func (es $P) waitStreamClose() {", "}", opEventStreamStructure,
                 () -> {
                     writer.write("""
-                                 if es.done == nil {
-                                     return
-                                 }
-
                                  type errorSet interface {
                                      ErrorSet() <-chan struct{}
                                  }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoEventStreamIndex.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoEventStreamIndex.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.EventStreamIndex;
+import software.amazon.smithy.model.knowledge.EventStreamInfo;
+import software.amazon.smithy.model.knowledge.KnowledgeIndex;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ToShapeId;
+
+/**
+ * Provides a knowledge index about event streams and their corresponding usage in operations.
+ */
+public class GoEventStreamIndex implements KnowledgeIndex {
+    final Map<ShapeId, Map<ShapeId, Set<EventStreamInfo>>> inputEventStreams = new HashMap<>();
+    final Map<ShapeId, Map<ShapeId, Set<EventStreamInfo>>> outputEventStreams = new HashMap<>();
+
+    public GoEventStreamIndex(Model model) {
+        EventStreamIndex eventStreamIndex = EventStreamIndex.of(model);
+
+        for (ServiceShape serviceShape : model.getServiceShapes()) {
+            final Map<ShapeId, Set<EventStreamInfo>> serviceInputStreams = new HashMap<>();
+            final Map<ShapeId, Set<EventStreamInfo>> serviceOutputStreams = new HashMap<>();
+            TopDownIndex.of(model).getContainedOperations(serviceShape).forEach(operationShape -> {
+                eventStreamIndex.getInputInfo(operationShape).ifPresent(eventStreamInfo -> {
+                    ShapeId eventStreamTargetId = eventStreamInfo.getEventStreamTarget().getId();
+                    if (serviceInputStreams.containsKey(eventStreamTargetId)) {
+                        serviceInputStreams.get(eventStreamTargetId).add(eventStreamInfo);
+                    } else {
+                        serviceInputStreams.put(eventStreamTargetId,
+                                new HashSet<>(Collections.singleton(eventStreamInfo)));
+                    }
+                });
+                eventStreamIndex.getOutputInfo(operationShape).ifPresent(eventStreamInfo -> {
+                    ShapeId eventStreamTargetId = eventStreamInfo.getEventStreamTarget().getId();
+                    if (serviceOutputStreams.containsKey(eventStreamTargetId)) {
+                        serviceInputStreams.get(eventStreamTargetId).add(eventStreamInfo);
+                    } else {
+                        serviceOutputStreams.put(eventStreamTargetId,
+                                new HashSet<>(Collections.singleton(eventStreamInfo)));
+                    }
+                });
+            });
+            if (!serviceInputStreams.isEmpty()) {
+                inputEventStreams.put(serviceShape.getId(), serviceInputStreams);
+            }
+            if (!serviceOutputStreams.isEmpty()) {
+                outputEventStreams.put(serviceShape.getId(), serviceOutputStreams);
+            }
+        }
+    }
+
+    /**
+     * Get the input event streams and their usages in operations for the provided service.
+     *
+     * @param service the service shape
+     * @return the map of event stream unions to their corresponding event infos
+     */
+    public Optional<Map<ShapeId, Set<EventStreamInfo>>> getInputEventStreams(ToShapeId service) {
+        return Optional.ofNullable(inputEventStreams.get(service.toShapeId()));
+    }
+
+    /**
+     * Get the output event streams and their usages in operations for the provided service.
+     *
+     * @param service the service shape
+     * @return the map of event stream unions to their corresponding event infos
+     */
+    public Optional<Map<ShapeId, Set<EventStreamInfo>>> getOutputEventStreams(ToShapeId service) {
+        return Optional.ofNullable(outputEventStreams.get(service.toShapeId()));
+    }
+
+    /**
+     * Returns a {@link GoEventStreamIndex} for the given model.
+     *
+     * @param model the model
+     * @return the knowledge index
+     */
+    public static GoEventStreamIndex of(Model model) {
+        return model.getKnowledge(GoEventStreamIndex.class, GoEventStreamIndex::new);
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -117,7 +117,11 @@ final class ServiceGenerator implements Runnable {
     ) {
         plugin.getConfigFieldResolvers().stream().filter(predicate)
                 .forEach(resolver -> {
-                    writer.write("$T(&options)", resolver.getResolver());
+                    writer.writeInline("$T(&options", resolver.getResolver());
+                    if (resolver.isWithOperationName()) {
+                        writer.writeInline(", opID");
+                    }
+                    writer.write(")");
                     writer.write("");
                 });
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -40,6 +40,7 @@ public final class SmithyGoDependency {
     public static final GoDependency TESTING = stdlib("testing");
     public static final GoDependency ERRORS = stdlib("errors");
     public static final GoDependency XML = stdlib("encoding/xml");
+    public static final GoDependency SYNC = stdlib("sync");
 
     public static final GoDependency SMITHY = smithy(null, "smithy");
     public static final GoDependency SMITHY_HTTP_TRANSPORT = smithy("transport/http", "smithyhttp");
@@ -56,6 +57,7 @@ public final class SmithyGoDependency {
     public static final GoDependency SMITHY_WAITERS = smithy("waiter", "smithywaiter");
     public static final GoDependency SMITHY_DOCUMENT = smithy("document", "smithydocument");
     public static final GoDependency SMITHY_DOCUMENT_JSON = smithy("document/json", "smithydocumentjson");
+    public static final GoDependency SMITHY_SYNC = smithy("sync", "smithysync");
 
     public static final GoDependency GO_CMP = goCmp("cmp");
     public static final GoDependency GO_CMP_OPTIONS = goCmp("cmp/cmpopts");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -99,6 +99,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
                 // the go reserved words are lower case, it's functionally impossible to conflict,
                 // so we only need to protect against common names. As of now there's only one.
                 .put("String", "String_")
+                .put("GetStream", "GetStream_")
                 .build();
 
         model.shapes(StructureShape.class)
@@ -409,7 +410,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol documentShape(DocumentShape shape) {
         return ProtocolDocumentGenerator.Utilities.getDocumentSymbolBuilder(settings,
-                ProtocolDocumentGenerator.DOCUMENT_INTERFACE_NAME)
+                        ProtocolDocumentGenerator.DOCUMENT_INTERFACE_NAME)
                 .build();
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ConfigFieldResolver.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ConfigFieldResolver.java
@@ -33,11 +33,13 @@ public final class ConfigFieldResolver {
     private final Location location;
     private final Target target;
     private final Symbol resolver;
+    private final boolean withOperationName;
 
     private ConfigFieldResolver(Builder builder) {
         location = SmithyBuilder.requiredState("location", builder.location);
         target = SmithyBuilder.requiredState("target", builder.target);
         resolver = SmithyBuilder.requiredState("resolver", builder.resolver);
+        withOperationName = builder.withOperationName;
     }
 
     public Location getLocation() {
@@ -50,6 +52,10 @@ public final class ConfigFieldResolver {
 
     public Symbol getResolver() {
         return resolver;
+    }
+
+    public boolean isWithOperationName() {
+        return withOperationName && location == Location.OPERATION;
     }
 
     public static Builder builder() {
@@ -66,12 +72,13 @@ public final class ConfigFieldResolver {
         }
         ConfigFieldResolver that = (ConfigFieldResolver) o;
         return location == that.location
-                && target == that.target
-                && resolver.equals(that.resolver);
+               && target == that.target
+               && resolver.equals(that.resolver);
     }
 
     /**
      * Returns a hash code value for the object.
+     *
      * @return the hash code.
      */
     @Override
@@ -112,6 +119,7 @@ public final class ConfigFieldResolver {
         private Location location;
         private Target target;
         private Symbol resolver;
+        private boolean withOperationName = false;
 
         public Builder location(Location location) {
             this.location = location;
@@ -125,6 +133,11 @@ public final class ConfigFieldResolver {
 
         public Builder resolver(Symbol resolver) {
             this.resolver = resolver;
+            return this;
+        }
+
+        public Builder withOperationName(boolean withOperationName) {
+            this.withOperationName = withOperationName;
             return this;
         }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -134,7 +134,7 @@ public final class HttpProtocolGeneratorUtils {
      * @return boolean indicating presence of response bindings in the shape for provided location
      */
     public static boolean isShapeWithResponseBindings(Model model, Shape shape, HttpBinding.Location location) {
-        Collection<HttpBinding> bindings = model.getKnowledge(HttpBindingIndex.class)
+        Collection<HttpBinding> bindings = HttpBindingIndex.of(model)
                 .getResponseBindings(shape).values();
 
         for (HttpBinding binding : bindings) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
@@ -426,6 +426,15 @@ public interface ProtocolGenerator {
     }
 
     /**
+     * Generate specific components for the protocol's event stream implementation. These components
+     * types should provide implementations that satisfy the reader and writer event stream interfaces.
+     *
+     * @param context the generation context.
+     */
+    default void generateEventStreamComponents(GenerationContext context) {
+    }
+
+    /**
      * Context object used for service serialization and deserialization.
      */
     class GenerationContext {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolUtils.java
@@ -70,7 +70,7 @@ public final class ProtocolUtils {
             processed.add(shape.getId());
             resolvedShapes.add(shape);
             walker.iterateShapes(shape, relationship -> MEMBER_RELATIONSHIPS.contains(
-                    relationship.getRelationshipType()))
+                            relationship.getRelationshipType()))
                     .forEachRemaining(walkedShape -> {
                         // MemberShape type itself is not what we are interested in
                         if (walkedShape.getType() == ShapeType.MEMBER) {
@@ -109,7 +109,7 @@ public final class ProtocolUtils {
      * @return The operation's input as a structure shape.
      */
     public static StructureShape expectInput(Model model, OperationShape operation) {
-        return model.getKnowledge(OperationIndex.class).getInput(operation)
+        return OperationIndex.of(model).getInput(operation)
                 .orElseThrow(() -> new CodegenException(
                         "Expected input shape for operation " + operation.getId().toString()));
     }
@@ -122,7 +122,7 @@ public final class ProtocolUtils {
      * @return The operation's output as a structure shape.
      */
     public static StructureShape expectOutput(Model model, OperationShape operation) {
-        return model.getKnowledge(OperationIndex.class).getOutput(operation)
+        return OperationIndex.of(model).getOutput(operation)
                 .orElseThrow(() -> new CodegenException(
                         "Expected output shape for operation " + operation.getId().toString()));
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ValidationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ValidationGenerator.java
@@ -62,6 +62,7 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
@@ -152,6 +153,10 @@ public class ValidationGenerator implements GoIntegration {
                 switch (shape.getType()) {
                     case STRUCTURE:
                         shape.members().forEach(memberShape -> {
+                            if (StreamingTrait.isEventStream(model, memberShape)) {
+                                return;
+                            }
+
                             String memberName = symbolProvider.toMemberName(memberShape);
                             Shape targetShape = model.expectShape(memberShape.getTarget());
                             boolean required = GoValidationIndex.isRequiredParameter(model, memberShape, topLevelShape);

--- a/internal/uuid/uuid.go
+++ b/internal/uuid/uuid.go
@@ -1,0 +1,26 @@
+package uuid
+
+import "encoding/hex"
+
+const dash byte = '-'
+
+// Format returns the canonical text representation of a UUID.
+// This implementation is optimized to not use fmt.
+// Example: 82e42f16-b6cc-4d5b-95f5-d403c4befd3d
+func Format(u [16]byte) string {
+	// https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29
+
+	var scratch [36]byte
+
+	hex.Encode(scratch[:8], u[0:4])
+	scratch[8] = dash
+	hex.Encode(scratch[9:13], u[4:6])
+	scratch[13] = dash
+	hex.Encode(scratch[14:18], u[6:8])
+	scratch[18] = dash
+	hex.Encode(scratch[19:23], u[8:10])
+	scratch[23] = dash
+	hex.Encode(scratch[24:], u[10:])
+
+	return string(scratch[:])
+}

--- a/rand/uuid.go
+++ b/rand/uuid.go
@@ -1,7 +1,7 @@
 package rand
 
 import (
-	"encoding/hex"
+	"github.com/aws/smithy-go/internal/uuid"
 	"io"
 )
 
@@ -31,42 +31,36 @@ type UUID struct {
 }
 
 // NewUUID returns an initialized UUID value that can be used to retrieve
-// random UUID values.
+// random UUID version 4 values.
 func NewUUID(r io.Reader) *UUID {
 	return &UUID{randSrc: r}
 }
 
-// GetUUID returns a UUID  random string sourced from the random reader the
+// GetUUID returns a random UUID version 4 string representation sourced from the random reader the
 // UUID was created with. Returns an error if unable to compute the UUID.
 func (r *UUID) GetUUID() (string, error) {
 	var b [16]byte
 	if _, err := io.ReadFull(r.randSrc, b[:]); err != nil {
 		return "", err
 	}
-
-	return uuidVersion4(b), nil
+	r.makeUUIDv4(b[:])
+	return uuid.Format(b), nil
 }
 
-// uuidVersion4 returns a random UUID version 4 from the byte slice provided.
-func uuidVersion4(u [16]byte) string {
-	// https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29
+// GetBytes returns a byte slice containing a random UUID version 4 sourced from the random reader the
+// UUID was created with. Returns an error if unable to compute the UUID.
+func (r *UUID) GetBytes() (u []byte, err error) {
+	u = make([]byte, 16)
+	if _, err = io.ReadFull(r.randSrc, u); err != nil {
+		return u, err
+	}
+	r.makeUUIDv4(u)
+	return u, nil
+}
 
+func (r *UUID) makeUUIDv4(u []byte) {
 	// 13th character is "4"
 	u[6] = (u[6] & 0x0f) | 0x40 // Version 4
 	// 17th character is "8", "9", "a", or "b"
-	u[8] = (u[8] & 0x3f) | 0x80 // Variant is 10
-
-	var scratch [36]byte
-
-	hex.Encode(scratch[:8], u[0:4])
-	scratch[8] = dash
-	hex.Encode(scratch[9:13], u[4:6])
-	scratch[13] = dash
-	hex.Encode(scratch[14:18], u[6:8])
-	scratch[18] = dash
-	hex.Encode(scratch[19:23], u[8:10])
-	scratch[23] = dash
-	hex.Encode(scratch[24:], u[10:])
-
-	return string(scratch[:])
+	u[8] = (u[8] & 0x3f) | 0x80 // Variant most significant bits are 10x where x can be either 1 or 0
 }

--- a/rand/uuid_test.go
+++ b/rand/uuid_test.go
@@ -2,7 +2,9 @@ package rand_test
 
 import (
 	"bytes"
+	mathrand "math/rand"
 	"testing"
+	"time"
 
 	"github.com/aws/smithy-go/rand"
 )
@@ -29,5 +31,17 @@ func TestUUID(t *testing.T) {
 	}
 	if e, a := `01010101-0101-4101-8101-010101010101`, v; e != a {
 		t.Errorf("expect %v, got %v", e, a)
+	}
+}
+
+func BenchmarkUUID_GetUUID(b *testing.B) {
+	src := mathrand.NewSource(time.Now().Unix())
+	uuid := rand.NewUUID(mathrand.New(src))
+
+	for i := 0; i < b.N; i++ {
+		_, err := uuid.GetUUID()
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/sync/error.go
+++ b/sync/error.go
@@ -1,0 +1,54 @@
+package sync
+
+import "sync"
+
+// OnceErr wraps the behavior of recording an error
+// once and signal on a channel when this has occurred.
+// Signaling is done by closing of the channel.
+//
+// Type is safe for concurrent usage.
+type OnceErr struct {
+	mu  sync.RWMutex
+	err error
+	ch  chan struct{}
+}
+
+// NewOnceErr return a new OnceErr
+func NewOnceErr() *OnceErr {
+	return &OnceErr{
+		ch: make(chan struct{}, 1),
+	}
+}
+
+// Err acquires a read-lock and returns an
+// error if one has been set.
+func (e *OnceErr) Err() error {
+	e.mu.RLock()
+	err := e.err
+	e.mu.RUnlock()
+
+	return err
+}
+
+// SetError acquires a write-lock and will set
+// the underlying error value if one has not been set.
+func (e *OnceErr) SetError(err error) {
+	if err == nil {
+		return
+	}
+
+	e.mu.Lock()
+	if e.err == nil {
+		e.err = err
+		close(e.ch)
+	}
+	e.mu.Unlock()
+}
+
+// ErrorSet returns a channel that will be used to signal
+// that an error has been set. This channel will be closed
+// when the error value has been set for OnceErr.
+func (e *OnceErr) ErrorSet() <-chan struct{} {
+	return e.ch
+}
+

--- a/transport/http/middleware_http_logging.go
+++ b/transport/http/middleware_http_logging.go
@@ -46,11 +46,13 @@ func (r *RequestResponseLogger) HandleDeserialize(
 
 		logger.Logf(logging.Debug, "Request\n%v", string(reqBytes))
 
-		smithyRequest, err = smithyRequest.SetStream(rc.Body)
-		if err != nil {
-			return out, metadata, err
+		if r.LogRequestWithBody {
+			smithyRequest, err = smithyRequest.SetStream(rc.Body)
+			if err != nil {
+				return out, metadata, err
+			}
+			in.Request = smithyRequest
 		}
-		in.Request = smithyRequest
 	}
 
 	out, metadata, err = next.HandleDeserialize(ctx, in)

--- a/transport/http/middleware_min_proto.go
+++ b/transport/http/middleware_min_proto.go
@@ -1,0 +1,70 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/smithy-go/middleware"
+	"strings"
+)
+
+// MinimumProtocolError is an error type indicating that the established connection did not meet the expected minimum
+// HTTP protocol version.
+type MinimumProtocolError struct {
+	proto              string
+	expectedProtoMajor int
+	expectedProtoMinor int
+}
+
+// Error returns the error message.
+func (m *MinimumProtocolError) Error() string {
+	return fmt.Sprintf("operation requires minimum HTTP protocol of HTTP/%d.%d, but was %s",
+		m.expectedProtoMajor, m.expectedProtoMinor, m.proto)
+}
+
+// RequireMinimumProtocol is a deserialization middleware that asserts that the established HTTP connection
+// meets the minimum major ad minor version.
+type RequireMinimumProtocol struct {
+	ProtoMajor int
+	ProtoMinor int
+}
+
+// ID returns the middleware identifier string.
+func (r *RequireMinimumProtocol) ID() string {
+	return "RequireMinimumProtocol"
+}
+
+// HandleDeserialize asserts that the established connection is a HTTP connection with the minimum major and minor
+// protocol version.
+func (r *RequireMinimumProtocol) HandleDeserialize(
+	ctx context.Context, in middleware.DeserializeInput, next middleware.DeserializeHandler,
+) (
+	out middleware.DeserializeOutput, metadata middleware.Metadata, err error,
+) {
+	out, metadata, err = next.HandleDeserialize(ctx, in)
+	if err != nil {
+		return out, metadata, err
+	}
+
+	response, ok := out.RawResponse.(*Response)
+	if !ok {
+		return out, metadata, fmt.Errorf("unknown transport type: %T", out.RawResponse)
+	}
+
+	if !strings.HasPrefix(response.Proto, "HTTP") {
+		return out, metadata, &MinimumProtocolError{
+			proto:              response.Proto,
+			expectedProtoMajor: r.ProtoMajor,
+			expectedProtoMinor: r.ProtoMinor,
+		}
+	}
+
+	if response.ProtoMajor < r.ProtoMajor || response.ProtoMinor < r.ProtoMinor {
+		return out, metadata, &MinimumProtocolError{
+			proto:              response.Proto,
+			expectedProtoMajor: r.ProtoMajor,
+			expectedProtoMinor: r.ProtoMinor,
+		}
+	}
+
+	return out, metadata, err
+}


### PR DESCRIPTION
Adds support for event streaming in protocol implementations. Provides the basic type and interface generator for operations, and delegates the concrete implementations to the underlying protocols.

Fixes https://github.com/aws/aws-sdk-go-v2/issues/1317