### PR TITLE
encoding/httpbinding: fix dropped error

### DIFF
--- a/encoding/httpbinding/uri.go
+++ b/encoding/httpbinding/uri.go
@@ -20,6 +20,9 @@ func newURIValue(path *[]byte, rawPath *[]byte, buffer *[]byte, key string) URIV
 
 func (u URIValue) modifyURI(value string) (err error) {
 	*u.path, *u.buffer, err = replacePathElement(*u.path, *u.buffer, u.key, value, false)
+	if err != nil {
+		return err
+	}
 	*u.rawPath, *u.buffer, err = replacePathElement(*u.rawPath, *u.buffer, u.key, value, true)
 	return err
 }


### PR DESCRIPTION
This fixes a dropped `err` variable in `encoding/httpbinding`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
