### PR TITLE
Upgrade to smithy 1.25.0

### DIFF
--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,2 +1,2 @@
-smithyVersion=1.23.1
+smithyVersion=1.25.0
 smithyGradleVersion=0.6.0

--- a/codegen/smithy-go-codegen-test/build.gradle.kts
+++ b/codegen/smithy-go-codegen-test/build.gradle.kts
@@ -23,6 +23,7 @@ tasks["jar"].enabled = false
 buildscript {
     val smithyVersion: String by project
     repositories {
+        mavenLocal()
         mavenCentral()
     }
     dependencies {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/Paginators.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/Paginators.java
@@ -201,7 +201,7 @@ public class Paginators implements GoIntegration {
                                  """);
 
                     pageSizeMember.ifPresent(memberShape -> {
-                        if (pointableIndex.isPointable(model.expectShape(memberShape.getTarget()))) {
+                        if (pointableIndex.isPointable(memberShape)) {
                             writer.write("""
                                          var limit $P
                                          if p.options.Limit > 0 {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/knowledge/GoPointableIndex.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/knowledge/GoPointableIndex.java
@@ -140,7 +140,7 @@ public class GoPointableIndex implements KnowledgeIndex {
     }
 
     private boolean isMemberDereferencable(MemberShape member, Shape targetShape) {
-        return isShapeDereferencable(targetShape) && isMemberPointable(member, targetShape);
+        return !INHERENTLY_NONDEREFERENCABLE.contains(targetShape.getType()) && isMemberPointable(member, targetShape);
     }
 
     private boolean isMemberNillable(MemberShape member, Shape targetShape) {
@@ -148,7 +148,17 @@ public class GoPointableIndex implements KnowledgeIndex {
     }
 
     private boolean isMemberPointable(MemberShape member, Shape targetShape) {
-        return isShapePointable(targetShape) && nullableIndex.isNullable(member);
+
+        // Streamed blob shapes are never pointers because they are interfaces
+        if (isBlobStream(targetShape)) {
+            return false;
+        }
+
+        if (INHERENTLY_VALUE.contains(targetShape.getType()) || isShapeEnum(targetShape)) {
+            return false;
+        }
+
+        return nullableIndex.isMemberNullable(member, NullableIndex.CheckMode.CLIENT_ZERO_VALUE_V1_NO_INPUT);
     }
 
     private boolean isShapeDereferencable(Shape shape) {


### PR DESCRIPTION
# Dependent on Smithy 1.25.0 release, BLOCK merging until then.

*Issue #, if available:*

N/A

---

*Description of changes:*

**Note: This change introduces break/fix's for pointable types.**

Update paginators code generation

- Use the member shape to check pointability instead of the target shape for passing the limit from the options to the params.

Fix GoPointableIndex bugs

- `isMemberDereferencable()` previously used the `isShapeDereferencable()` method, but now is switched to check the that it is NOT in the `INHERENTLY_NONDEREFERENCABLE` set.

- `isMemberPointable()` used to incorrectly categorize pointability due to an incorrect condition using `NullableIndex::isNullable()` method, but is now using a new conditionals and the updated `NullableIndex::isMemberNullable()` method with the `CLIENT_ZERO_VALUE_V1_NO_INPUT` check mode.

Chores:

- Add mavenLocal to codegen build file

---

*Testing:*

- Use smithy changes from awslabs/smithy#1394
  - `./gradlew clean build publishToMavenLocal smithy-cli:runtime`
- Build smithy-go with current changes and smithy (awslabs/smithy#1394) changes: `make smithy-clean smithy-build smithy-publish-local smithy-clean`
- Build aws-sdk-go-v2 with its (aws/aws-sdk-go-v2#1835) and smithy-go and smithy (awslabs/smithy#1394) changes: `make generate` and `make unit`
  - Verify [expected diff](https://github.com/syall/aws-sdk-go-v2/blob/nullability-fix-diffs/aws-sdk-go-v2-diff.diff) (should be a lot of break/fix's for pointable types that were serialized as value types before).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
