### PR TITLE
Add jsonName and json struct tag support

### DIFF
--- a/codegen/smithy-go-codegen-test/model/main.smithy
+++ b/codegen/smithy-go-codegen-test/model/main.smithy
@@ -159,6 +159,7 @@ structure GetCityInput {
     // has to be marked as required.
     @required
     @httpLabel
+    @jsonName("city-id")
     cityId: CityId,
 }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
@@ -25,6 +25,7 @@ import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.JsonNameTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SetUtils;
@@ -113,7 +114,17 @@ final class StructureGenerator implements Runnable {
                                 .orElse(memberSymbol);
                     }
 
-                    writer.write("$L $P", memberName, memberSymbol);
+                    String jsonTag = "";
+                    if (member.hasTrait(JsonNameTrait.ID)) {
+                        jsonTag = member.getMemberTrait(model, JsonNameTrait.class).get().getValue();
+                    }
+
+                    if (!jsonTag.isEmpty()) {
+                        writer.write("$L $P `json:\"$L\"`", memberName, memberSymbol, jsonTag);
+                    } else {
+                        writer.write("$L $P", memberName, memberSymbol);
+                    }
+
                 });
 
         runnable.run();


### PR DESCRIPTION
*Issue #326, if available:*

*Description of changes:*

If you specify `jsonName("somevalue")` trait in your smithy model, then assume you want a json struct tag.

I think that's the most intuitive approach to take this but definitely open to other ideas. Something like you have to specify  in `smithy-build.json` some value such as `useJsonStructTag: true`. But may be more work for not much reward.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
