### PR TITLE
Upgrade to Smithy 1.26.x

### DIFF
--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,2 +1,2 @@
-smithyVersion=1.26.0
+smithyVersion=[1.26.0,1.27.0[
 smithyGradleVersion=0.6.0


### PR DESCRIPTION
*Issue #, if available:*

N/A

---

*Description of changes:*

Upgrade to smithy 1.26.x using a version range.

---

*Testing:*

1. smithy-go: `make smithy-clean smithy-build smithy-publish-local smithy-clean`
2. aws-sdk-go-v2: `make`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
