### PR TITLE
transport: Add accessor method to get slice of Fields

### DIFF
--- a/transport/fieldset.go
+++ b/transport/fieldset.go
@@ -4,36 +4,48 @@ package transport
 
 // FieldSet is a collection of fields grouped by their usage.
 type FieldSet struct {
-	header *Fields
+	header *fields
 }
 
 // NewFieldSet returns an initalized FieldSet.
 func NewFieldSet() *FieldSet {
 	return &FieldSet{
-		header: &Fields{},
+		header: newFields(),
 	}
 }
 
-// GetHeader retrieves the header Field by name, by performing a case-insensitive lookup.
+// GetHeader retrieves the header Field by name, by performing a
+// case-insensitive lookup.
 func (fs *FieldSet) GetHeader(name string) Field {
 	return fs.header.Get(name)
 }
 
-// HasHeader returns whether a matching header Field exists for the given name using case-insensitive lookup.
+// HasHeader returns whether a matching header Field exists for the given
+// name using case-insensitive lookup.
 func (fs *FieldSet) HasHeader(name string) bool {
 	return fs.header.Has(name)
 }
 
-// SetHeader adds field to set of header Fields. If a header field with the same name exists (case-insensitive matching),
-// that field's is replaced with the values from the provided field, with the casing of the name remaining the same.
-// If the field doesn't exist, then it will be added. Returns the old field and true if the field already existed,
-// otherwise returns false.
+// SetHeader adds field to set of header Fields. If a header field
+// with the same name exists (case-insensitive matching), that field's is
+// replaced with the values from the provided field, with the casing of the
+// name remaining the same. If the field doesn't exist, then it will be added.
+// Returns the old field and true if the field already existed, otherwise
+// returns false.
 func (fs *FieldSet) SetHeader(field Field) (old Field, ok bool) {
 	return fs.header.Set(field)
 }
 
-// RemoveHeader searches the header Fields for a Field matching the provided name (case-insensitive), and removes the field if
-// found. Returns the old field and true if the field was removed, otherwise returns false.
+// RemoveHeader searches the header Fields for a Field matching the
+// provided name (case-insensitive), and removes the field if found. Returns
+// the old field and true if the field was removed, otherwise returns false.
 func (fs *FieldSet) RemoveHeader(name string) (old Field, ok bool) {
 	return fs.header.Remove(name)
+}
+
+// GetHeaderFields returns a copy of the Header fields. Any
+// modifications to the returned slice of Fields will not be reflected upstream
+// in the FieldSet.
+func (fs *FieldSet) GetHeaderFields() []Field {
+	return fs.header.GetFields()
 }

--- a/transport/internal/fieldset/main.go
+++ b/transport/internal/fieldset/main.go
@@ -31,7 +31,7 @@ package transport
 // FieldSet is a collection of fields grouped by their usage.
 type FieldSet struct {
 {{- range $name, $_ := $.Locations -}}
-	{{ (privateSymbol $name) }} *Fields
+	{{ (privateSymbol $name) }} *fields
 {{ end -}}
 }
 
@@ -39,7 +39,7 @@ type FieldSet struct {
 func NewFieldSet() *FieldSet {
 	return &FieldSet{
 	{{- range $name, $_ := $.Locations }}
-		{{ (privateSymbol $name) }}: &Fields{},
+		{{ (privateSymbol $name) }}: newFields(),
 	{{ end -}}
 	}
 }
@@ -48,31 +48,44 @@ func NewFieldSet() *FieldSet {
 {{ $privateName := (privateSymbol $name) -}}
 {{ $publicName := (publicSymbol $name) -}}
 {{ $get := (join "Get" $publicName) -}}
-// {{ $get }} retrieves the {{ $name }} Field by name, by performing a case-insensitive lookup.
+// {{ $get }} retrieves the {{ $name }} Field by name, by performing a
+// case-insensitive lookup.
 func (fs *FieldSet) {{ $get }}(name string) Field {
 	return fs.{{ $privateName }}.Get(name)
 }
 
 {{ $has := (join "Has" $publicName) -}}
-// {{ $has }} returns whether a matching {{ $name }} Field exists for the given name using case-insensitive lookup.
+// {{ $has }} returns whether a matching {{ $name }} Field exists for the given
+// name using case-insensitive lookup.
 func (fs *FieldSet) {{ $has }}(name string) bool {
 	return fs.{{ $privateName }}.Has(name)
 }
 
 {{ $set := (join "Set" $publicName) -}}
-// {{ $set }} adds field to set of {{ $name }} Fields. If a {{ $name }} field with the same name exists (case-insensitive matching),
-// that field's is replaced with the values from the provided field, with the casing of the name remaining the same.
-// If the field doesn't exist, then it will be added. Returns the old field and true if the field already existed,
-// otherwise returns false.
+// {{ $set }} adds field to set of {{ $name }} Fields. If a {{ $name }} field
+// with the same name exists (case-insensitive matching), that field's is
+// replaced with the values from the provided field, with the casing of the
+// name remaining the same. If the field doesn't exist, then it will be added.
+// Returns the old field and true if the field already existed, otherwise
+// returns false.
 func (fs *FieldSet) {{ $set }}(field Field) (old Field, ok bool) {
 	return fs.{{ $privateName }}.Set(field)
 }
 
 {{ $remove := (join "Remove" $publicName) -}}
-// {{ $remove }} searches the {{ $name }} Fields for a Field matching the provided name (case-insensitive), and removes the field if
-// found. Returns the old field and true if the field was removed, otherwise returns false.
+// {{ $remove }} searches the {{ $name }} Fields for a Field matching the
+// provided name (case-insensitive), and removes the field if found. Returns
+// the old field and true if the field was removed, otherwise returns false.
 func (fs *FieldSet) {{ $remove }}(name string) (old Field, ok bool) {
 	return fs.{{ $privateName }}.Remove(name)
+}
+
+{{ $getFields := (join "Get" $publicName "Fields") -}}
+// {{ $getFields }} returns a copy of the {{ $publicName }} fields. Any
+// modifications to the returned slice of Fields will not be reflected upstream
+// in the FieldSet.
+func (fs *FieldSet) {{ $getFields }}() []Field {
+	return fs.{{ $privateName }}.GetFields()
 }
 {{- end -}}
 {{- end }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds an accessor method to FieldSet, GetHeaderFields. This method returns copy of the slice of Field stored within the FieldSet.

Makes Fields type unexported since it doesn't need to be exposed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
