### PR TITLE
updates content checksum middleware order to 0

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/AddChecksumRequiredMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/AddChecksumRequiredMiddleware.java
@@ -30,7 +30,7 @@ import software.amazon.smithy.utils.ListUtils;
 public class AddChecksumRequiredMiddleware implements GoIntegration {
     @Override
     public byte getOrder() {
-        return 127;
+        return 0;
     }
 
     @Override


### PR DESCRIPTION
Please run code-generation on SDK (will update order of middleware for s3 and s3control that use the httpChecksumRequired trait).  Expect no change in behavior.

*Description of changes:*

This lets AWS SDK handle  the updated middleware at a later time. Changes order to `0` so this smithy-go middleware is handled before any other aws build middleware with order more than 0.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
