### PR TITLE
codegen: Update codegen to escape ErrorMessage API error member

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -117,6 +117,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         // Reserved words that only apply to error members.
         ReservedWords reservedErrorMembers = new ReservedWordsBuilder()
                 .put("ErrorCode", "ErrorCode_")
+                .put("ErrorMessage", "ErrorMessage_")
                 .put("ErrorFault", "ErrorFault_")
                 .put("Unwrap", "Unwrap_")
                 .put("Error", "Error_")


### PR DESCRIPTION

*Issue #, if available:*
n/a

*Description of changes:*
Updates the SDK's code generation of modeled API error members to escape ErrorMessage since its a reserved word and used as a generated method.

Any API model that already had an API error shaped modeled with an `ErrorMessage` member would of failed to compile due to the method generated on the struct with the same name.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
