### PR TITLE
Update smithy-go to pin updated version of smithy

### DIFF
--- a/.changelog/b8bab33defab491db0c1f257f2435d1e.json
+++ b/.changelog/b8bab33defab491db0c1f257f2435d1e.json
@@ -1,0 +1,8 @@
+{
+    "id": "b8bab33d-efab-491d-b0c1-f257f2435d1e",
+    "type": "feature",
+    "description": "Updates deserialization of header list to supported quoted strings",
+    "modules": [
+        "."
+    ]
+}

--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,1 +1,1 @@
-smithyVersion=1.14.0
+smithyVersion=1.15.0

--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,1 +1,1 @@
-smithyVersion=1.15.0
+smithyVersion=1.16.3

--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,1 +1,1 @@
-smithyVersion=1.16.3
+smithyVersion=1.17.0

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -115,7 +115,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                     httpTrait -> containedOperations.add(operation),
                     () -> LOGGER.warning(String.format(
                             "Unable to fetch %s protocol request bindings for %s because it does not have an "
-                            + "http binding trait", getProtocol(), operation.getId()))
+                                    + "http binding trait", getProtocol(), operation.getId()))
             );
         }
         return containedOperations;
@@ -185,7 +185,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         Optional<EventStreamInfo> streamInfo = EventStreamIndex.of(context.getModel()).getInputInfo(operation);
 
         if (!CodegenUtils.isStubSyntheticClone(ProtocolUtils.expectInput(context.getModel(), operation))
-            && streamInfo.isEmpty()) {
+                && streamInfo.isEmpty()) {
             generateOperationDocumentSerializer(context, operation);
             addOperationDocumentShapeBindersForSerializer(context, operation);
         }
@@ -219,7 +219,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             // Check if the input shape has a members that target the document or payload and require serializers.
             // If an operation has an input event stream it will have seperate serializers generated.
             if (requiresDocumentSerdeFunction(targetShape)
-                && (binding.getLocation() == HttpBinding.Location.DOCUMENT
+                    && (binding.getLocation() == HttpBinding.Location.DOCUMENT
                     || binding.getLocation() == HttpBinding.Location.PAYLOAD)) {
                 serializeDocumentBindingShapes.add(targetShape);
             }
@@ -250,7 +250,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.write("request, ok := in.Request.($P)", requestType);
             writer.openBlock("if !ok {", "}", () -> {
                 writer.write("return out, metadata, "
-                             + "&smithy.SerializationError{Err: fmt.Errorf(\"unknown transport type %T\", in.Request)}"
+                        + "&smithy.SerializationError{Err: fmt.Errorf(\"unknown transport type %T\", in.Request)}"
                 );
             });
             writer.write("");
@@ -260,8 +260,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.write("_ = input");
             writer.openBlock("if !ok {", "}", () -> {
                 writer.write("return out, metadata, "
-                             + "&smithy.SerializationError{Err: fmt.Errorf(\"unknown input parameters type %T\","
-                             + " in.Parameters)}");
+                        + "&smithy.SerializationError{Err: fmt.Errorf(\"unknown input parameters type %T\","
+                        + " in.Parameters)}");
             });
 
             writer.write("");
@@ -270,7 +270,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.write("request.URL.RawQuery = smithyhttp.JoinRawQuery(request.URL.RawQuery, opQuery)");
             writer.write("request.Method = $S", httpTrait.getMethod());
             writer.write("restEncoder, err := httpbinding.NewEncoder(request.URL.Path, request.URL.RawQuery, "
-                         + "request.Header)");
+                    + "request.Header)");
             writer.openBlock("if err != nil {", "}", () -> {
                 writer.write("return out, metadata, &smithy.SerializationError{Err: err}");
             });
@@ -299,14 +299,14 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                                 !streamInfo.getEventStreamMember().equals(httpBinding.getMember())).orElse(true));
 
                 Optional<HttpBinding> payloadBinding = httpBindingIndex.getRequestBindings(operation,
-                                HttpBinding.Location.PAYLOAD).stream()
+                        HttpBinding.Location.PAYLOAD).stream()
                         .filter(httpBinding -> eventStreamInfo.map(streamInfo ->
                                 !streamInfo.getEventStreamMember().equals(httpBinding.getMember())).orElse(true))
                         .findFirst();
 
                 if (eventStreamInfo.isPresent() && (hasDocumentBindings || payloadBinding.isPresent())) {
                     throw new CodegenException("HTTP Binding Protocol unexpected document or payload bindings with "
-                                               + "input event stream");
+                            + "input event stream");
                 }
 
                 if (eventStreamInfo.isPresent()) {
@@ -406,7 +406,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             // Discard without deserializing the response if the input shape is a stubbed synthetic clone
             // without an archetype.
             if (CodegenUtils.isStubSyntheticClone(ProtocolUtils.expectOutput(model, operation))
-                && streamInfoOptional.isEmpty()) {
+                    && streamInfoOptional.isEmpty()) {
                 writer.addUseImports(SmithyGoDependency.IOUTIL);
                 writer.openBlock("if _, err = io.Copy(ioutil.Discard, response.Body); err != nil {", "}", () -> {
                     writer.openBlock("return out, metadata, &smithy.DeserializationError{", "}", () -> {
@@ -416,12 +416,12 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             } else {
                 boolean hasBodyBinding = HttpBindingIndex.of(model).getResponseBindings(operation).values().stream()
                         .filter(httpBinding -> httpBinding.getLocation() == HttpBinding.Location.DOCUMENT
-                                               || httpBinding.getLocation() == HttpBinding.Location.PAYLOAD)
+                                || httpBinding.getLocation() == HttpBinding.Location.PAYLOAD)
                         .anyMatch(httpBinding -> streamInfoOptional.map(esi -> !esi.getEventStreamMember()
                                 .equals(httpBinding.getMember())).orElse(true));
                 if (hasBodyBinding && streamInfoOptional.isPresent()) {
                     throw new CodegenException("HTTP Binding Protocol unexpected document or payload bindings with "
-                                               + "output event stream");
+                            + "output event stream");
                 }
                 if (hasBodyBinding) {
                     // Output Shape Document Binding middleware generation
@@ -477,10 +477,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
      */
     protected void writeSetPayloadShapeHeader(GoWriter writer, Shape payloadShape) {
         writer.write("""
-                     if !restEncoder.HasHeader("Content-Type") {
-                         restEncoder.SetHeader("Content-Type").String($S)
-                     }
-                     """, getPayloadShapeMediaType(payloadShape));
+                if !restEncoder.HasHeader("Content-Type") {
+                    restEncoder.SetHeader("Content-Type").String($S)
+                }
+                """, getPayloadShapeMediaType(payloadShape));
     }
 
     /**
@@ -491,9 +491,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
      */
     protected void writeSetStream(GoWriter writer, String operand) {
         writer.write("""
-                     if request, err = request.SetStream($L); err != nil {
-                         return out, metadata, &smithy.SerializationError{Err: err}
-                     }""", operand);
+                if request, err = request.SetStream($L); err != nil {
+                    return out, metadata, &smithy.SerializationError{Err: err}
+                }""", operand);
     }
 
     /**
@@ -595,11 +595,11 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
     private boolean isRestBinding(HttpBinding.Location location) {
         return location == HttpBinding.Location.HEADER
-               || location == HttpBinding.Location.PREFIX_HEADERS
-               || location == HttpBinding.Location.LABEL
-               || location == HttpBinding.Location.QUERY
-               || location == HttpBinding.Location.QUERY_PARAMS
-               || location == HttpBinding.Location.RESPONSE_CODE;
+                || location == HttpBinding.Location.PREFIX_HEADERS
+                || location == HttpBinding.Location.LABEL
+                || location == HttpBinding.Location.QUERY
+                || location == HttpBinding.Location.QUERY_PARAMS
+                || location == HttpBinding.Location.RESPONSE_CODE;
     }
 
     // returns whether an operation shape has Rest Request Bindings
@@ -793,7 +793,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                     memberShape, "v", false, true, operand -> {
                         writer.addUseImports(SmithyGoDependency.SMITHY);
                         writer.write("return &smithy.SerializationError { "
-                                     + "Err: fmt.Errorf(\"input member $L must not be empty\")}",
+                                        + "Err: fmt.Errorf(\"input member $L must not be empty\")}",
                                 memberShape.getMemberName());
                     });
         }
@@ -816,8 +816,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
                             if (targetShape.getType() != ShapeType.MAP) {
                                 throw new CodegenException("Unexpected prefix headers target shape "
-                                                           + valueMemberTarget.getType() + ", "
-                                                           + valueMemberShape.getId());
+                                        + valueMemberTarget.getType() + ", "
+                                        + valueMemberShape.getId());
                             }
 
                             writer.write("hv := encoder.Headers($S)", getCanonicalHeader(locationName));
@@ -921,7 +921,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         Shape targetShape = model.expectShape(memberShape.getTarget());
 
         if (!(targetShape instanceof CollectionShape)) {
-            String op = conditionallyBase64Encode(writer, targetShape, operand);
+            String op = conditionallyBase64Encode(context, writer, targetShape, operand);
             writeHttpBindingSetter(context, writer, memberShape, location, op, (w, s) -> {
                 w.writeInline("$L.SetHeader($L).$L", dest, locationName, s);
             });
@@ -934,23 +934,108 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             String indexedOperand = operand + "[i]";
             GoValueAccessUtils.writeIfNonZeroValue(context.getModel(), writer, collectionMemberShape, indexedOperand,
                     false, false, () -> {
-                        String op = conditionallyBase64Encode(writer, targetShape, indexedOperand);
-                        writeHttpBindingSetter(context, writer, collectionMemberShape, location, op, (w, s) -> {
-                            w.writeInline("$L.AddHeader($L).$L", dest, locationName, s);
-                        });
+                        String op = conditionallyEscapeHeader(context, writer, collectionMemberShape, indexedOperand);
+                        writeHttpBindingSetter(context, writer, collectionMemberShape, location, op,
+                                (w, s) -> {
+                                    w.writeInline("$L.AddHeader($L).$L", dest, locationName, s);
+                                });
                     });
         });
     }
 
-    private String conditionallyBase64Encode(GoWriter writer, Shape targetShape, String operand) {
-        // MediaType strings written to headers must be base64 encoded
-        if (targetShape.isStringShape() && targetShape.hasTrait(MediaTypeTrait.class)) {
-            writer.addUseImports(SmithyGoDependency.SMITHY_PTR);
-            writer.addUseImports(SmithyGoDependency.BASE64);
-            writer.write("encoded := ptr.String(base64.StdEncoding.EncodeToString([]byte(*$L)))", operand);
-            return "encoded";
+    private String conditionallyEscapeHeader(
+            GenerationContext context,
+            GoWriter writer,
+            MemberShape memberShape,
+            String operand
+    ) {
+        var targetShape = context.getModel().expectShape(memberShape.getTarget());
+        if (!targetShape.isStringShape()) {
+            return operand;
         }
-        return operand;
+        if (targetShape.hasTrait(MediaTypeTrait.class)) {
+            return conditionallyBase64Encode(context, writer, targetShape, operand);
+        }
+
+        writer.pushState();
+
+        var returnVar = "escaped";
+        var pointableIndex = GoPointableIndex.of(context.getModel());
+        var shouldDereference = pointableIndex.isDereferencable(memberShape);
+        if (shouldDereference) {
+            operand = CodegenUtils.getAsValueIfDereferencable(pointableIndex, memberShape, operand);
+            writer.putContext("escapedVar", "escapedVal");
+            returnVar = "escapedPtr";
+        } else {
+            writer.putContext("escapedVar", returnVar);
+        }
+        writer.putContext("returnVar", returnVar);
+
+        if (targetShape.hasTrait(EnumTrait.class)) {
+            operand = "string(" + operand + ")";
+        }
+
+        writer.putContext("value", operand);
+        writer.putContext("quoteValue", SymbolUtils.createValueSymbolBuilder(
+                "Quote", SmithyGoDependency.STRCONV).build());
+        writer.putContext("indexOf", SymbolUtils.createValueSymbolBuilder(
+                "Index", SmithyGoDependency.STRINGS).build());
+        writer.putContext("ptrString", SymbolUtils.createValueSymbolBuilder(
+                "String", SmithyGoDependency.SMITHY_PTR).build());
+
+        writer.write("""
+                $escapedVar:L := $value:L
+                if $indexOf:T($value:L, `,`) != -1 || $indexOf:T($value:L, `"`) != -1 {
+                    $escapedVar:L = $quoteValue:T($value:L)
+                }
+                """);
+        if (shouldDereference) {
+            writer.write("$returnVar:L := $ptrString:T($escapedVar:L)");
+        }
+
+        writer.popState();
+
+        return returnVar;
+    }
+
+    private String conditionallyBase64Encode(
+            GenerationContext context,
+            GoWriter writer,
+            Shape targetShape,
+            String operand
+    ) {
+        // MediaType strings written to headers must be base64 encoded
+        if (!targetShape.isStringShape() || !targetShape.hasTrait(MediaTypeTrait.class)) {
+            return operand;
+        }
+
+        writer.pushState();
+
+        var returnVar = "encoded";
+        var pointableIndex = GoPointableIndex.of(context.getModel());
+        var shouldDereference = pointableIndex.isDereferencable(targetShape);
+        if (shouldDereference) {
+            operand = CodegenUtils.getAsValueIfDereferencable(pointableIndex, targetShape, operand);
+            writer.putContext("encodedVar", "encodedVal");
+            returnVar = "encodedPtr";
+        } else {
+            writer.putContext("encodedVar", returnVar);
+        }
+        writer.putContext("returnVar", returnVar);
+
+        writer.putContext("value", operand);
+        writer.putContext("ptrString", SymbolUtils.createValueSymbolBuilder(
+                "String", SmithyGoDependency.SMITHY_PTR).build());
+        writer.putContext("encodeToString", SymbolUtils.createValueSymbolBuilder(
+                "StdEncoding.EncodeToString", SmithyGoDependency.BASE64).build());
+
+        writer.write("$encodedVar:L := $encodeToString:T([]byte($value:L))");
+        if (shouldDereference) {
+            writer.write("$returnVar:L := $ptrString:T($encodedVar:L)");
+        }
+
+        writer.popState();
+        return returnVar;
     }
 
     /**
@@ -974,7 +1059,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             Optional<EventStreamInfo> streamInfo = streamIndex.getOutputInfo(operation);
 
             if (!CodegenUtils.isStubSyntheticClone(ProtocolUtils.expectOutput(context.getModel(), operation))
-                && streamInfo.isEmpty()) {
+                    && streamInfo.isEmpty()) {
                 generateOperationDocumentDeserializer(context, operation);
                 addOperationDocumentShapeBindersForDeserializer(context, operation);
             }
@@ -1259,7 +1344,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
             writer.openBlock(
                     "if lenPrefix := len($S); "
-                    + "len(headerKey) >= lenPrefix && strings.EqualFold(headerKey[:lenPrefix], $S) {",
+                            + "len(headerKey) >= lenPrefix && strings.EqualFold(headerKey[:lenPrefix], $S) {",
                     "}", prefix, prefix, () -> {
                         writer.openBlock("if v.$L == nil {", "}", memberName, () -> {
                             writer.write("v.$L = $P{}", memberName, targetSymbol);
@@ -1389,7 +1474,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             // Add deserializer helpers for document and payload shape bindings if the operation does not have
             // any output event streams.
             if (requiresDocumentSerdeFunction(targetShape)
-                && (binding.getLocation() == HttpBinding.Location.DOCUMENT
+                    && (binding.getLocation() == HttpBinding.Location.DOCUMENT
                     || binding.getLocation() == HttpBinding.Location.PAYLOAD)) {
                 deserializeDocumentBindingShapes.add(targetShape);
             }

--- a/transport/http/headerlist.go
+++ b/transport/http/headerlist.go
@@ -2,48 +2,120 @@ package http
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
+	"unicode"
 )
 
 func splitHeaderListValues(vs []string, splitFn func(string) ([]string, error)) ([]string, error) {
-	for i := 0; i < len(vs); i++ {
-		if len(vs[i]) == 0 {
-			continue
-		}
+	values := make([]string, 0, len(vs))
 
+	for i := 0; i < len(vs); i++ {
 		parts, err := splitFn(vs[i])
 		if err != nil {
 			return nil, err
 		}
-		if len(parts) < 2 {
-			continue
-		}
-
-		tmp := make([]string, len(vs)+len(parts)-1)
-		copy(tmp, vs[:i])
-
-		for j, p := range parts {
-			tmp[i+j] = strings.TrimSpace(p)
-		}
-
-		copy(tmp[i+len(parts):], vs[i+1:])
-
-		vs = tmp
-		i += len(parts) - 1
+		values = append(values, parts...)
 	}
 
-	return vs, nil
+	return values, nil
 }
 
 // SplitHeaderListValues attempts to split the elements of the slice by commas,
 // and return a list of all values separated. Returns error if unable to
 // separate the values.
 func SplitHeaderListValues(vs []string) ([]string, error) {
-	return splitHeaderListValues(vs, commaSplit)
+	return splitHeaderListValues(vs, quotedCommaSplit)
 }
 
-func commaSplit(v string) ([]string, error) {
-	return strings.Split(v, ","), nil
+func quotedCommaSplit(v string) (parts []string, err error) {
+	v = strings.TrimSpace(v)
+
+	expectMore := true
+	for i := 0; i < len(v); i++ {
+		if unicode.IsSpace(rune(v[i])) {
+			continue
+		}
+		expectMore = false
+
+		// leading  space in part is ignored.
+		// Start of value must be non-space, or quote.
+		//
+		// - If quote, enter quoted mode, find next non-escaped quote to
+		//   terminate the value.
+		// - Otherwise, find next comma to terminate value.
+
+		remaining := v[i:]
+
+		var value string
+		var valueLen int
+		if remaining[0] == '"' {
+			//------------------------------
+			// Quoted value
+			//------------------------------
+			var j int
+			var skipQuote bool
+			for j += 1; j < len(remaining); j++ {
+				if remaining[j] == '\\' || (remaining[j] != '\\' && skipQuote) {
+					skipQuote = !skipQuote
+					continue
+				}
+				if remaining[j] == '"' {
+					break
+				}
+			}
+			if j == len(remaining) || j == 1 {
+				return nil, fmt.Errorf("value %v missing closing double quote",
+					remaining)
+			}
+			valueLen = j + 1
+
+			tail := remaining[valueLen:]
+			var k int
+			for ; k < len(tail); k++ {
+				if !unicode.IsSpace(rune(tail[k])) && tail[k] != ',' {
+					return nil, fmt.Errorf("value %v has non-space trailing characters",
+						remaining)
+				}
+				if tail[k] == ',' {
+					expectMore = true
+					break
+				}
+			}
+			value = remaining[:valueLen]
+			value, err = strconv.Unquote(value)
+			if err != nil {
+				return nil, fmt.Errorf("failed to unquote value %v, %w", value, err)
+			}
+
+			// Pad valueLen to include trailing space(s) so `i` is updated correctly.
+			valueLen += k
+
+		} else {
+			//------------------------------
+			// Unquoted value
+			//------------------------------
+
+			// Index of the next comma is the length of the value, or end of string.
+			valueLen = strings.Index(remaining, ",")
+			if valueLen != -1 {
+				expectMore = true
+			} else {
+				valueLen = len(remaining)
+			}
+			value = strings.TrimSpace(remaining[:valueLen])
+		}
+
+		i += valueLen
+		parts = append(parts, value)
+
+	}
+
+	if expectMore {
+		parts = append(parts, "")
+	}
+
+	return parts, nil
 }
 
 // SplitHTTPDateTimestampHeaderListValues attempts to split the HTTP-Date
@@ -56,10 +128,10 @@ func SplitHTTPDateTimestampHeaderListValues(vs []string) ([]string, error) {
 }
 
 func splitHTTPDateHeaderValue(v string) ([]string, error) {
-	if n := strings.Count(v, ","); n == 1 {
-		// Skip values with only a single HTTPDate value
-		return nil, nil
-	} else if n == 0 || n%2 == 0 {
+	if n := strings.Count(v, ","); n <= 1 {
+		// Nothing to do if only contains a no, or single HTTPDate value
+		return []string{v}, nil
+	} else if n%2 == 0 {
 		return nil, fmt.Errorf("invalid timestamp HTTPDate header comma separations, %q", v)
 	}
 
@@ -71,7 +143,7 @@ func splitHTTPDateHeaderValue(v string) ([]string, error) {
 		if v[i] == ',' {
 			if doSplit {
 				doSplit = false
-				parts = append(parts, v[j:i])
+				parts = append(parts, strings.TrimSpace(v[j:i]))
 				j = i + 1
 			} else {
 				// Skip the first comma in the timestamp value since that
@@ -82,8 +154,9 @@ func splitHTTPDateHeaderValue(v string) ([]string, error) {
 			}
 		}
 	}
+	// Add final part
 	if j < len(v) {
-		parts = append(parts, v[j:])
+		parts = append(parts, strings.TrimSpace(v[j:]))
 	}
 
 	return parts, nil


### PR DESCRIPTION
Updates smithy-go to pin to the smithy 1.17.0 version.

Updates the code generation to handle (de)serialization of quoted header list values.