### PR TITLE
codegen: Updates codegen to support non-model writing, and lazy writable

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -142,7 +142,7 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
                 ? ApplicationProtocol.createDefaultHttpApplicationProtocol()
                 : protocolGenerator.getApplicationProtocol();
 
-        writers = new GoDelegator(settings, model, fileManifest, symbolProvider);
+        writers = new GoDelegator(fileManifest, symbolProvider);
 
         protocolDocumentGenerator = new ProtocolDocumentGenerator(settings, model, writers);
 
@@ -155,7 +155,7 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
             ServiceShape service,
             GoSettings settings
     ) {
-        // Collect all of the supported protocol generators.
+        // Collect all the supported protocol generators.
         Map<ShapeId, ProtocolGenerator> generators = new HashMap<>();
         for (GoIntegration integration : integrations) {
             for (ProtocolGenerator generator : integration.getProtocolGenerators()) {
@@ -163,7 +163,7 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
             }
         }
 
-        ServiceIndex serviceIndex = model.getKnowledge(ServiceIndex.class);
+        ServiceIndex serviceIndex = ServiceIndex.of(model);
 
         ShapeId protocolTrait;
         try {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
@@ -60,6 +60,8 @@ public final class GoWriter extends AbstractCodeWriter<GoWriter> {
     private static final Logger LOGGER = Logger.getLogger(GoWriter.class.getName());
     private static final int DEFAULT_DOC_WRAP_LENGTH = 80;
 
+    private static final Pattern ARGUMENT_NAME_PATTERN = Pattern.compile("\\$([a-z][a-zA-Z_0-9]+)(:\\w)?");
+
     private final String fullPackageName;
     private final ImportDeclarations imports = new ImportDeclarations();
     private final List<SymbolDependency> dependencies = new ArrayList<>();
@@ -263,8 +265,7 @@ public final class GoWriter extends AbstractCodeWriter<GoWriter> {
     }
 
     private void validateContext(String template, Map<String, Object> scope) {
-        var pattern = Pattern.compile("\\$([a-z][a-zA-Z_0-9]+)(:\\w)?");
-        var matcher = pattern.matcher(template);
+        var matcher = ARGUMENT_NAME_PATTERN.matcher(template);
 
         var foundKeys = new HashSet<String>();
         while (matcher.find()) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriterDelegator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriterDelegator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import software.amazon.smithy.build.FileManifest;
+import software.amazon.smithy.codegen.core.SymbolDependency;
+
+public class GoWriterDelegator {
+    private final FileManifest fileManifest;
+    private final Map<String, GoWriter> writers = new HashMap<>();
+
+    public GoWriterDelegator(FileManifest fileManifest) {
+        this.fileManifest = fileManifest;
+    }
+
+    /**
+     * Writes all pending writers to disk and then clears them out.
+     */
+    public void flushWriters() {
+        writers.forEach((filename, writer) -> fileManifest.writeFile(filename, writer.toString()));
+        writers.clear();
+    }
+
+    /**
+     * Gets all the dependencies that have been registered in writers owned by the
+     * delegator.
+     *
+     * @return Returns all the dependencies.
+     */
+    public List<SymbolDependency> getDependencies() {
+        List<SymbolDependency> resolved = new ArrayList<>();
+        writers.values().forEach(s -> resolved.addAll(s.getDependencies()));
+        return resolved;
+    }
+
+    /**
+     * Gets a previously created writer or creates a new one if needed
+     * and adds a new line if the writer already exists.
+     *
+     * @param filename       Name of the file to create.
+     * @param namespace      Namespace of the file's content.
+     * @param writerConsumer Consumer that accepts and works with the file.
+     */
+    public void useFileWriter(String filename, String namespace, Consumer<GoWriter> writerConsumer) {
+        writerConsumer.accept(checkoutWriter(filename, namespace));
+    }
+
+    GoWriter checkoutWriter(String filename, String namespace) {
+        String formattedFilename = Paths.get(filename).normalize().toString();
+        boolean needsNewline = writers.containsKey(formattedFilename);
+
+        GoWriter writer = writers.computeIfAbsent(formattedFilename, f -> new GoWriter(namespace));
+
+        if (needsNewline) {
+            writer.write("\n");
+        }
+
+        return writer;
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ManifestWriter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ManifestWriter.java
@@ -37,6 +37,7 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.traits.UnstableTrait;
+import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.SmithyBuilder;
 
 /**
@@ -55,7 +56,7 @@ public final class ManifestWriter {
     private ManifestWriter(Builder builder) {
         moduleName = SmithyBuilder.requiredState("moduleName", builder.moduleName);
         fileManifest = SmithyBuilder.requiredState("fileManifest", builder.fileManifest);
-        dependencies = SmithyBuilder.requiredState("dependencies", builder.dependencies);
+        dependencies = builder.dependencies.copy();
         minimumGoVersion = builder.minimumGoVersion;
         isUnstable = builder.isUnstable;
     }
@@ -166,7 +167,7 @@ public final class ManifestWriter {
     public static class Builder implements SmithyBuilder<ManifestWriter> {
         private String moduleName;
         private FileManifest fileManifest;
-        private List<SymbolDependency> dependencies;
+        private final BuilderRef<List<SymbolDependency>> dependencies = BuilderRef.forList();
         private Optional<String> minimumGoVersion = Optional.empty();
         private boolean isUnstable;
 
@@ -181,7 +182,8 @@ public final class ManifestWriter {
         }
 
         public Builder dependencies(List<SymbolDependency> dependencies) {
-            this.dependencies = dependencies;
+            this.dependencies.clear();
+            this.dependencies.get().addAll(dependencies);
             return this;
         }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ManifestWriter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ManifestWriter.java
@@ -37,18 +37,31 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.traits.UnstableTrait;
+import software.amazon.smithy.utils.SmithyBuilder;
 
 /**
- * Generates a manifest description of the generated code, minimum go version, and minimum dependencies required.
+ * Generates a manifest description of the generated code, minimum go version,
+ * and minimum dependencies required.
  */
 public final class ManifestWriter {
     private static final String GENERATED_JSON = "generated.json";
 
-    private ManifestWriter() {
+    private final String moduleName;
+    private final FileManifest fileManifest;
+    private final List<SymbolDependency> dependencies;
+    private final Optional<String> minimumGoVersion;
+    private final boolean isUnstable;
+
+    private ManifestWriter(Builder builder) {
+        moduleName = SmithyBuilder.requiredState("moduleName", builder.moduleName);
+        fileManifest = SmithyBuilder.requiredState("fileManifest", builder.fileManifest);
+        dependencies = SmithyBuilder.requiredState("dependencies", builder.dependencies);
+        minimumGoVersion = builder.minimumGoVersion;
+        isUnstable = builder.isUnstable;
     }
 
     /**
-     * Write the manifest description of the generated code.
+     * Write the manifest description of the Smithy model based generated source code.
      *
      * @param settings     the go settings
      * @param model        the smithy model
@@ -61,6 +74,20 @@ public final class ManifestWriter {
             FileManifest fileManifest,
             List<SymbolDependency> dependencies
     ) {
+        builder()
+                .moduleName(settings.getModuleName())
+                .fileManifest(fileManifest)
+                .dependencies(dependencies)
+                .isUnstable(settings.getService(model).getTrait(UnstableTrait.class).isPresent())
+                .build()
+                .writeManifest();
+    }
+
+
+    /**
+     * Write the manifest description of the generated code.
+     */
+    public void writeManifest() {
         Path manifestFile = fileManifest.getBaseDir().resolve(GENERATED_JSON);
 
         if (Files.exists(manifestFile)) {
@@ -72,31 +99,28 @@ public final class ManifestWriter {
         }
         fileManifest.addFile(manifestFile);
 
-        Node generatedJson = buildManifestFile(settings, model, fileManifest, dependencies);
+        Node generatedJson = buildManifestFile();
         fileManifest.writeFile(manifestFile.toString(), Node.prettyPrintJson(generatedJson) + "\n");
+
     }
 
-    private static Node buildManifestFile(
-            GoSettings settings,
-            Model model,
-            FileManifest fileManifest,
-            List<SymbolDependency> dependencies
-    ) {
-
+    private Node buildManifestFile() {
         List<SymbolDependency> nonStdLib = new ArrayList<>();
-        Optional<SymbolDependency> minStandard = Optional.empty();
+        Optional<String> minimumGoVersion = this.minimumGoVersion;
 
         for (SymbolDependency dependency : dependencies) {
             if (!dependency.getDependencyType().equals(GoDependency.Type.STANDARD_LIBRARY.toString())) {
                 nonStdLib.add(dependency);
-            } else {
-                if (minStandard.isPresent()) {
-                    if (minStandard.get().getVersion().compareTo(dependency.getVersion()) < 0) {
-                        minStandard = Optional.of(dependency);
-                    }
-                } else {
-                    minStandard = Optional.of(dependency);
+                continue;
+            }
+
+            var otherVersion = dependency.getVersion();
+            if (minimumGoVersion.isPresent()) {
+                if (minimumGoVersion.get().compareTo(otherVersion) < 0) {
+                    minimumGoVersion = Optional.of(otherVersion);
                 }
+            } else {
+                minimumGoVersion = Optional.of(otherVersion);
             }
         }
 
@@ -106,8 +130,7 @@ public final class ManifestWriter {
 
         Map<StringNode, Node> dependencyNodes = new HashMap<>();
         for (Map.Entry<String, String> entry : minimumDependencies.entrySet()) {
-            dependencyNodes.put(StringNode.from(entry.getKey()),
-                    StringNode.from(entry.getValue()));
+            dependencyNodes.put(StringNode.from(entry.getKey()), StringNode.from(entry.getValue()));
         }
 
         Collection<String> generatedFiles = new ArrayList<>();
@@ -117,13 +140,12 @@ public final class ManifestWriter {
         }
         generatedFiles = generatedFiles.stream().sorted().collect(Collectors.toList());
 
-        manifestNodes.put(StringNode.from("module"), StringNode.from(settings.getModuleName()));
-        minStandard.ifPresent(symbolDependency ->
-                manifestNodes.put(StringNode.from("go"), StringNode.from(symbolDependency.getVersion())));
+        manifestNodes.put(StringNode.from("module"), StringNode.from(moduleName));
+        minimumGoVersion.ifPresent(version -> manifestNodes.put(StringNode.from("go"),
+                StringNode.from(version)));
         manifestNodes.put(StringNode.from("dependencies"), ObjectNode.objectNode(dependencyNodes));
         manifestNodes.put(StringNode.from("files"), ArrayNode.fromStrings(generatedFiles));
-        manifestNodes.put(StringNode.from("unstable"),
-                BooleanNode.from(settings.getService(model).getTrait(UnstableTrait.class).isPresent()));
+        manifestNodes.put(StringNode.from("unstable"), BooleanNode.from(isUnstable));
 
         return ObjectNode.objectNode(manifestNodes).withDeepSortedKeys();
     }
@@ -131,11 +153,51 @@ public final class ManifestWriter {
     private static Map<String, String> gatherMinimumDependencies(
             Stream<SymbolDependency> symbolStream
     ) {
-        return SymbolDependency.gatherDependencies(symbolStream, GoDependency::mergeByMinimumVersionSelection)
-                .entrySet().stream()
-                .flatMap(entry -> entry.getValue().entrySet().stream())
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey, entry -> entry.getValue().getVersion(), (a, b) -> b, TreeMap::new));
+        return SymbolDependency.gatherDependencies(symbolStream,
+                GoDependency::mergeByMinimumVersionSelection).entrySet().stream().flatMap(
+                entry -> entry.getValue().entrySet().stream()).collect(
+                Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getVersion(), (a, b) -> b, TreeMap::new));
     }
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder implements SmithyBuilder<ManifestWriter> {
+        private String moduleName;
+        private FileManifest fileManifest;
+        private List<SymbolDependency> dependencies;
+        private Optional<String> minimumGoVersion = Optional.empty();
+        private boolean isUnstable;
+
+        public Builder moduleName(String moduleName) {
+            this.moduleName = moduleName;
+            return this;
+        }
+
+        public Builder fileManifest(FileManifest fileManifest) {
+            this.fileManifest = fileManifest;
+            return this;
+        }
+
+        public Builder dependencies(List<SymbolDependency> dependencies) {
+            this.dependencies = dependencies;
+            return this;
+        }
+
+        public Builder minimumGoVersion(String minimumGoVersion) {
+            this.minimumGoVersion = Optional.of(minimumGoVersion);
+            return this;
+        }
+
+        public Builder isUnstable(boolean isUnstable) {
+            this.isUnstable = isUnstable;
+            return this;
+        }
+
+        @Override
+        public ManifestWriter build() {
+            return new ManifestWriter(this);
+        }
+    }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/testutils/ExecuteCommand.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/testutils/ExecuteCommand.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.testutils;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Logger;
+import software.amazon.smithy.utils.SmithyBuilder;
+
+/**
+ * Utility for invoking command line utilities.
+ */
+public final class ExecuteCommand {
+    private static final Logger LOGGER = Logger.getLogger(ExecuteCommand.class.getName());
+
+    private final String[] command;
+    private final File workingDir;
+
+    private ExecuteCommand(Builder builder) {
+        var cmdList = SmithyBuilder.requiredState("command", builder.command);
+        command = new String[cmdList.size()];
+        cmdList.toArray(command);
+
+        workingDir = builder.workingDir;
+    }
+
+    /**
+     * Invokes the command in the filepath directory provided.
+     * @param workingDir Directory to execute the command in.
+     * @param command Command to be executed.
+     * @throws Exception if the command fails.
+     */
+    public static void execute(File workingDir, String... command) throws Exception {
+        ExecuteCommand.builder()
+                .addCommand(command)
+                .workingDir(workingDir)
+                .build()
+                .execute();
+    }
+
+    /**
+     * Invokes the command returning the exception if there was any.
+     * @throws Exception if the command fails.
+     */
+    public void execute() throws Exception {
+        int exitCode = -1;
+        Process child;
+        try {
+            child = Runtime.getRuntime().exec(command, null, workingDir);
+            exitCode = child.waitFor();
+
+            BufferedReader stdOut = new BufferedReader(new
+                    InputStreamReader(child.getInputStream(), Charset.defaultCharset()));
+
+            BufferedReader stdErr = new BufferedReader(new
+                    InputStreamReader(child.getErrorStream(), Charset.defaultCharset()));
+
+            String s;
+            while ((s = stdOut.readLine()) != null) {
+                LOGGER.info(s);
+            }
+            stdOut.close();
+            while ((s = stdErr.readLine()) != null) {
+                LOGGER.warning(s);
+            }
+            stdErr.close();
+        } catch (Exception e) {
+            throw new Exception("Unable to execute command" + Arrays.toString(command), e);
+        }
+
+        if (exitCode != 0) {
+            throw new Exception("Command existed with non-zero code, " + Arrays.toString(command)
+                    + ", status code: " + exitCode);
+        }
+    }
+
+    /**
+     * Returns the builder for ExecuteCommand.
+     * @return ExecuteCommand builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * ExecuteCommand builder.
+     */
+    public static final class Builder implements SmithyBuilder<ExecuteCommand> {
+        private List<String> command;
+        private File workingDir;
+
+        private Builder() {
+        }
+
+        /**
+         * Adds command arguments to the set of arguments the command will be executed with.
+         * @param command command and arguments to be executed.
+         * @return builder
+         */
+        public Builder addCommand(String... command) {
+            if (this.command == null) {
+                this.command = new ArrayList<>();
+            }
+
+            this.command.addAll(List.of(command));
+            return this;
+        }
+
+        /**
+         * Sets the working directory for the command.
+         * @param workingDir working directory.
+         * @return builder
+         */
+        public Builder workingDir(File workingDir) {
+            this.workingDir = workingDir;
+            return this;
+        }
+
+        /**
+         * Builds the ExecuteCommand.
+         * @return Execute command
+         */
+        @Override
+        public ExecuteCommand build() {
+            return new ExecuteCommand(this);
+        }
+    }
+}

--- a/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GenerateStandaloneGoModuleTest.java
+++ b/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GenerateStandaloneGoModuleTest.java
@@ -1,0 +1,105 @@
+package software.amazon.smithy.go.codegen;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+import static software.amazon.smithy.go.codegen.TestUtils.hasGoInstalled;
+import static software.amazon.smithy.go.codegen.TestUtils.makeGoModule;
+import static software.amazon.smithy.go.codegen.TestUtils.testGoModule;
+
+import java.nio.file.Path;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.FileManifest;
+import software.amazon.smithy.utils.MapUtils;
+
+public class GenerateStandaloneGoModuleTest {
+    private static final Logger LOGGER = Logger.getLogger(GenerateStandaloneGoModuleTest.class.getName());
+
+    @Test
+    public void testGenerateGoModule() throws Exception {
+        if (!hasGoInstalled()) {
+            LOGGER.warning("Skipping testGenerateGoModule, go command cannot be executed.");
+            return;
+        }
+
+        var testPath = getTestOutputDir();
+        LOGGER.warning("generating test suites into " + testPath);
+
+        var fileManifest = FileManifest.create(testPath);
+        var writers = new GoWriterDelegator(fileManifest);
+
+        writers.useFileWriter("test-directory/package-name/gofile.go",
+                "github.com/aws/smithy-go/internal/testmodule/packagename",
+                (w) -> {
+                    w.writeGoTemplate("""
+                                    type $name:L struct {
+                                        Bar $barType:T
+                                        Baz *$bazType:T
+                                    }
+
+                                    $somethingElse:W
+                                    """,
+                            MapUtils.of(
+                                    "name", "Foo",
+                                    "barType", SymbolUtils.createValueSymbolBuilder("string").build(),
+                                    "bazType", SymbolUtils.createValueSymbolBuilder("Request",
+                                            SmithyGoDependency.SMITHY_HTTP_TRANSPORT).build(),
+                                    "somethingElse", generateSomethingElse()
+                            ));
+                });
+
+        writers.useFileWriter("test-directory/package-name/gofile_test.go",
+                "github.com/aws/smithy-go/internal/testmodule/packagename",
+                (w) -> {
+                    w.writeGoTemplate("""
+                                    func Test$name:L(t *$testingT:T) {
+                                        v := $name:L{}
+                                        v.Baz = nil
+                                    }
+                                    """,
+                            MapUtils.of(
+                                    "name", "Foo",
+                                    "testingT", SymbolUtils.createValueSymbolBuilder("T",
+                                            SmithyGoDependency.TESTING).build()
+                            ));
+                });
+
+        var dependencies = writers.getDependencies();
+        writers.flushWriters();
+
+        ManifestWriter.builder()
+                .moduleName("github.com/aws/smithy-go/internal/testmodule")
+                .fileManifest(fileManifest)
+                .dependencies(dependencies)
+                .build()
+                .writeManifest();
+
+        makeGoModule(testPath);
+        testGoModule(testPath);
+    }
+
+    private GoWriter.Writable generateSomethingElse() {
+        return goTemplate("""
+                        func (s *$name:L) SomeFunction(i int) string {
+                            return "hello there!"
+                        }
+                        """,
+                MapUtils.of(
+                        "name", "Foo"
+                ));
+    }
+
+    private static Path getTestOutputDir() {
+        var testWorkspace = System.getenv("SMITHY_GO_TEST_WORKSPACE");
+        if (testWorkspace != null) {
+            return Path.of(testWorkspace).toAbsolutePath();
+        }
+
+        return Path.of(System.getProperty("user.dir"))
+                .resolve("build")
+                .resolve("test-generated")
+                .resolve("go")
+                .resolve("internal")
+                .resolve("testmodule")
+                .toAbsolutePath();
+    }
+}


### PR DESCRIPTION
Updates the smithy-go codegen to include support for writing file manifests for non-model based Go code generation. This allows code generation for standalone Go modules that are not smithy model based. Including Go module unit tests.

Adds GoWritable for lazy code writing. Allows a Writable to be returned from a method improving the ability to do inline code generation.