### PR TITLE
Dynamo putitem escaping

### DIFF
--- a/.changelog/461d165a25e346669f076407175b6bd5.json
+++ b/.changelog/461d165a25e346669f076407175b6bd5.json
@@ -1,0 +1,8 @@
+{
+    "id": "461d165a-25e3-4666-9f07-6407175b6bd5",
+    "type": "bugfix",
+    "description": "Fixes a bug where JSON object keys were not escaped.",
+    "modules": [
+        "."
+    ]
+}

--- a/encoding/json/escape_test.go
+++ b/encoding/json/escape_test.go
@@ -23,16 +23,16 @@ func TestEscapeStringBytes(t *testing.T) {
 			input:    []byte(`hello\\world`),
 		},
 		"new line": {
-			expected: `"foo\\nbar"`,
-			input:    []byte(`foo\nbar`),
+			expected: `"foo\nbar"`,
+			input:    []byte("foo\nbar"),
 		},
 		"carriage return": {
-			expected: `"foo\\rbar"`,
-			input:    []byte(`foo\rbar`),
+			expected: `"foo\rbar"`,
+			input:    []byte("foo\rbar"),
 		},
 		"tab": {
-			expected: `"foo\\tbar"`,
-			input:    []byte(`foo\tbar`),
+			expected: `"foo\tbar"`,
+			input:    []byte("foo\tbar"),
 		},
 	}
 	for name, c := range cases {

--- a/encoding/json/escape_test.go
+++ b/encoding/json/escape_test.go
@@ -1,0 +1,21 @@
+package json
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEscapeStringBytes(t *testing.T) {
+	jsonEncoder := NewEncoder()
+	object := jsonEncoder.Object()
+
+	object.Key("foo\"").String("bar")
+	object.Key("faz").String("baz")
+	object.Close()
+
+	expected := []byte(`{"foo\"":"bar","faz":"baz"}`)
+	actual := object.w.Bytes()
+	if bytes.Compare(expected, actual) != 0 {
+		t.Errorf("expected %+q, but got %+q", expected, actual)
+	}
+}

--- a/encoding/json/object.go
+++ b/encoding/json/object.go
@@ -17,9 +17,7 @@ func newObject(w *bytes.Buffer, scratch *[]byte) *Object {
 }
 
 func (o *Object) writeKey(key string) {
-	o.w.WriteRune(quote)
-	o.w.Write([]byte(key))
-	o.w.WriteRune(quote)
+	escapeStringBytes(o.w, []byte(key))
 	o.w.WriteRune(colon)
 }
 

--- a/encoding/json/object_test.go
+++ b/encoding/json/object_test.go
@@ -19,3 +19,18 @@ func TestObject(t *testing.T) {
 		t.Errorf("expected %+q, but got %+q", e, a)
 	}
 }
+
+func TestObjectEscapeKeys(t *testing.T) {
+	buffer := bytes.NewBuffer(nil)
+	scratch := make([]byte, 64)
+
+	object := newObject(buffer, &scratch)
+	object.Key("foo\"").String("bar")
+	object.Key("faz").String("baz")
+	object.Close()
+
+	e := []byte(`{"foo\"":"bar","faz":"baz"}`)
+	if a := buffer.Bytes(); bytes.Compare(e, a) != 0 {
+		t.Errorf("expected %+q, but got %+q", e, a)
+	}
+}

--- a/encoding/json/object_test.go
+++ b/encoding/json/object_test.go
@@ -7,9 +7,9 @@ import (
 
 func TestObject(t *testing.T) {
 	buffer := bytes.NewBuffer(nil)
-	scatch := make([]byte, 64)
+	scratch := make([]byte, 64)
 
-	object := newObject(buffer, &scatch)
+	object := newObject(buffer, &scratch)
 	object.Key("foo").String("bar")
 	object.Key("faz").String("baz")
 	object.Close()
@@ -20,17 +20,15 @@ func TestObject(t *testing.T) {
 	}
 }
 
-func TestObjectEscapeKeys(t *testing.T) {
-	buffer := bytes.NewBuffer(nil)
-	scratch := make([]byte, 64)
-
-	object := newObject(buffer, &scratch)
+func TestObjectKey_escaped(t *testing.T) {
+	jsonEncoder := NewEncoder()
+	object := jsonEncoder.Object()
 	object.Key("foo\"").String("bar")
 	object.Key("faz").String("baz")
 	object.Close()
 
 	e := []byte(`{"foo\"":"bar","faz":"baz"}`)
-	if a := buffer.Bytes(); bytes.Compare(e, a) != 0 {
+	if a := object.w.Bytes(); bytes.Compare(e, a) != 0 {
 		t.Errorf("expected %+q, but got %+q", e, a)
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-go-v2/issues/1764

*Description of changes:*
- fixed escaping on `writeKey` function. 
- Added test coverage for that
- Fixed typo
- Added test coverage for `escapeStringBytes`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
