### PR TITLE
Upgrade to Smithy IDL 2.0

### DIFF
--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,1 +1,2 @@
-smithyVersion=1.21.0
+smithyVersion=1.23.1
+smithyGradleVersion=0.6.0

--- a/codegen/smithy-go-codegen-test/build.gradle.kts
+++ b/codegen/smithy-go-codegen-test/build.gradle.kts
@@ -31,7 +31,8 @@ buildscript {
 }
 
 plugins {
-    id("software.amazon.smithy").version("0.5.3")
+    val smithyGradleVersion: String by project
+    id("software.amazon.smithy") version smithyGradleVersion
 }
 
 repositories {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoValueAccessUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoValueAccessUtils.java
@@ -72,6 +72,8 @@ public final class GoValueAccessUtils {
         } else if (container instanceof CollectionShape || container.getType() == ShapeType.MAP) {
             if (!ignoreEmptyString && targetShape.getType() == ShapeType.STRING) {
                 check = String.format("if len(%s) > 0 {", operand);
+            } else if (!ignoreEmptyString && targetShape.getType() == ShapeType.ENUM) {
+                check = String.format("if len(%s) > 0 {", operand);
             }
         } else if (targetShape.hasTrait(EnumTrait.class)) {
             check = String.format("if len(%s) > 0 {", operand);

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeValueGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeValueGenerator.java
@@ -289,6 +289,10 @@ public final class ShapeValueGenerator {
                 funcName = "String";
                 break;
 
+            case ENUM:
+                funcName = target.getId().getName();
+                break;
+
             case TIMESTAMP:
                 funcName = "Time";
                 break;
@@ -359,6 +363,12 @@ public final class ShapeValueGenerator {
                     writer.writeInline("$T(", enumSymbol);
                     closing = ")";
                 }
+                break;
+            case ENUM:
+                // Enum are not pointers, but string alias values
+                Symbol enumSymbol = symbolProvider.toSymbol(target);
+                writer.writeInline("$T(", enumSymbol);
+                closing = ")";
                 break;
 
             default:
@@ -691,6 +701,10 @@ public final class ShapeValueGenerator {
             switch (currentShape.getType()) {
                 case BLOB:
                 case STRING:
+                    writer.writeInline("$S", node.getValue());
+                    break;
+
+                case ENUM:
                     writer.writeInline("$S", node.getValue());
                     break;
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -753,6 +753,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 operand = targetShape.hasTrait(EnumTrait.class) ? "string(" + operand + ")" : operand;
                 locationEncoder.accept(writer, "String(" + operand + ")");
                 break;
+            case ENUM:
+                operand = "string(" + operand + ")";
+                locationEncoder.accept(writer, "String(" + operand + ")");
+                break;
             case TIMESTAMP:
                 generateHttpBindingTimestampSerializer(model, writer, memberShape, location, operand, locationEncoder);
                 break;
@@ -1161,6 +1165,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                     return "string(b)";
                 }
                 return operand;
+            case ENUM:
+                value = String.format("types.%s(%s)", targetShape.getId().getName(), operand);
+                return value;
             case BOOLEAN:
                 writer.addUseImports(SmithyGoDependency.STRCONV);
                 writer.write("vv, err := strconv.ParseBool($L)", operand);

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/knowledge/GoPointableIndex.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/knowledge/GoPointableIndex.java
@@ -191,7 +191,8 @@ public class GoPointableIndex implements KnowledgeIndex {
     }
 
     private boolean isShapeEnum(Shape shape) {
-        return shape.getType() == ShapeType.STRING && shape.hasTrait(EnumTrait.class);
+        return shape.getType() == ShapeType.STRING && shape.hasTrait(EnumTrait.class)
+                || shape.getType() == ShapeType.ENUM;
     }
 
     private boolean isBlobStream(Shape shape) {


### PR DESCRIPTION
*Issue #, if available:*

N/A

---

*Description of changes:*

Upgrade to Smithy IDL 2.0:

- Upgrade `smithyVersion` to 1.23.1
- Extract Smithy Gradle Plugin to `smithyGradleVersion` to 0.6.0
- Add partial support `ENUM` support to maintain consistent code generation
- Omit deprecation comments for Prelude shapes

**These changes are a temporary workaround.**

In the future, smithy-go should be refactored to use a visitor pattern instead of switch-statements on `ShapeType` / if-statements on `EnumTrait`.

---

*Testing:*

File Structure:

```tree
.
├── aws-sdk-go-v2
└── smithy-go
```

1. smithy-go: Ran `make smithy-clean smithy-build smithy-publish-local smithy-clean`.
2. aws-sdk-go-v2: Ran `make`
3. aws-sdk-go-v2: Verified expected diffs in protocol tests and services

---

<p id="open-issues"><em>Open Issues:</em></p>

**&#9989; `[]byte` vs `*string`**

<details>
<summary>
After learning more about protocol tests are generated, it turns out this is an expected diff. See commit <a href="https://github.com/awslabs/smithy/commit/3664330bd26f9c422a4d420725a0afcb72c42b64#diff-637369fe56d7d3556803ff85b0f6852fb2c62704ca454821949cbbe53e39276fL106-R109">here</a>.
</summary>

<br />

***Diff Details***

There is a [potentially problematic diff](https://github.com/syall/aws-sdk-go-v2/commit/4939296113ffaa120aca90d623725de82f04abff#) (focus on `[]byte` and `*string` changes) in the generated output of aws-sdk-go-v2, but not sure if this is related to a change before Smithy 1.23.0.

- File `aws-sdk-go-v2/internal/protocoltest/awsrestjson/api_op_MalformedAcceptWithGenericString.go` was last changed [Nov 11, 2021](https://github.com/syall/aws-sdk-go-v2/commit/0b6e601f54f1c6d7c84b72a6ca478840deaa5743)
- File `aws-sdk-go-v2/internal/protocoltest/awsrestjson/serializers.go` was last changed [Jun 28 2022](https://github.com/syall/aws-sdk-go-v2/commit/3cc55fe104963aa9bf66559f9ca5c5bb2f96df02)

```diff
diff --git a/internal/protocoltest/awsrestjson/api_op_MalformedAcceptWithGenericString.go b/internal/protocoltest/awsrestjson/api_op_MalformedAcceptWithGenericString.go
index aec31720fa..abdef70081 100644
--- a/internal/protocoltest/awsrestjson/api_op_MalformedAcceptWithGenericString.go
+++ b/internal/protocoltest/awsrestjson/api_op_MalformedAcceptWithGenericString.go
@@ -25,7 +25,7 @@ func (c *Client) MalformedAcceptWithGenericString(ctx context.Context, params *M
 }
 
 type MalformedAcceptWithGenericStringInput struct {
-       Payload []byte
+       Payload *string
 
        noSmithyDocumentSerde
 }
diff --git a/internal/protocoltest/awsrestjson/serializers.go b/internal/protocoltest/awsrestjson/serializers.go
index ceb6bce2e1..0d336bbb68 100644
--- a/internal/protocoltest/awsrestjson/serializers.go
+++ b/internal/protocoltest/awsrestjson/serializers.go
@@ -2501,11 +2501,11 @@ func (m *awsRestjson1_serializeOpMalformedAcceptWithGenericString) HandleSeriali
 
        if !restEncoder.HasHeader("Content-Type") {
                ctx = smithyhttp.SetIsContentTypeDefaultValue(ctx, true)
-               restEncoder.SetHeader("Content-Type").String("application/octet-stream")
+               restEncoder.SetHeader("Content-Type").String("text/plain")
        }
 
        if input.Payload != nil {
-               payload := bytes.NewReader(input.Payload)
+               payload := strings.NewReader(*input.Payload)
                if request, err = request.SetStream(payload); err != nil {
                        return out, metadata, &smithy.SerializationError{Err: err}
                }
@@ -3658,83 +3658,6 @@ func awsRestjson1_serializeOpDocumentMalformedRequestBodyInput(v *MalformedReque
        return nil
 }
```
</details>

**&#9989; `TestResolveCredentialsIMDSClient`**

<details>
<summary>
Resolved by removing local <code>~/.aws/credentials</code> file.
</summary>

<br />

***Changes need to be tested in a proper local environment with changes from both #376 and aws/aws-sdk-go-v2#1806.***

***All other tests have already passed, see the "Testing" section for more details.***

`TestResolveCredentialsIMDSClient` fails locally when running `make` in aws-sdk-go-v2, ~~but not sure if that is normal~~ [probably due to local environment issues](https://github.com/aws/smithy-go/pull/376#issuecomment-1220960572).

```text
2022/08/16 12:47:10 config: go test -tags example,codegen,integration,ec2env,perftest -run NONE ./... =>
--- FAIL: TestResolveCredentialsIMDSClient (0.00s)
    --- FAIL: TestResolveCredentialsIMDSClient/default_no_options (0.00s)
        resolve_credentials_test.go:481: expect error got none
    --- FAIL: TestResolveCredentialsIMDSClient/state_enabled (0.00s)
        resolve_credentials_test.go:481: expect error got none
    --- FAIL: TestResolveCredentialsIMDSClient/state_disabled (0.00s)
        resolve_credentials_test.go:491: unexpected error: <nil>
    --- FAIL: TestResolveCredentialsIMDSClient/env_var_DISABLED_true (0.00s)
        resolve_credentials_test.go:491: unexpected error: <nil>
    --- FAIL: TestResolveCredentialsIMDSClient/env_var_DISABLED_false (0.00s)
        resolve_credentials_test.go:481: expect error got none
    --- FAIL: TestResolveCredentialsIMDSClient/option_state_enabled_overrides_env_var_DISABLED_true (0.00s)
        resolve_credentials_test.go:481: expect error got none
    --- FAIL: TestResolveCredentialsIMDSClient/option_state_disabled_overrides_env_var_DISABLED_false (0.00s)
        resolve_credentials_test.go:491: unexpected error: <nil>
2022/08/16 12:47:16 http: TLS handshake error from 127.0.0.1:61844: remote error: tls: bad certificate
FAIL
FAIL    github.com/aws/aws-sdk-go-v2/config     9.317s
FAIL
2022/08/16 12:47:21 config: go test -timeout=1m  ./... => error: failed to run command, exit status 1
2022/08/16 12:47:21 a command failed
exit status 1
make: *** [unit-modules-.] Error 1

```
</details>

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
