### PR TITLE
[issues-391] Fix document typecheck in encoding  for nested types

### DIFF
--- a/.changelog/52ea7af068da449f918698755a7d0f01.json
+++ b/.changelog/52ea7af068da449f918698755a7d0f01.json
@@ -1,0 +1,8 @@
+{
+    "id": "52ea7af0-68da-449f-9186-98755a7d0f01",
+    "type": "bugfix",
+    "description": "fixed document type checking for encoding nested types",
+    "modules": [
+        "."
+    ]
+}

--- a/document/json/encoder_test.go
+++ b/document/json/encoder_test.go
@@ -1,6 +1,7 @@
 package json_test
 
 import (
+	"github.com/aws/smithy-go/document"
 	"github.com/aws/smithy-go/document/internal/serde"
 	"github.com/aws/smithy-go/document/json"
 	"github.com/google/go-cmp/cmp"
@@ -41,10 +42,20 @@ func TestEncoder_Encode(t *testing.T) {
 
 func TestNewEncoderUnsupportedTypes(t *testing.T) {
 	type customTime time.Time
+	type noSerde = document.NoSerde
+	type NestedThing struct {
+		SomeThing string
+		noSerde
+	}
+	type Thing struct {
+		OtherThing  string
+		NestedThing NestedThing
+	}
 
 	cases := []interface{}{
 		time.Now().UTC(),
 		customTime(time.Now().UTC()),
+		Thing{OtherThing: "foo", NestedThing: NestedThing{SomeThing: "bar"}},
 	}
 
 	encoder := json.NewEncoder()


### PR DESCRIPTION
This resolves github issue 391 where encoding of document types is not checking to see if nested types are explicitly marked for no serialization or deserialization. In order to to check for every layer of nesting, I moved the noserde check to the recursive layer from the original top-level function. This mimics how it correctly works in decoding

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
