### PR TITLE
Adds smithy-cli dependency to prevent auto use of smithy-cli 1.16

### DIFF
--- a/codegen/smithy-go-codegen-test/build.gradle.kts
+++ b/codegen/smithy-go-codegen-test/build.gradle.kts
@@ -20,6 +20,16 @@ extra["moduleName"] = "software.amazon.smithy.go.codegen.test"
 
 tasks["jar"].enabled = false
 
+buildscript {
+    val smithyVersion: String by project
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        "classpath"("software.amazon.smithy:smithy-cli:$smithyVersion")
+    }
+}
+
 plugins {
     id("software.amazon.smithy").version("0.5.3")
 }


### PR DESCRIPTION
Fixes the SDK's code generation to pin smithy-cli to $smithyVersion to restrict the supported version.