### PR TITLE
Split CI unit tests into supported and deprecated Go version stages

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   unit-tests:
-    name: Test SDK
+    name: SDK Unit Tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: [1.17, 1.16, 1.15]
+        go-version: [1.18, 1.17]
     steps:
     - uses: actions/checkout@v2
 
@@ -25,3 +25,21 @@ jobs:
     - name: Test
       run: go test -v ./...
 
+  deprecated-unit-tests:
+    needs: unit-tests
+    name: Deprecated Go version SDK Unit Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version: [1.16, 1.15]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Test
+      run: go test -v ./...


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Splits the GitHub Action CI unit tests for Go into two different sections, version supported by Go, and deprecated. This allows the unit tests to fail faster on cross version issues, and separate deprecated Go versions into a separate group.

Related to: https://github.com/aws/aws-sdk-go-v2/pull/1738/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
