### PR TITLE
Add support for Smithy httpBearerAuth authentication trait

### DIFF
--- a/.changelog/07aa0cb9fd244f52aac3f66f0047b25e.json
+++ b/.changelog/07aa0cb9fd244f52aac3f66f0047b25e.json
@@ -1,0 +1,8 @@
+{
+    "id": "07aa0cb9-fd24-4f52-aac3-f66f0047b25e",
+    "type": "feature",
+    "description": "Adds support for the Smithy httpBearerAuth authentication trait to smithy-go. This allows the SDK to support the bearer authentication flow for API operations decorated with httpBearerAuth. An API client will need to be provided with its own bearer.TokenProvider implementation or use the bearer.StaticTokenProvider implementation.",
+    "modules": [
+        "."
+    ]
+}

--- a/auth/bearer/docs.go
+++ b/auth/bearer/docs.go
@@ -1,0 +1,4 @@
+// Package bearer provides middleware and utilities for authenticating API
+// operation calls with a Bearer Token.
+
+package bearer

--- a/auth/bearer/docs.go
+++ b/auth/bearer/docs.go
@@ -1,4 +1,3 @@
 // Package bearer provides middleware and utilities for authenticating API
 // operation calls with a Bearer Token.
-
 package bearer

--- a/auth/bearer/middleware.go
+++ b/auth/bearer/middleware.go
@@ -18,14 +18,6 @@ type Signer interface {
 	SignWithBearerToken(context.Context, Token, Message) (Message, error)
 }
 
-// // SignerFunc provides a wrapper around a function to implement the Signer interface.
-// type SignerFunc func(context.Context, Token, Message) (Message, error)
-//
-// // SignWithBearerToken invokes the wrapped function to satisfy the Signer interface.
-// func (fn SignerFunc) SignWithBearerToken(ctx context.Context, token Token, message Message) (Message, error) {
-// 	return fn(ctx, token, message)
-// }
-
 // AuthenticationMiddleware provides the Finalize middleware step for signing
 // an request message with a bearer token.
 type AuthenticationMiddleware struct {

--- a/auth/bearer/middleware.go
+++ b/auth/bearer/middleware.go
@@ -1,0 +1,107 @@
+package bearer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+// Message is the middleware stack's request transport message value.
+type Message interface{}
+
+// Signer provides an interface for implementations to decorate a request
+// message with a bearer token. The signer is responsible for validating the
+// message type is compatible with the signer.
+type Signer interface {
+	SignWithBearerToken(context.Context, Token, Message) (Message, error)
+}
+
+// // SignerFunc provides a wrapper around a function to implement the Signer interface.
+// type SignerFunc func(context.Context, Token, Message) (Message, error)
+//
+// // SignWithBearerToken invokes the wrapped function to satisfy the Signer interface.
+// func (fn SignerFunc) SignWithBearerToken(ctx context.Context, token Token, message Message) (Message, error) {
+// 	return fn(ctx, token, message)
+// }
+
+// AuthenticationMiddleware provides the Finalize middleware step for signing
+// an request message with a bearer token.
+type AuthenticationMiddleware struct {
+	signer        Signer
+	tokenProvider TokenProvider
+}
+
+// AddAuthenticationMiddleware helper adds the AuthenticationMiddleware to the
+// middleware Stack in the Finalize step with the options provided.
+func AddAuthenticationMiddleware(s *middleware.Stack, signer Signer, tokenProvider TokenProvider) error {
+	return s.Finalize.Add(
+		NewAuthenticationMiddleware(signer, tokenProvider),
+		middleware.After,
+	)
+}
+
+// NewAuthenticationMiddleware returns an initialized AuthenticationMiddleware.
+func NewAuthenticationMiddleware(signer Signer, tokenProvider TokenProvider) *AuthenticationMiddleware {
+	return &AuthenticationMiddleware{
+		signer:        signer,
+		tokenProvider: tokenProvider,
+	}
+}
+
+const authenticationMiddlewareID = "BearerTokenAuthentication"
+
+// ID returns the resolver identifier
+func (m *AuthenticationMiddleware) ID() string {
+	return authenticationMiddlewareID
+}
+
+// HandleFinalize implements the FinalizeMiddleware interface in order to
+// update the request with bearer token authentication.
+func (m *AuthenticationMiddleware) HandleFinalize(
+	ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler,
+) (
+	out middleware.FinalizeOutput, metadata middleware.Metadata, err error,
+) {
+	token, err := m.tokenProvider.RetrieveBearerToken(ctx)
+	if err != nil {
+		return out, metadata, fmt.Errorf("failed AuthenticationMiddleware wrap message, %w", err)
+	}
+
+	signedMessage, err := m.signer.SignWithBearerToken(ctx, token, in.Request)
+	if err != nil {
+		return out, metadata, fmt.Errorf("failed AuthenticationMiddleware sign message, %w", err)
+	}
+
+	in.Request = signedMessage
+	return next.HandleFinalize(ctx, in)
+}
+
+// SignHTTPSMessage provides a bearer token authentication implementation that
+// will sign the message with the provided bearer token.
+//
+// Will fail if the message is not a smithy-go HTTP request or the request is
+// not HTTPS.
+type SignHTTPSMessage struct{}
+
+// SignWithBearerToken returns a copy of the HTTP request with the bearer token
+// added via the "Authorization" header, per [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750).
+//
+// Returns an error if the request's URL scheme is not HTTPS, or the request
+// message is not an smithy-go HTTP Request pointer type.
+func (SignHTTPSMessage) SignWithBearerToken(ctx context.Context, token Token, message Message) (Message, error) {
+	req, ok := message.(*smithyhttp.Request)
+	if !ok {
+		return nil, fmt.Errorf("expect smithy-go HTTP Request, got %T", message)
+	}
+
+	if !req.IsHTTPS() {
+		return nil, fmt.Errorf("bearer token with HTTP request requires HTTPS")
+	}
+
+	reqClone := req.Clone()
+	reqClone.Header.Set("Authorization", "Bearer "+token.Value)
+
+	return reqClone, nil
+}

--- a/auth/bearer/middleware.go
+++ b/auth/bearer/middleware.go
@@ -85,8 +85,13 @@ func (m *AuthenticationMiddleware) HandleFinalize(
 // not HTTPS.
 type SignHTTPSMessage struct{}
 
+// NewSignHTTPSMessage returns an initialized signer for HTTP messages.
+func NewSignHTTPSMessage() *SignHTTPSMessage {
+	return &SignHTTPSMessage{}
+}
+
 // SignWithBearerToken returns a copy of the HTTP request with the bearer token
-// added via the "Authorization" header, per [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750).
+// added via the "Authorization" header, per RFC 6750, https://datatracker.ietf.org/doc/html/rfc6750.
 //
 // Returns an error if the request's URL scheme is not HTTPS, or the request
 // message is not an smithy-go HTTP Request pointer type.

--- a/auth/bearer/middleware_test.go
+++ b/auth/bearer/middleware_test.go
@@ -1,0 +1,78 @@
+package bearer
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestSignHTTPSMessage(t *testing.T) {
+	cases := map[string]struct {
+		message       Message
+		token         Token
+		expectMessage Message
+		expectErr     string
+	}{
+		// Cases
+		"not smithyhttp.Request": {
+			message:   struct{}{},
+			expectErr: "expect smithy-go HTTP Request",
+		},
+		"not https": {
+			message: func() Message {
+				r := smithyhttp.NewStackRequest().(*smithyhttp.Request)
+				r.URL, _ = url.Parse("http://example.aws")
+				return r
+			}(),
+			expectErr: "requires HTTPS",
+		},
+		"success": {
+			message: func() Message {
+				r := smithyhttp.NewStackRequest().(*smithyhttp.Request)
+				r.URL, _ = url.Parse("https://example.aws")
+				return r
+			}(),
+			token: Token{Value: "abc123"},
+			expectMessage: func() Message {
+				r := smithyhttp.NewStackRequest().(*smithyhttp.Request)
+				r.URL, _ = url.Parse("https://example.aws")
+				r.Header.Set("Authorization", "Bearer abc123")
+				return r
+			}(),
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			signer := SignHTTPSMessage{}
+			message, err := signer.SignWithBearerToken(ctx, c.token, c.message)
+			if c.expectErr != "" {
+				if err == nil {
+					t.Fatalf("expect error, got none")
+				}
+				if e, a := c.expectErr, err.Error(); !strings.Contains(a, e) {
+					t.Fatalf("expect %v in error %v", e, a)
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("expect no error, got %v", err)
+			}
+
+			options := []cmp.Option{
+				cmpopts.IgnoreUnexported(smithyhttp.Request{}),
+				cmpopts.IgnoreUnexported(http.Request{}),
+			}
+
+			if diff := cmp.Diff(c.expectMessage, message, options...); diff != "" {
+				t.Errorf("expect match\n%s", diff)
+			}
+		})
+	}
+}

--- a/auth/bearer/token.go
+++ b/auth/bearer/token.go
@@ -19,7 +19,7 @@ func (t Token) Expired(now time.Time) bool {
 	if !t.CanExpire {
 		return false
 	}
-	return now.Equal(t.Expires) || now.After(t.Expires)
+	return now.Round(0).Equal(t.Expires) || now.After(t.Expires)
 }
 
 // TokenProvider provides interface for retrieving bearer tokens.

--- a/auth/bearer/token.go
+++ b/auth/bearer/token.go
@@ -1,0 +1,49 @@
+package bearer
+
+import (
+	"context"
+	"time"
+)
+
+// Token provides a type wrapping a bearer token and expiration metadata.
+type Token struct {
+	Value string
+
+	CanExpire bool
+	Expires   time.Time
+}
+
+// IsExpired returns if the token's Expires time is before or equal to the time
+// provided. If CanExpires is false, Expired will always return false.
+func (t Token) Expired(now time.Time) bool {
+	if !t.CanExpire {
+		return false
+	}
+	return now.Equal(t.Expires) || now.After(t.Expires)
+}
+
+// TokenProvider provides interface for retrieving bearer tokens.
+type TokenProvider interface {
+	RetrieveBearerToken(context.Context) (Token, error)
+}
+
+// TokenProviderFunc provides a helper utility to wrap a function as a type
+// that implements the TokenProvider interface.
+type TokenProviderFunc func(context.Context) (Token, error)
+
+// RetrieveBearerToken calls the wrapped function, returning the Token or
+// error.
+func (fn TokenProviderFunc) RetrieveBearerToken(ctx context.Context) (Token, error) {
+	return fn(ctx)
+}
+
+// StaticTokenProvider provides a utility for wrapping a static bearer token
+// value within an implementation of a token provider.
+type StaticTokenProvider struct {
+	Token Token
+}
+
+// RetrieveBearerToken returns the static token specified.
+func (s StaticTokenProvider) RetrieveBearerToken(context.Context) (Token, error) {
+	return s.Token, nil
+}

--- a/auth/bearer/token.go
+++ b/auth/bearer/token.go
@@ -13,7 +13,7 @@ type Token struct {
 	Expires   time.Time
 }
 
-// IsExpired returns if the token's Expires time is before or equal to the time
+// Expired returns if the token's Expires time is before or equal to the time
 // provided. If CanExpires is false, Expired will always return false.
 func (t Token) Expired(now time.Time) bool {
 	if !t.CanExpire {

--- a/auth/bearer/token.go
+++ b/auth/bearer/token.go
@@ -19,7 +19,8 @@ func (t Token) Expired(now time.Time) bool {
 	if !t.CanExpire {
 		return false
 	}
-	return now.Round(0).Equal(t.Expires) || now.After(t.Expires)
+	now = now.Round(0)
+	return now.Equal(t.Expires) || now.After(t.Expires)
 }
 
 // TokenProvider provides interface for retrieving bearer tokens.

--- a/auth/bearer/token_cache.go
+++ b/auth/bearer/token_cache.go
@@ -1,0 +1,213 @@
+package bearer
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/aws/smithy-go/internal/sync/singleflight"
+)
+
+// package variable that can be override in unit tests.
+var timeNow = time.Now
+
+// TokenCacheOptions provides a set of optional configuration options for the
+// TokenCache TokenProvider.
+type TokenCacheOptions struct {
+	// The duration before the token will expire when the credentials will be
+	// refreshed. If DisableAsyncRefresh is true, the RetrieveBearerToken calls
+	// will be blocking.
+	//
+	// Asynchronous refreshes are deduplicated, and only one will be in-flight
+	// at a time. If the token expires while an asynchronous refresh is in
+	// flight, the next call to RetrieveBearerToken will block on that refresh
+	// to return.
+	RefreshBeforeExpires time.Duration
+	// TODO probably need RefreshBeforeExpires jitter factor
+
+	// The timeout the underlying TokenProvider's RetrieveBearerToken call must
+	// return within, or will be canceled. Defaults to 0, no timeout.
+	//
+	// If 0 timeout, its possible for the underlying tokenProvider's
+	// RetrieveBearerToken call to block forever. Preventing subsequent
+	// TokenCache attempts to refresh the token.
+	//
+	// If this timeout is reached all pending deduplicated calls to
+	// TokenCache RetrieveBearerToken will fail with an error.
+	RetrieveBearerTokenTimeout time.Duration
+
+	// The minimum duration between asynchronous refresh attempts. If the next
+	// asynchronous recent refresh attempt was within the minimum delay
+	// duration, the call to retrieve will return the current cached token, if
+	// not expired.
+	//
+	// The asynchronous retrieve is deduplicated across multiple calls when
+	// RetrieveBearerToken is called. The asynchronous retrieve is not a
+	// periodic task. It is only performed when the token has not yet expired,
+	// and the current item is within the RefreshBeforeExpires window, and the
+	// TokenCache's RetrieveBearerToken method is called.
+	//
+	// If 0, (default) there will be no minimum delay between asynchronous
+	// refresh attempts.
+	//
+	// If DisableAsyncRefresh is true, this option is ignored.
+	AsyncRefreshMinimumDelay time.Duration
+
+	// Sets if the TokenCache will attempt to refresh the token in the
+	// background asynchronously instead of blocking for credentials to be
+	// refreshed. If disabled token refresh will be blocking.
+	//
+	// The first call to RetrieveBearerToken will always be blocking, because
+	// there is no cached token.
+	DisableAsyncRefresh bool
+}
+
+// TokenCache provides an utility to cache Bearer Authentication tokens from a
+// wrapped TokenProvider. The TokenCache can be has options to configure the
+// cache's early and asynchronous refresh of the token.
+type TokenCache struct {
+	options  TokenCacheOptions
+	provider TokenProvider
+
+	cachedToken            atomic.Value
+	lastRefreshAttemptTime atomic.Value
+	sfGroup                singleflight.Group
+}
+
+// NewTokenCache returns a initialized TokenCache that implements the
+// TokenProvider interface. Wrapping the provider passed in. Also taking a set
+// of optional functional option parameters to configure the token cache.
+func NewTokenCache(provider TokenProvider, optFns ...func(*TokenCacheOptions)) *TokenCache {
+	var options TokenCacheOptions
+	for _, fn := range optFns {
+		fn(&options)
+	}
+
+	return &TokenCache{
+		options:  options,
+		provider: provider,
+	}
+}
+
+// RetrieveBearerToken returns the token if it could be obtained, or error if a
+// valid token could not be retrieved.
+//
+// The passed in Context's cancel/deadline/timeout will impacting only this
+// individual retrieve call and not any other already queued up calls. This
+// means underlying provider's RetrieveBearerToken calls could block for ever,
+// and not be canceled with the Context. Set RetrieveBearerTokenTimeout to
+// provide a timeout, preventing the underlying TokenProvider blocking forever.
+//
+// Without RetrieveBearerTokenTimeout there is the potential for a underlying
+// Provider's RetrieveBearerToken call to sit forever. Blocking in subsequent
+// attempts at refreshing the token.
+func (p *TokenCache) RetrieveBearerToken(ctx context.Context) (Token, error) {
+	cachedToken, ok := p.getCachedToken()
+	if !ok || cachedToken.Expired(timeNow()) {
+		return p.refreshBearerToken(ctx)
+	}
+
+	// Check if the token should be refreshed before it expires.
+	refreshToken := cachedToken.Expired(timeNow().Add(p.options.RefreshBeforeExpires))
+	if !refreshToken {
+		return cachedToken, nil
+	}
+
+	if p.options.DisableAsyncRefresh {
+		return p.refreshBearerToken(ctx)
+	}
+
+	p.tryAsyncRefresh(ctx)
+
+	return cachedToken, nil
+}
+
+// tryAsyncRefresh attempts to asynchronously refresh the token returning the
+// already cached token. If it AsyncRefreshMinimumDelay option is not zero, and
+// the duration since the last refresh is less than that value, nothing will be
+// done.
+func (p *TokenCache) tryAsyncRefresh(ctx context.Context) {
+	if p.options.AsyncRefreshMinimumDelay != 0 {
+		var lastRefreshAttempt time.Time
+		if v := p.lastRefreshAttemptTime.Load(); v != nil {
+			lastRefreshAttempt = v.(time.Time)
+		}
+
+		if timeNow().Before(lastRefreshAttempt.Add(p.options.AsyncRefreshMinimumDelay)) {
+			return
+		}
+	}
+
+	// Ignore the returned channel so this won't be blocking, and limit the
+	// number of additional goroutines created.
+	p.sfGroup.DoChan("async-refresh", func() (interface{}, error) {
+		res, err := p.refreshBearerToken(ctx)
+		if p.options.AsyncRefreshMinimumDelay != 0 {
+			var refreshAttempt time.Time
+			if err != nil {
+				refreshAttempt = timeNow()
+			}
+			p.lastRefreshAttemptTime.Store(refreshAttempt)
+		}
+
+		return res, err
+	})
+}
+
+func (p *TokenCache) refreshBearerToken(ctx context.Context) (Token, error) {
+	resCh := p.sfGroup.DoChan("refresh-token", func() (interface{}, error) {
+		var ctx context.Context = &suppressedContext{ctx}
+		if v := p.options.RetrieveBearerTokenTimeout; v != 0 {
+			var cancel func()
+			ctx, cancel = context.WithTimeout(ctx, v)
+			defer cancel()
+		}
+		return p.singleRetrieve(ctx)
+	})
+
+	select {
+	case res := <-resCh:
+		return res.Val.(Token), res.Err
+	case <-ctx.Done():
+		return Token{}, fmt.Errorf("retrieve bearer token canceled, %w", ctx.Err())
+	}
+}
+
+func (p *TokenCache) singleRetrieve(ctx context.Context) (interface{}, error) {
+	token, err := p.provider.RetrieveBearerToken(ctx)
+	if err != nil {
+		return Token{}, fmt.Errorf("failed to retrieve bearer token, %w", err)
+	}
+
+	p.cachedToken.Store(&token)
+	return token, nil
+}
+
+// getCachedToken returns the currently cached token and true if found. Returns
+// false if no token is cached.
+func (p *TokenCache) getCachedToken() (Token, bool) {
+	v := p.cachedToken.Load()
+	if v == nil {
+		return Token{}, false
+	}
+
+	t := v.(*Token)
+	if t == nil || t.Value == "" {
+		return Token{}, false
+	}
+
+	return *t, true
+}
+
+type suppressedContext struct {
+	context.Context
+}
+
+func (s *suppressedContext) Deadline() (deadline time.Time, ok bool) {
+	return time.Time{}, false
+}
+
+func (s *suppressedContext) Done() <-chan struct{} { return nil }
+
+func (s *suppressedContext) Err() error { return nil }

--- a/auth/bearer/token_cache.go
+++ b/auth/bearer/token_cache.go
@@ -25,7 +25,6 @@ type TokenCacheOptions struct {
 	// flight, the next call to RetrieveBearerToken will block on that refresh
 	// to return.
 	RefreshBeforeExpires time.Duration
-	// TODO probably need RefreshBeforeExpires jitter factor
 
 	// The timeout the underlying TokenProvider's RetrieveBearerToken call must
 	// return within, or will be canceled. Defaults to 0, no timeout.
@@ -207,15 +206,3 @@ func (p *TokenCache) getCachedToken() (Token, bool) {
 
 	return *t, true
 }
-
-type suppressedContext struct {
-	context.Context
-}
-
-func (s *suppressedContext) Deadline() (deadline time.Time, ok bool) {
-	return time.Time{}, false
-}
-
-func (s *suppressedContext) Done() <-chan struct{} { return nil }
-
-func (s *suppressedContext) Err() error { return nil }

--- a/auth/bearer/token_cache_test.go
+++ b/auth/bearer/token_cache_test.go
@@ -159,7 +159,7 @@ func TestTokenCache_cancelled(t *testing.T) {
 	}))
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	cancel()
 
 	// Retrieve that will have its context canceled, should return error, but
 	// underlying provider retrieve will continue to block in the background.
@@ -181,7 +181,6 @@ func TestTokenCache_cancelled(t *testing.T) {
 	}()
 
 	<-providerRunning
-	cancel()
 
 	// Retrieve that will be added to existing single flight group, (or create
 	// a new group). Returning valid token.

--- a/auth/bearer/token_cache_test.go
+++ b/auth/bearer/token_cache_test.go
@@ -1,0 +1,513 @@
+package bearer
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var _ TokenProvider = (*TokenCache)(nil)
+
+func TestTokenCache_cache(t *testing.T) {
+	expectToken := Token{
+		Value: "abc123",
+	}
+
+	var retrieveCalled bool
+	provider := NewTokenCache(TokenProviderFunc(func(ctx context.Context) (Token, error) {
+		if retrieveCalled {
+			t.Fatalf("expect wrapped provider to be called once")
+		}
+		retrieveCalled = true
+		return expectToken, nil
+	}))
+
+	token, err := provider.RetrieveBearerToken(context.Background())
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if diff := cmp.Diff(expectToken, token); diff != "" {
+		t.Errorf("expect token match\n%s", diff)
+	}
+
+	for i := 0; i < 100; i++ {
+		token, err := provider.RetrieveBearerToken(context.Background())
+		if err != nil {
+			t.Fatalf("expect no error, got %v", err)
+		}
+		if diff := cmp.Diff(expectToken, token); diff != "" {
+			t.Errorf("expect token match\n%s", diff)
+		}
+	}
+}
+
+func TestTokenCache_cacheConcurrent(t *testing.T) {
+	expectToken := Token{
+		Value: "abc123",
+	}
+
+	var retrieveCalled bool
+	provider := NewTokenCache(TokenProviderFunc(func(ctx context.Context) (Token, error) {
+		if retrieveCalled {
+			t.Fatalf("expect wrapped provider to be called once")
+		}
+		retrieveCalled = true
+		return expectToken, nil
+	}))
+
+	token, err := provider.RetrieveBearerToken(context.Background())
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if diff := cmp.Diff(expectToken, token); diff != "" {
+		t.Errorf("expect token match\n%s", diff)
+	}
+
+	for i := 0; i < 100; i++ {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
+			token, err := provider.RetrieveBearerToken(context.Background())
+			if err != nil {
+				t.Fatalf("expect no error, got %v", err)
+			}
+			if diff := cmp.Diff(expectToken, token); diff != "" {
+				t.Errorf("expect token match\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestTokenCache_expired(t *testing.T) {
+	origTimeNow := timeNow
+	defer func() { timeNow = origTimeNow }()
+
+	timeNow = func() time.Time { return time.Time{} }
+
+	expectToken := Token{
+		Value:     "abc123",
+		CanExpire: true,
+		Expires:   timeNow().Add(10 * time.Minute),
+	}
+	refreshedToken := Token{
+		Value:     "refreshed-abc123",
+		CanExpire: true,
+		Expires:   timeNow().Add(30 * time.Minute),
+	}
+
+	retrievedCount := new(int32)
+	provider := NewTokenCache(TokenProviderFunc(func(ctx context.Context) (Token, error) {
+		if atomic.AddInt32(retrievedCount, 1) > 1 {
+			return refreshedToken, nil
+		}
+		return expectToken, nil
+	}))
+
+	for i := 0; i < 10; i++ {
+		token, err := provider.RetrieveBearerToken(context.Background())
+		if err != nil {
+			t.Fatalf("expect no error, got %v", err)
+		}
+		if diff := cmp.Diff(expectToken, token); diff != "" {
+			t.Errorf("expect token match\n%s", diff)
+		}
+	}
+	if e, a := 1, int(atomic.LoadInt32(retrievedCount)); e != a {
+		t.Errorf("expect %v provider calls, got %v", e, a)
+	}
+
+	// Offset time for refresh
+	timeNow = func() time.Time {
+		return (time.Time{}).Add(10 * time.Minute)
+	}
+
+	token, err := provider.RetrieveBearerToken(context.Background())
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if diff := cmp.Diff(refreshedToken, token); diff != "" {
+		t.Errorf("expect refreshed token match\n%s", diff)
+	}
+	if e, a := 2, int(atomic.LoadInt32(retrievedCount)); e != a {
+		t.Errorf("expect %v provider calls, got %v", e, a)
+	}
+}
+
+func TestTokenCache_cancelled(t *testing.T) {
+	providerRunning := make(chan struct{})
+	providerDone := make(chan struct{})
+	var onceClose sync.Once
+	provider := NewTokenCache(TokenProviderFunc(func(ctx context.Context) (Token, error) {
+		onceClose.Do(func() { close(providerRunning) })
+
+		// Provider running never receives context cancel so that if the first
+		// retrieve call is canceled all subsequent retrieve callers won't get
+		// canceled as well.
+		select {
+		case <-providerDone:
+			return Token{Value: "abc123"}, nil
+		case <-ctx.Done():
+			return Token{}, fmt.Errorf("unexpected context canceled, %w", ctx.Err())
+		}
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Retrieve that will have its context canceled, should return error, but
+	// underlying provider retrieve will continue to block in the background.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		_, err := provider.RetrieveBearerToken(ctx)
+		if err == nil {
+			t.Errorf("expect error, got none")
+
+		} else if e, a := "unexpected context canceled", err.Error(); strings.Contains(a, e) {
+			t.Errorf("unexpected context canceled received, %v", err)
+
+		} else if e, a := "context canceled", err.Error(); !strings.Contains(a, e) {
+			t.Errorf("expect %v error in, %v", e, a)
+		}
+	}()
+
+	<-providerRunning
+	cancel()
+
+	// Retrieve that will be added to existing single flight group, (or create
+	// a new group). Returning valid token.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		token, err := provider.RetrieveBearerToken(context.Background())
+		if err != nil {
+			t.Errorf("expect no error, got %v", err)
+		} else {
+			if diff := cmp.Diff(Token{Value: "abc123"}, token); diff != "" {
+				t.Errorf("expect token retrieve match\n%s", diff)
+			}
+		}
+	}()
+	close(providerDone)
+
+	wg.Wait()
+}
+
+func TestTokenCache_cancelledWithTimeout(t *testing.T) {
+	providerReady := make(chan struct{})
+	var providerReadCloseOnce sync.Once
+	provider := NewTokenCache(TokenProviderFunc(func(ctx context.Context) (Token, error) {
+		providerReadCloseOnce.Do(func() { close(providerReady) })
+
+		<-ctx.Done()
+		return Token{}, fmt.Errorf("token retrieve timeout, %w", ctx.Err())
+	}), func(o *TokenCacheOptions) {
+		o.RetrieveBearerTokenTimeout = time.Millisecond
+	})
+
+	var wg sync.WaitGroup
+
+	// Spin up additional retrieves that will be deduplicated and block on the
+	// original retrieve call.
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-providerReady
+
+			_, err := provider.RetrieveBearerToken(context.Background())
+			if err == nil {
+				t.Errorf("expect error, got none")
+
+			} else if e, a := "token retrieve timeout", err.Error(); !strings.Contains(a, e) {
+				t.Errorf("expect %v error in, %v", e, a)
+			}
+		}()
+	}
+
+	_, err := provider.RetrieveBearerToken(context.Background())
+	if err == nil {
+		t.Errorf("expect error, got none")
+
+	} else if e, a := "token retrieve timeout", err.Error(); !strings.Contains(a, e) {
+		t.Errorf("expect %v error in, %v", e, a)
+	}
+
+	wg.Wait()
+}
+
+func TestTokenCache_asyncRefresh(t *testing.T) {
+	origTimeNow := timeNow
+	defer func() { timeNow = origTimeNow }()
+
+	timeNow = func() time.Time { return time.Time{} }
+
+	expectToken := Token{
+		Value:     "abc123",
+		CanExpire: true,
+		Expires:   timeNow().Add(10 * time.Minute),
+	}
+	refreshedToken := Token{
+		Value:     "refreshed-abc123",
+		CanExpire: true,
+		Expires:   timeNow().Add(30 * time.Minute),
+	}
+
+	retrievedCount := new(int32)
+	provider := NewTokenCache(TokenProviderFunc(func(ctx context.Context) (Token, error) {
+		c := atomic.AddInt32(retrievedCount, 1)
+		switch {
+		case c == 1:
+			return expectToken, nil
+		case c > 1 && c < 5:
+			return Token{}, fmt.Errorf("some error")
+		case c == 5:
+			return refreshedToken, nil
+		default:
+			return Token{}, fmt.Errorf("unexpected error")
+		}
+	}), func(o *TokenCacheOptions) {
+		o.RefreshBeforeExpires = 5 * time.Minute
+	})
+
+	// 1: Initial retrieve to cache token
+	token, err := provider.RetrieveBearerToken(context.Background())
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if diff := cmp.Diff(expectToken, token); diff != "" {
+		t.Errorf("expect token match\n%s", diff)
+	}
+
+	// 2-5: Offset time for subsequent calls to retrieve to trigger asynchronous
+	// refreshes.
+	timeNow = func() time.Time {
+		return (time.Time{}).Add(6 * time.Minute)
+	}
+
+	for i := 0; i < 4; i++ {
+		token, err := provider.RetrieveBearerToken(context.Background())
+		if err != nil {
+			t.Fatalf("expect no error, got %v", err)
+		}
+		if diff := cmp.Diff(expectToken, token); diff != "" {
+			t.Errorf("expect token match\n%s", diff)
+		}
+	}
+	// Wait for all async refreshes to complete
+	testWaitAsyncRefreshDone(provider)
+
+	if c := int(atomic.LoadInt32(retrievedCount)); c < 2 || c > 5 {
+		t.Fatalf("expect async refresh to be called [2,5) times, got, %v", c)
+	}
+
+	// Ensure enough retrieves have been done to trigger refresh.
+	if c := atomic.LoadInt32(retrievedCount); c != 5 {
+		atomic.StoreInt32(retrievedCount, 4)
+		token, err := provider.RetrieveBearerToken(context.Background())
+		if err != nil {
+			t.Fatalf("expect no error, got %v", err)
+		}
+		if diff := cmp.Diff(expectToken, token); diff != "" {
+			t.Errorf("expect token match\n%s", diff)
+		}
+		testWaitAsyncRefreshDone(provider)
+	}
+
+	// Last async refresh will succeed and update cached token, expect the next
+	// call to get refreshed token.
+	token, err = provider.RetrieveBearerToken(context.Background())
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if diff := cmp.Diff(refreshedToken, token); diff != "" {
+		t.Errorf("expect refreshed token match\n%s", diff)
+	}
+}
+
+func TestTokenCache_asyncRefreshWithMinDelay(t *testing.T) {
+	origTimeNow := timeNow
+	defer func() { timeNow = origTimeNow }()
+
+	timeNow = func() time.Time { return time.Time{} }
+
+	expectToken := Token{
+		Value:     "abc123",
+		CanExpire: true,
+		Expires:   timeNow().Add(10 * time.Minute),
+	}
+	refreshedToken := Token{
+		Value:     "refreshed-abc123",
+		CanExpire: true,
+		Expires:   timeNow().Add(30 * time.Minute),
+	}
+
+	retrievedCount := new(int32)
+	provider := NewTokenCache(TokenProviderFunc(func(ctx context.Context) (Token, error) {
+		c := atomic.AddInt32(retrievedCount, 1)
+		switch {
+		case c == 1:
+			return expectToken, nil
+		case c > 1 && c < 5:
+			return Token{}, fmt.Errorf("some error")
+		case c == 5:
+			return refreshedToken, nil
+		default:
+			return Token{}, fmt.Errorf("unexpected error")
+		}
+	}), func(o *TokenCacheOptions) {
+		o.RefreshBeforeExpires = 5 * time.Minute
+		o.AsyncRefreshMinimumDelay = 30 * time.Second
+	})
+
+	// 1: Initial retrieve to cache token
+	token, err := provider.RetrieveBearerToken(context.Background())
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if diff := cmp.Diff(expectToken, token); diff != "" {
+		t.Errorf("expect token match\n%s", diff)
+	}
+
+	// 2-5: Offset time for subsequent calls to retrieve to trigger asynchronous
+	// refreshes.
+	timeNow = func() time.Time {
+		return (time.Time{}).Add(6 * time.Minute)
+	}
+
+	for i := 0; i < 4; i++ {
+		token, err := provider.RetrieveBearerToken(context.Background())
+		if err != nil {
+			t.Fatalf("expect no error, got %v", err)
+		}
+		if diff := cmp.Diff(expectToken, token); diff != "" {
+			t.Errorf("expect token match\n%s", diff)
+		}
+		// Wait for all async refreshes to complete ensure not deduped
+		testWaitAsyncRefreshDone(provider)
+	}
+
+	// Only a single refresh attempt is expected.
+	if e, a := 2, int(atomic.LoadInt32(retrievedCount)); e != a {
+		t.Fatalf("expect %v min async refresh, got %v", e, a)
+	}
+
+	// Move time forward to ensure another async refresh is triggered.
+	timeNow = func() time.Time { return (time.Time{}).Add(7 * time.Minute) }
+	// Make sure the next attempt refreshes the token
+	atomic.StoreInt32(retrievedCount, 4)
+
+	// Do async retrieve that will succeed refreshing in background.
+	token, err = provider.RetrieveBearerToken(context.Background())
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if diff := cmp.Diff(expectToken, token); diff != "" {
+		t.Errorf("expect token match\n%s", diff)
+	}
+	// Wait for all async refreshes to complete ensure not deduped
+	testWaitAsyncRefreshDone(provider)
+
+	// Last async refresh will succeed and update cached token, expect the next
+	// call to get refreshed token.
+	token, err = provider.RetrieveBearerToken(context.Background())
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if diff := cmp.Diff(refreshedToken, token); diff != "" {
+		t.Errorf("expect refreshed token match\n%s", diff)
+	}
+}
+
+func TestTokenCache_disableAsyncRefresh(t *testing.T) {
+	origTimeNow := timeNow
+	defer func() { timeNow = origTimeNow }()
+
+	timeNow = func() time.Time { return time.Time{} }
+
+	expectToken := Token{
+		Value:     "abc123",
+		CanExpire: true,
+		Expires:   timeNow().Add(10 * time.Minute),
+	}
+	refreshedToken := Token{
+		Value:     "refreshed-abc123",
+		CanExpire: true,
+		Expires:   timeNow().Add(30 * time.Minute),
+	}
+
+	retrievedCount := new(int32)
+	provider := NewTokenCache(TokenProviderFunc(func(ctx context.Context) (Token, error) {
+		c := atomic.AddInt32(retrievedCount, 1)
+		switch {
+		case c == 1:
+			return expectToken, nil
+		case c > 1 && c < 5:
+			return Token{}, fmt.Errorf("some error")
+		case c == 5:
+			return refreshedToken, nil
+		default:
+			return Token{}, fmt.Errorf("unexpected error")
+		}
+	}), func(o *TokenCacheOptions) {
+		o.RefreshBeforeExpires = 5 * time.Minute
+		o.DisableAsyncRefresh = true
+	})
+
+	// 1: Initial retrieve to cache token
+	token, err := provider.RetrieveBearerToken(context.Background())
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if diff := cmp.Diff(expectToken, token); diff != "" {
+		t.Errorf("expect token match\n%s", diff)
+	}
+
+	// Update time into refresh window before token expires
+	timeNow = func() time.Time {
+		return (time.Time{}).Add(6 * time.Minute)
+	}
+
+	for i := 0; i < 3; i++ {
+		_, err = provider.RetrieveBearerToken(context.Background())
+		if err == nil {
+			t.Fatalf("expect error, got none")
+		}
+		if e, a := "some error", err.Error(); !strings.Contains(a, e) {
+			t.Fatalf("expect %v error in %v", e, a)
+		}
+		if e, a := i+2, int(atomic.LoadInt32(retrievedCount)); e != a {
+			t.Fatalf("expect %v retrieveCount, got %v", e, a)
+		}
+	}
+	if e, a := 4, int(atomic.LoadInt32(retrievedCount)); e != a {
+		t.Fatalf("expect %v retrieveCount, got %v", e, a)
+	}
+
+	// Last refresh will succeed and update cached token, expect the next
+	// call to get refreshed token.
+	token, err = provider.RetrieveBearerToken(context.Background())
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if diff := cmp.Diff(refreshedToken, token); diff != "" {
+		t.Errorf("expect refreshed token match\n%s", diff)
+	}
+}
+
+func testWaitAsyncRefreshDone(provider *TokenCache) {
+	asyncResCh := provider.sfGroup.DoChan("async-refresh", func() (interface{}, error) {
+		return nil, nil
+	})
+	<-asyncResCh
+}

--- a/codegen/smithy-go-codegen-test/model/main.smithy
+++ b/codegen/smithy-go-codegen-test/model/main.smithy
@@ -6,6 +6,7 @@ use smithy.test#httpResponseTests
 use smithy.waiters#waitable
 
 /// Provides weather forecasts.
+@httpBearerAuth
 @fakeProtocol
 @paginated(inputToken: "nextToken", outputToken: "nextToken", pageSize: "pageSize")
 service Weather {

--- a/codegen/smithy-go-codegen-test/smithy-build.json
+++ b/codegen/smithy-go-codegen-test/smithy-build.json
@@ -3,7 +3,7 @@
     "plugins": {
         "go-codegen": {
             "service": "example.weather#Weather",
-            "module": "weather",
+            "module": "github.com/aws/smithy-go/internal/tests/service/weather",
             "moduleVersion": "0.0.1"
         }
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -60,6 +60,7 @@ public final class SmithyGoDependency {
     public static final GoDependency SMITHY_DOCUMENT = smithy("document", "smithydocument");
     public static final GoDependency SMITHY_DOCUMENT_JSON = smithy("document/json", "smithydocumentjson");
     public static final GoDependency SMITHY_SYNC = smithy("sync", "smithysync");
+    public static final GoDependency SMITHY_AUTH_BEARER = smithy("auth/bearer");
 
     public static final GoDependency GO_CMP = goCmp("cmp");
     public static final GoDependency GO_CMP_OPTIONS = goCmp("cmp/cmpopts");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/auth/HttpBearerAuth.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/auth/HttpBearerAuth.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.integration.auth;
+
+import java.util.List;
+import java.util.Map;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.go.codegen.GoDelegator;
+import software.amazon.smithy.go.codegen.GoSettings;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.SymbolUtils;
+import software.amazon.smithy.go.codegen.integration.ConfigField;
+import software.amazon.smithy.go.codegen.integration.ConfigFieldResolver;
+import software.amazon.smithy.go.codegen.integration.GoIntegration;
+import software.amazon.smithy.go.codegen.integration.MiddlewareRegistrar;
+import software.amazon.smithy.go.codegen.integration.RuntimeClientPlugin;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.ServiceIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.HttpBearerAuthTrait;
+import software.amazon.smithy.model.traits.OptionalAuthTrait;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.utils.ListUtils;
+
+/**
+ * Integration to add support for httpBearerAuth authentication scheme to an API client.
+ */
+public class HttpBearerAuth implements GoIntegration {
+
+    public static final String TOKEN_PROVIDER_OPTION_NAME = "BearerAuthTokenProvider";
+    private static final String SIGNER_OPTION_NAME = "BearerAuthSigner";
+    private static final String NEW_DEFAULT_SIGNER_NAME = "newDefault" + SIGNER_OPTION_NAME;
+    private static final String SIGNER_RESOLVER_NAME = "resolve" + SIGNER_OPTION_NAME;
+    private static final String REGISTER_MIDDLEWARE_NAME = "add";
+
+    @Override
+    public void writeAdditionalFiles(
+            GoSettings settings,
+            Model model,
+            SymbolProvider symbolProvider,
+            GoDelegator goDelegator
+    ) {
+        var service = settings.getService(model);
+        if (!isSupportedAuthentication(model, service)) {
+            return;
+        }
+
+        goDelegator.useShapeWriter(service, (writer) -> {
+            writeMiddlewareRegister(writer);
+            writeConfigFieldResolver(writer);
+            writeNewSignerFunc(writer);
+        });
+    }
+
+    private void writeMiddlewareRegister(GoWriter writer) {
+        writer.pushState();
+
+        writer.putContext("funcName", REGISTER_MIDDLEWARE_NAME);
+        writer.putContext("stack", SymbolUtils.createValueSymbolBuilder("Stack",
+                SmithyGoDependency.SMITHY_MIDDLEWARE).build());
+        writer.putContext("addMiddleware", SymbolUtils.createValueSymbolBuilder("AddAuthenticationMiddleware",
+                SmithyGoDependency.SMITHY_AUTH_BEARER).build());
+        writer.putContext("signerOption", SIGNER_OPTION_NAME);
+        writer.putContext("providerOption", TOKEN_PROVIDER_OPTION_NAME);
+
+        writer.write("""
+                func $funcName:L(stack *$stack:T, o Options) error {
+                    return $addMiddleware:T(stack, o.$signerOption:L, o.$providerOption:L)
+                }
+                """);
+
+        writer.popState();
+    }
+
+    private void writeConfigFieldResolver(GoWriter writer) {
+        writer.pushState();
+
+        writer.putContext("funcName", SIGNER_RESOLVER_NAME);
+        writer.putContext("signer", SymbolUtils.createValueSymbolBuilder("TokenProvider",
+                SmithyGoDependency.SMITHY_AUTH_BEARER).build());
+
+        writer.putContext("newDefaultSigner", NEW_DEFAULT_SIGNER_NAME);
+
+        writer.write("""
+                func $funcName:L(o *Options) {
+                    if o.$signerOption:L != nil {
+                        return
+                    }
+                    o.$signerOption:L = $newDefaultSigner(*o)
+                }
+                """);
+
+        writer.popState();
+    }
+
+    private void writeNewSignerFunc(GoWriter writer) {
+        writer.pushState();
+
+        writer.putContext("funcName", NEW_DEFAULT_SIGNER_NAME);
+        writer.putContext("signer", SymbolUtils.createValueSymbolBuilder("TokenProvider",
+                SmithyGoDependency.SMITHY_AUTH_BEARER).build());
+
+        // TODO this is HTTP specific, should be based on protocol/transport of API.
+        writer.putContext("newDefaultSigner", SymbolUtils.createValueSymbolBuilder("NewSignHTTPSMessage",
+                SmithyGoDependency.SMITHY_AUTH_BEARER).build());
+
+        writer.write("""
+                func $funcName:L(o Options) *$signer:T {
+                    return $newDefaultSigner:T()
+                }
+                """);
+
+        writer.popState();
+    }
+
+    @Override
+    public List<RuntimeClientPlugin> getClientPlugins() {
+        return ListUtils.of(
+                RuntimeClientPlugin.builder()
+                        .servicePredicate(HttpBearerAuth::isSupportedAuthentication)
+                        .addConfigField(ConfigField.builder()
+                                .name(TOKEN_PROVIDER_OPTION_NAME)
+                                .type(SymbolUtils.createValueSymbolBuilder("TokenProvider",
+                                        SmithyGoDependency.SMITHY_AUTH_BEARER).build())
+                                .documentation("Bearer token value provider")
+                                .build())
+                        .build(),
+                RuntimeClientPlugin.builder()
+                        .servicePredicate(HttpBearerAuth::isSupportedAuthentication)
+                        .addConfigField(ConfigField.builder()
+                                .name(SIGNER_OPTION_NAME)
+                                .type(SymbolUtils.createValueSymbolBuilder("Signer",
+                                        SmithyGoDependency.SMITHY_AUTH_BEARER).build())
+                                .documentation("Signer for authenticating requests with bearer auth")
+                                .build())
+                        .addConfigFieldResolver(ConfigFieldResolver.builder()
+                                .location(ConfigFieldResolver.Location.CLIENT)
+                                .target(ConfigFieldResolver.Target.INITIALIZATION)
+                                .resolver(SymbolUtils.createValueSymbolBuilder(SIGNER_RESOLVER_NAME).build())
+                                .build())
+                        .build(),
+
+                // TODO this is incorrect for an API client/operation that supports multiple auth schemes.
+                RuntimeClientPlugin.builder()
+                        .operationPredicate(HttpBearerAuth::hasBearerAuthScheme)
+                        .registerMiddleware(MiddlewareRegistrar.builder()
+                                .resolvedFunction(SymbolUtils.createValueSymbolBuilder(
+                                       REGISTER_MIDDLEWARE_NAME).build())
+                                .useClientOptions()
+                                .build())
+                        .build()
+        );
+    }
+
+    /**
+     * Returns if the service has the httpBearerAuth trait.
+     *
+     * @param model   model definition
+     * @param service service shape for the API
+     * @return if the httpBearerAuth trait is used by the service
+     */
+    public static boolean isSupportedAuthentication(Model model, ServiceShape service) {
+        return ServiceIndex.of(model).getAuthSchemes(service).values().stream().anyMatch(trait -> trait.getClass()
+                .equals(HttpBearerAuthTrait.class));
+
+    }
+
+    /**
+     * Returns if the service and operation support the httpBearerAuthTrait.
+     *
+     * @param model     model definition
+     * @param service   service shape for the API
+     * @param operation operation shape
+     * @return if the service and operation support the httpBearerAuthTrait
+     */
+    public static boolean hasBearerAuthScheme(Model model, ServiceShape service, OperationShape operation) {
+        Map<ShapeId, Trait> auth = ServiceIndex.of(model).getEffectiveAuthSchemes(service.getId(), operation.getId());
+        return auth.containsKey(HttpBearerAuthTrait.ID) && !operation.hasTrait(OptionalAuthTrait.class);
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.go.codegen.integration.GoIntegration
+++ b/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.go.codegen.integration.GoIntegration
@@ -1,3 +1,4 @@
+software.amazon.smithy.go.codegen.integration.auth.HttpBearerAuth
 software.amazon.smithy.go.codegen.integration.ValidationGenerator
 software.amazon.smithy.go.codegen.integration.IdempotencyTokenMiddlewareGenerator
 software.amazon.smithy.go.codegen.integration.AddChecksumRequiredMiddleware

--- a/context/suppress_expired.go
+++ b/context/suppress_expired.go
@@ -1,0 +1,81 @@
+package context
+
+import "context"
+
+// valueOnlyContext provides a utility to preserve only the values of a
+// Context. Suppressing any cancellation or deadline on that context being
+// propagated downstream of this value.
+//
+// If preserveExpiredValues is false (default), and the valueCtx is canceled,
+// calls to lookup values with the Values method, will always return nil. Setting
+// preserveExpiredValues to true, will allow the valueOnlyContext to lookup
+// values in valueCtx even if valueCtx is canceled.
+//
+// Based on the Go standard libraries net/lookup.go onlyValuesCtx utility.
+// https://github.com/golang/go/blob/da2773fe3e2f6106634673a38dc3a6eb875fe7d8/src/net/lookup.go
+type valueOnlyContext struct {
+	context.Context
+
+	preserveExpiredValues bool
+	valuesCtx             context.Context
+}
+
+var _ context.Context = (*valueOnlyContext)(nil)
+
+// Value looks up the key, returning its value. If configured to not preserve
+// values of expired context, and the wrapping context is canceled, nil will be
+// returned.
+func (v *valueOnlyContext) Value(key interface{}) interface{} {
+	if !v.preserveExpiredValues {
+		select {
+		case <-v.valuesCtx.Done():
+			return nil
+		default:
+		}
+	}
+
+	return v.valuesCtx.Value(key)
+}
+
+// WithSuppressCancel wraps the Context value, suppressing its deadline and
+// cancellation events being propagated downstream to consumer of the returned
+// context.
+//
+// By default the wrapped Context's Values are available downstream until the
+// wrapped Context is canceled. Once the wrapped Context is canceled, Values
+// method called on the context return will no longer lookup any key. As they
+// are now considered expired.
+//
+// To override this behavior, use WithPreserveExpiredValues on the Context
+// before it is wrapped by WithSuppressCancel. This will make the Context
+// returned by WithSuppressCancel allow lookup of expired values.
+func WithSuppressCancel(ctx context.Context) context.Context {
+	return &valueOnlyContext{
+		Context:   context.Background(),
+		valuesCtx: ctx,
+
+		preserveExpiredValues: GetPreserveExpiredValues(ctx),
+	}
+}
+
+type preserveExpiredValuesKey struct{}
+
+// WithPreserveExpiredValues adds a Value to the Context if expired values
+// should be preserved, and looked up by a Context wrapped by
+// WithSuppressCancel.
+//
+// WithPreserveExpiredValues must be added as a value to a Context, before that
+// Context is wrapped by WithSuppressCancel
+func WithPreserveExpiredValues(ctx context.Context, enable bool) context.Context {
+	return context.WithValue(ctx, preserveExpiredValuesKey{}, enable)
+}
+
+// GetPreserveExpiredValues looks up, and returns the PreserveExpressValues
+// value in the context. Returning true if enabled, false otherwise.
+func GetPreserveExpiredValues(ctx context.Context) bool {
+	v := ctx.Value(preserveExpiredValuesKey{})
+	if v != nil {
+		return v.(bool)
+	}
+	return false
+}

--- a/internal/sync/singleflight/LICENSE
+++ b/internal/sync/singleflight/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/internal/sync/singleflight/docs.go
+++ b/internal/sync/singleflight/docs.go
@@ -1,0 +1,8 @@
+// Package singleflight provides a duplicate function call suppression
+// mechanism. This package is a fork of the Go golang.org/x/sync/singleflight
+// package. The package is forked, because the package a part of the unstable
+// and unversioned golang.org/x/sync module.
+//
+// https://github.com/golang/sync/tree/67f06af15bc961c363a7260195bcd53487529a21/singleflight
+
+package singleflight

--- a/internal/sync/singleflight/singleflight.go
+++ b/internal/sync/singleflight/singleflight.go
@@ -1,0 +1,210 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package singleflight
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"sync"
+)
+
+// errGoexit indicates the runtime.Goexit was called in
+// the user given function.
+var errGoexit = errors.New("runtime.Goexit was called")
+
+// A panicError is an arbitrary value recovered from a panic
+// with the stack trace during the execution of given function.
+type panicError struct {
+	value interface{}
+	stack []byte
+}
+
+// Error implements error interface.
+func (p *panicError) Error() string {
+	return fmt.Sprintf("%v\n\n%s", p.value, p.stack)
+}
+
+func newPanicError(v interface{}) error {
+	stack := debug.Stack()
+
+	// The first line of the stack trace is of the form "goroutine N [status]:"
+	// but by the time the panic reaches Do the goroutine may no longer exist
+	// and its status will have changed. Trim out the misleading line.
+	if line := bytes.IndexByte(stack[:], '\n'); line >= 0 {
+		stack = stack[line+1:]
+	}
+	return &panicError{value: v, stack: stack}
+}
+
+// call is an in-flight or completed singleflight.Do call
+type call struct {
+	wg sync.WaitGroup
+
+	// These fields are written once before the WaitGroup is done
+	// and are only read after the WaitGroup is done.
+	val interface{}
+	err error
+
+	// forgotten indicates whether Forget was called with this call's key
+	// while the call was still in flight.
+	forgotten bool
+
+	// These fields are read and written with the singleflight
+	// mutex held before the WaitGroup is done, and are read but
+	// not written after the WaitGroup is done.
+	dups  int
+	chans []chan<- Result
+}
+
+// Group represents a class of work and forms a namespace in
+// which units of work can be executed with duplicate suppression.
+type Group struct {
+	mu sync.Mutex       // protects m
+	m  map[string]*call // lazily initialized
+}
+
+// Result holds the results of Do, so they can be passed
+// on a channel.
+type Result struct {
+	Val    interface{}
+	Err    error
+	Shared bool
+}
+
+// Do executes and returns the results of the given function, making
+// sure that only one execution is in-flight for a given key at a
+// time. If a duplicate comes in, the duplicate caller waits for the
+// original to complete and receives the same results.
+// The return value shared indicates whether v was given to multiple callers.
+func (g *Group) Do(key string, fn func() (interface{}, error)) (v interface{}, err error, shared bool) {
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		g.mu.Unlock()
+		c.wg.Wait()
+
+		if e, ok := c.err.(*panicError); ok {
+			panic(e)
+		} else if c.err == errGoexit {
+			runtime.Goexit()
+		}
+		return c.val, c.err, true
+	}
+	c := new(call)
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	g.doCall(c, key, fn)
+	return c.val, c.err, c.dups > 0
+}
+
+// DoChan is like Do but returns a channel that will receive the
+// results when they are ready.
+//
+// The returned channel will not be closed.
+func (g *Group) DoChan(key string, fn func() (interface{}, error)) <-chan Result {
+	ch := make(chan Result, 1)
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		c.chans = append(c.chans, ch)
+		g.mu.Unlock()
+		return ch
+	}
+	c := &call{chans: []chan<- Result{ch}}
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	go g.doCall(c, key, fn)
+
+	return ch
+}
+
+// doCall handles the single call for a key.
+func (g *Group) doCall(c *call, key string, fn func() (interface{}, error)) {
+	normalReturn := false
+	recovered := false
+
+	// use double-defer to distinguish panic from runtime.Goexit,
+	// more details see https://golang.org/cl/134395
+	defer func() {
+		// the given function invoked runtime.Goexit
+		if !normalReturn && !recovered {
+			c.err = errGoexit
+		}
+
+		c.wg.Done()
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		if !c.forgotten {
+			delete(g.m, key)
+		}
+
+		if e, ok := c.err.(*panicError); ok {
+			// In order to prevent the waiting channels from being blocked forever,
+			// needs to ensure that this panic cannot be recovered.
+			if len(c.chans) > 0 {
+				go panic(e)
+				select {} // Keep this goroutine around so that it will appear in the crash dump.
+			} else {
+				panic(e)
+			}
+		} else if c.err == errGoexit {
+			// Already in the process of goexit, no need to call again
+		} else {
+			// Normal return
+			for _, ch := range c.chans {
+				ch <- Result{c.val, c.err, c.dups > 0}
+			}
+		}
+	}()
+
+	func() {
+		defer func() {
+			if !normalReturn {
+				// Ideally, we would wait to take a stack trace until we've determined
+				// whether this is a panic or a runtime.Goexit.
+				//
+				// Unfortunately, the only way we can distinguish the two is to see
+				// whether the recover stopped the goroutine from terminating, and by
+				// the time we know that, the part of the stack trace relevant to the
+				// panic has been discarded.
+				if r := recover(); r != nil {
+					c.err = newPanicError(r)
+				}
+			}
+		}()
+
+		c.val, c.err = fn()
+		normalReturn = true
+	}()
+
+	if !normalReturn {
+		recovered = true
+	}
+}
+
+// Forget tells the singleflight to forget about a key.  Future calls
+// to Do for this key will call the function rather than waiting for
+// an earlier call to complete.
+func (g *Group) Forget(key string) {
+	g.mu.Lock()
+	if c, ok := g.m[key]; ok {
+		c.forgotten = true
+	}
+	delete(g.m, key)
+	g.mu.Unlock()
+}

--- a/internal/sync/singleflight/singleflight_test.go
+++ b/internal/sync/singleflight/singleflight_test.go
@@ -1,0 +1,320 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package singleflight
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDo(t *testing.T) {
+	var g Group
+	v, err, _ := g.Do("key", func() (interface{}, error) {
+		return "bar", nil
+	})
+	if got, want := fmt.Sprintf("%v (%T)", v, v), "bar (string)"; got != want {
+		t.Errorf("Do = %v; want %v", got, want)
+	}
+	if err != nil {
+		t.Errorf("Do error = %v", err)
+	}
+}
+
+func TestDoErr(t *testing.T) {
+	var g Group
+	someErr := errors.New("Some error")
+	v, err, _ := g.Do("key", func() (interface{}, error) {
+		return nil, someErr
+	})
+	if err != someErr {
+		t.Errorf("Do error = %v; want someErr %v", err, someErr)
+	}
+	if v != nil {
+		t.Errorf("unexpected non-nil value %#v", v)
+	}
+}
+
+func TestDoDupSuppress(t *testing.T) {
+	var g Group
+	var wg1, wg2 sync.WaitGroup
+	c := make(chan string, 1)
+	var calls int32
+	fn := func() (interface{}, error) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			// First invocation.
+			wg1.Done()
+		}
+		v := <-c
+		c <- v // pump; make available for any future calls
+
+		time.Sleep(10 * time.Millisecond) // let more goroutines enter Do
+
+		return v, nil
+	}
+
+	const n = 10
+	wg1.Add(1)
+	for i := 0; i < n; i++ {
+		wg1.Add(1)
+		wg2.Add(1)
+		go func() {
+			defer wg2.Done()
+			wg1.Done()
+			v, err, _ := g.Do("key", fn)
+			if err != nil {
+				t.Errorf("Do error: %v", err)
+				return
+			}
+			if s, _ := v.(string); s != "bar" {
+				t.Errorf("Do = %T %v; want %q", v, v, "bar")
+			}
+		}()
+	}
+	wg1.Wait()
+	// At least one goroutine is in fn now and all of them have at
+	// least reached the line before the Do.
+	c <- "bar"
+	wg2.Wait()
+	if got := atomic.LoadInt32(&calls); got <= 0 || got >= n {
+		t.Errorf("number of calls = %d; want over 0 and less than %d", got, n)
+	}
+}
+
+// Test that singleflight behaves correctly after Forget called.
+// See https://github.com/golang/go/issues/31420
+func TestForget(t *testing.T) {
+	var g Group
+
+	var (
+		firstStarted  = make(chan struct{})
+		unblockFirst  = make(chan struct{})
+		firstFinished = make(chan struct{})
+	)
+
+	go func() {
+		g.Do("key", func() (i interface{}, e error) {
+			close(firstStarted)
+			<-unblockFirst
+			close(firstFinished)
+			return
+		})
+	}()
+	<-firstStarted
+	g.Forget("key")
+
+	unblockSecond := make(chan struct{})
+	secondResult := g.DoChan("key", func() (i interface{}, e error) {
+		<-unblockSecond
+		return 2, nil
+	})
+
+	close(unblockFirst)
+	<-firstFinished
+
+	thirdResult := g.DoChan("key", func() (i interface{}, e error) {
+		return 3, nil
+	})
+
+	close(unblockSecond)
+	<-secondResult
+	r := <-thirdResult
+	if r.Val != 2 {
+		t.Errorf("We should receive result produced by second call, expected: 2, got %d", r.Val)
+	}
+}
+
+func TestDoChan(t *testing.T) {
+	var g Group
+	ch := g.DoChan("key", func() (interface{}, error) {
+		return "bar", nil
+	})
+
+	res := <-ch
+	v := res.Val
+	err := res.Err
+	if got, want := fmt.Sprintf("%v (%T)", v, v), "bar (string)"; got != want {
+		t.Errorf("Do = %v; want %v", got, want)
+	}
+	if err != nil {
+		t.Errorf("Do error = %v", err)
+	}
+}
+
+// Test singleflight behaves correctly after Do panic.
+// See https://github.com/golang/go/issues/41133
+func TestPanicDo(t *testing.T) {
+	var g Group
+	fn := func() (interface{}, error) {
+		panic("invalid memory address or nil pointer dereference")
+	}
+
+	const n = 5
+	waited := int32(n)
+	panicCount := int32(0)
+	done := make(chan struct{})
+	for i := 0; i < n; i++ {
+		go func() {
+			defer func() {
+				if err := recover(); err != nil {
+					t.Logf("Got panic: %v\n%s", err, debug.Stack())
+					atomic.AddInt32(&panicCount, 1)
+				}
+
+				if atomic.AddInt32(&waited, -1) == 0 {
+					close(done)
+				}
+			}()
+
+			g.Do("key", fn)
+		}()
+	}
+
+	select {
+	case <-done:
+		if panicCount != n {
+			t.Errorf("Expect %d panic, but got %d", n, panicCount)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("Do hangs")
+	}
+}
+
+func TestGoexitDo(t *testing.T) {
+	var g Group
+	fn := func() (interface{}, error) {
+		runtime.Goexit()
+		return nil, nil
+	}
+
+	const n = 5
+	waited := int32(n)
+	done := make(chan struct{})
+	for i := 0; i < n; i++ {
+		go func() {
+			var err error
+			defer func() {
+				if err != nil {
+					t.Errorf("Error should be nil, but got: %v", err)
+				}
+				if atomic.AddInt32(&waited, -1) == 0 {
+					close(done)
+				}
+			}()
+			_, err, _ = g.Do("key", fn)
+		}()
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatalf("Do hangs")
+	}
+}
+
+func TestPanicDoChan(t *testing.T) {
+	if runtime.GOOS == "js" {
+		t.Skipf("js does not support exec")
+	}
+
+	if os.Getenv("TEST_PANIC_DOCHAN") != "" {
+		defer func() {
+			recover()
+		}()
+
+		g := new(Group)
+		ch := g.DoChan("", func() (interface{}, error) {
+			panic("Panicking in DoChan")
+		})
+		<-ch
+		t.Fatalf("DoChan unexpectedly returned")
+	}
+
+	t.Parallel()
+
+	cmd := exec.Command(os.Args[0], "-test.run="+t.Name(), "-test.v")
+	cmd.Env = append(os.Environ(), "TEST_PANIC_DOCHAN=1")
+	out := new(bytes.Buffer)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := cmd.Wait()
+	t.Logf("%s:\n%s", strings.Join(cmd.Args, " "), out)
+	if err == nil {
+		t.Errorf("Test subprocess passed; want a crash due to panic in DoChan")
+	}
+	if bytes.Contains(out.Bytes(), []byte("DoChan unexpectedly")) {
+		t.Errorf("Test subprocess failed with an unexpected failure mode.")
+	}
+	if !bytes.Contains(out.Bytes(), []byte("Panicking in DoChan")) {
+		t.Errorf("Test subprocess failed, but the crash isn't caused by panicking in DoChan")
+	}
+}
+
+func TestPanicDoSharedByDoChan(t *testing.T) {
+	if runtime.GOOS == "js" {
+		t.Skipf("js does not support exec")
+	}
+
+	if os.Getenv("TEST_PANIC_DOCHAN") != "" {
+		blocked := make(chan struct{})
+		unblock := make(chan struct{})
+
+		g := new(Group)
+		go func() {
+			defer func() {
+				recover()
+			}()
+			g.Do("", func() (interface{}, error) {
+				close(blocked)
+				<-unblock
+				panic("Panicking in Do")
+			})
+		}()
+
+		<-blocked
+		ch := g.DoChan("", func() (interface{}, error) {
+			panic("DoChan unexpectedly executed callback")
+		})
+		close(unblock)
+		<-ch
+		t.Fatalf("DoChan unexpectedly returned")
+	}
+
+	t.Parallel()
+
+	cmd := exec.Command(os.Args[0], "-test.run="+t.Name(), "-test.v")
+	cmd.Env = append(os.Environ(), "TEST_PANIC_DOCHAN=1")
+	out := new(bytes.Buffer)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := cmd.Wait()
+	t.Logf("%s:\n%s", strings.Join(cmd.Args, " "), out)
+	if err == nil {
+		t.Errorf("Test subprocess passed; want a crash due to panic in Do shared by DoChan")
+	}
+	if bytes.Contains(out.Bytes(), []byte("DoChan unexpectedly")) {
+		t.Errorf("Test subprocess failed with an unexpected failure mode.")
+	}
+	if !bytes.Contains(out.Bytes(), []byte("Panicking in Do")) {
+		t.Errorf("Test subprocess failed, but the crash isn't caused by panicking in Do")
+	}
+}

--- a/transport/http/request.go
+++ b/transport/http/request.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 
 	iointernal "github.com/aws/smithy-go/transport/http/internal/io"
 )
@@ -31,6 +32,14 @@ func NewStackRequest() interface{} {
 			ContentLength: -1, // default to unknown length
 		},
 	}
+}
+
+// IsHTTPS returns if the request is HTTPS. Returns false if no endpoint URL is set.
+func (r *Request) IsHTTPS() bool {
+	if r.URL == nil {
+		return false
+	}
+	return strings.EqualFold(r.URL.Scheme, "https")
 }
 
 // Clone returns a deep copy of the Request for the new context. A reference to


### PR DESCRIPTION
Adds support for the [Smithy httpBearerAuth](https://awslabs.github.io/smithy/1.0/spec/core/auth-traits.html#httpbearerauth-trait) authentication trait to smithy-go. This allows the SDK to support the bearer authentication flow for API operations decorated with `httpBearerAuth`. An API client will need to be provided with its own `bearer.TokenProvider` implementation or use the `bearer.StaticTokenProvider` implementation.