### PR TITLE
Add unit test for mixin code generation

### DIFF
--- a/codegen/smithy-go-codegen/src/main/resources/software/amazon/smithy/go/codegen/smithy-tests/mixin-test/expected/changeCardInput.go.mixin
+++ b/codegen/smithy-go-codegen/src/main/resources/software/amazon/smithy/go/codegen/smithy-tests/mixin-test/expected/changeCardInput.go.mixin
@@ -1,0 +1,8 @@
+type ChangeCardInput struct {
+	
+	Number *int32
+	
+	Suit *string
+	
+	noSmithyDocumentSerde
+}

--- a/codegen/smithy-go-codegen/src/main/resources/software/amazon/smithy/go/codegen/smithy-tests/mixin-test/expected/changeCardOutput.go.mixin
+++ b/codegen/smithy-go-codegen/src/main/resources/software/amazon/smithy/go/codegen/smithy-tests/mixin-test/expected/changeCardOutput.go.mixin
@@ -1,0 +1,11 @@
+type ChangeCardOutput struct {
+	
+	Number *int32
+	
+	Suit *string
+	
+	// Metadata pertaining to the operation's result.
+	ResultMetadata middleware.Metadata
+	
+	noSmithyDocumentSerde
+}

--- a/codegen/smithy-go-codegen/src/main/resources/software/amazon/smithy/go/codegen/smithy-tests/mixin-test/mixin-test.smithy
+++ b/codegen/smithy-go-codegen/src/main/resources/software/amazon/smithy/go/codegen/smithy-tests/mixin-test/mixin-test.smithy
@@ -1,0 +1,23 @@
+$version: "2.0"
+
+namespace smithy.example
+
+service Example {
+    version: "1.0.0"
+    operations: [
+        ChangeCard
+    ]
+}
+
+operation ChangeCard {
+    input: Card
+    output: Card
+}
+
+@mixin
+structure CardValuesMixin {
+    suit: String
+    number: Integer
+}
+
+structure Card with [CardValuesMixin] {}

--- a/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/MixinCodegenTest.java
+++ b/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/MixinCodegenTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen;
+
+import java.util.logging.Logger;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.smithy.build.MockManifest;
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.go.codegen.GoCodegenPlugin;
+import software.amazon.smithy.model.Model;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static software.amazon.smithy.go.codegen.TestUtils.buildMockPluginContext;
+import static software.amazon.smithy.go.codegen.TestUtils.loadSmithyModelFromResource;
+import static software.amazon.smithy.go.codegen.TestUtils.loadExpectedFileStringFromResource;
+
+
+public class MixinCodegenTest {
+    private static final Logger LOGGER = Logger.getLogger(MixinCodegenTest.class.getName());
+
+    @Test
+    public void testMixinCodegen() {
+
+        // Arrange
+        Model model =
+            loadSmithyModelFromResource("mixin-test");
+        MockManifest manifest =
+            new MockManifest();
+        PluginContext context =
+            buildMockPluginContext(model, manifest, "smithy.example#Example");
+
+        // Act
+        (new GoCodegenPlugin()).execute(context);
+
+        // Assert
+        String actualChangeCardOperationCode =
+            manifest.getFileString("api_op_ChangeCard.go").get();
+        String expectedInputMixinCode =
+            loadExpectedFileStringFromResource("mixin-test", "changeCardInput.go.mixin");
+        assertThat("mixins are properly applied in the input structure",
+            actualChangeCardOperationCode,
+            containsString(expectedInputMixinCode));
+        String expectedOutputMixinCode =
+            loadExpectedFileStringFromResource("mixin-test", "changeCardOutput.go.mixin");
+        assertThat("mixins are properly applied in the output structure",
+            actualChangeCardOperationCode,
+            containsString(expectedOutputMixinCode));
+
+    }
+
+}


### PR DESCRIPTION
*Issue #, if available:*

N/A

---

*Description of changes:*

Add unit test for mixin code generation.

---

*Testing*

Ran `make smithy-clean smithy-build smithy-publish-local smithy-clean`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
