### PR TITLE
codegen: Breakout codegen directory into its a Go module

### DIFF
--- a/codegen/go.mod
+++ b/codegen/go.mod
@@ -1,0 +1,3 @@
+module github.com/aws/smithy-go/codegen
+
+go 1.15

--- a/modman.toml
+++ b/modman.toml
@@ -1,0 +1,11 @@
+[dependencies]
+  "github.com/google/go-cmp" = "v0.5.8"
+  "github.com/jmespath/go-jmespath" = "v0.4.0"
+
+[modules]
+
+  [modules.codegen]
+    no_tag = true
+
+  [modules."codegen/smithy-go-codegen/build/test-generated/go/internal/testmodule"]
+    no_tag = true


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*

Breaks out the smithy codegen directory into a Go module so it can be ignored by Go's module packaging system. In addition, so that go commands are not run on any go mixin or test files used by codegen.

---

Before this can be merged in, we need to investigate the impact on the release automation determining what is the the latest smithy-go module version.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
