### PR TITLE
codegen: Update REST streaming request payload content-type usage

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -511,24 +511,24 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         Shape payloadShape = model.expectShape(memberShape.getTarget());
 
         if (payloadShape.hasTrait(StreamingTrait.class)) {
+            writeSetPayloadShapeHeader(writer, payloadShape);
             GoValueAccessUtils.writeIfNonZeroValueMember(context.getModel(), context.getSymbolProvider(), writer,
                     memberShape, "input", (s) -> {
-                        writeSetPayloadShapeHeader(writer, payloadShape);
                         writer.write("payload := $L", s);
                         writeSetStream(writer, "payload");
                     });
         } else if (payloadShape.isBlobShape()) {
+            writeSetPayloadShapeHeader(writer, payloadShape);
             GoValueAccessUtils.writeIfNonZeroValueMember(context.getModel(), context.getSymbolProvider(), writer,
                     memberShape, "input", (s) -> {
-                        writeSetPayloadShapeHeader(writer, payloadShape);
                         writer.addUseImports(SmithyGoDependency.BYTES);
                         writer.write("payload := bytes.NewReader($L)", s);
                         writeSetStream(writer, "payload");
                     });
         } else if (payloadShape.isStringShape()) {
+            writeSetPayloadShapeHeader(writer, payloadShape);
             GoValueAccessUtils.writeIfNonZeroValueMember(context.getModel(), context.getSymbolProvider(), writer,
                     memberShape, "input", (s) -> {
-                        writeSetPayloadShapeHeader(writer, payloadShape);
                         writer.addUseImports(SmithyGoDependency.STRINGS);
                         if (payloadShape.hasTrait(EnumTrait.class)) {
                             writer.write("payload := strings.NewReader(string($L))", s);


### PR DESCRIPTION
Updates the SDK's codegen for REST HTTP request payload to always
include content-type header for operations with streaming request
payloads. Prior the content-type header would only be added if the
streaming request io.Reader was not nil.
