### PR TITLE
Upgrade to Smithy 1.14.0

### DIFF
--- a/codegen/smithy-go-codegen-test/build.gradle.kts
+++ b/codegen/smithy-go-codegen-test/build.gradle.kts
@@ -28,6 +28,6 @@ repositories {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.2.0,2.0.0[")
+    implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.14.0,2.0.0[")
     implementation(project(":smithy-go-codegen"))
 }

--- a/codegen/smithy-go-codegen/build.gradle.kts
+++ b/codegen/smithy-go-codegen/build.gradle.kts
@@ -18,9 +18,9 @@ extra["displayName"] = "Smithy :: Go :: Codegen"
 extra["moduleName"] = "software.amazon.smithy.go.codegen"
 
 dependencies {
-    api("software.amazon.smithy:smithy-codegen-core:[1.13.1,2.0.0[")
-    implementation("software.amazon.smithy:smithy-waiters:[1.13.1,2.0.0[")
+    api("software.amazon.smithy:smithy-codegen-core:[1.14.0,2.0.0[")
+    implementation("software.amazon.smithy:smithy-waiters:[1.14.0,2.0.0[")
     api("com.atlassian.commonmark:commonmark:0.15.2")
     api("org.jsoup:jsoup:1.14.1")
-    implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.13.1,2.0.0[")
+    implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.14.0,2.0.0[")
 }

--- a/codegen/smithy-go-codegen/build.gradle.kts
+++ b/codegen/smithy-go-codegen/build.gradle.kts
@@ -18,9 +18,9 @@ extra["displayName"] = "Smithy :: Go :: Codegen"
 extra["moduleName"] = "software.amazon.smithy.go.codegen"
 
 dependencies {
-    api("software.amazon.smithy:smithy-codegen-core:[1.3.0,2.0.0[")
-    implementation("software.amazon.smithy:smithy-waiters:[1.4.0,2.0.0[")
+    api("software.amazon.smithy:smithy-codegen-core:[1.13.1,2.0.0[")
+    implementation("software.amazon.smithy:smithy-waiters:[1.13.1,2.0.0[")
     api("com.atlassian.commonmark:commonmark:0.15.2")
     api("org.jsoup:jsoup:1.14.1")
-    implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.3.0,2.0.0[")
+    implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.13.1,2.0.0[")
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -41,6 +41,7 @@ public final class SmithyGoDependency {
     public static final GoDependency ERRORS = stdlib("errors");
     public static final GoDependency XML = stdlib("encoding/xml");
     public static final GoDependency SYNC = stdlib("sync");
+    public static final GoDependency PATH = stdlib("path");
 
     public static final GoDependency SMITHY = smithy(null, "smithy");
     public static final GoDependency SMITHY_HTTP_TRANSPORT = smithy("transport/http", "smithyhttp");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestGenerator.java
@@ -176,7 +176,7 @@ public abstract class HttpProtocolUnitTestGenerator<T extends HttpMessageTestCas
                     handler.accept(writer);
                 });
         writer.write("defer $L.Close()", name);
-        writer.write("url := server.URL");
+        writer.write("serverURL := server.URL");
     }
 
     /**

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestResponseGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestResponseGenerator.java
@@ -118,7 +118,7 @@ public class HttpProtocolUnitTestResponseGenerator extends HttpProtocolUnitTestG
     @Override
     protected void generateTestServer(GoWriter writer, String name, Consumer<GoWriter> handler) {
         // We aren't using a test server, but we do need a URL to set.
-        writer.write("url := \"http://localhost:8888/\"");
+        writer.write("serverURL := \"http://localhost:8888/\"");
     }
 
     /**


### PR DESCRIPTION
Updates the smithy-go code generation to 1.14.0 and makes several modifications to properly support for new AWS protocol test requirements.