### PR TITLE
Update intEnum generation to use type alias

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenUtils.java
@@ -419,6 +419,7 @@ public final class CodegenUtils {
             case BYTE:
             case SHORT:
             case INTEGER:
+            case INT_ENUM:
             case LONG:
             case FLOAT:
             case DOUBLE:

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/IntEnumGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/IntEnumGenerator.java
@@ -48,7 +48,9 @@ final class IntEnumGenerator implements Runnable {
     public void run() {
         Symbol symbol = symbolProvider.toSymbol(shape);
 
-        writer.write("type $L int32", symbol.getName()).write("");
+        // TODO(smithy): Use type alias instead of type definition until refactoring
+        // protocol generators is prioritized.
+        writer.write("type $L = int32", symbol.getName()).write("");
 
         writer.writeDocs(String.format("Enum values for %s", symbol.getName()));
         Set<String> constants = new LinkedHashSet<>();
@@ -84,6 +86,9 @@ final class IntEnumGenerator implements Runnable {
             }
         }).write("");
 
+        // TODO(smithy): type aliases don't allow defining methods on base types (e.g. int32).
+        // Uncomment generating the Value() method when the type alias is migrated to type definition.
+        /*
         writer.writeDocs(String.format("Values returns all known values for %s. Note that this can be expanded in the "
                 + "future, and so it is only as up to date as the client.%n%nThe ordering of this slice is not "
                 + "guaranteed to be stable across updates.", symbol.getName()));
@@ -94,5 +99,6 @@ final class IntEnumGenerator implements Runnable {
                 }
             });
         });
+        */
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeValueGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeValueGenerator.java
@@ -304,6 +304,7 @@ public final class ShapeValueGenerator {
                 funcName = "Int16";
                 break;
             case INTEGER:
+            case INT_ENUM:
                 funcName = "Int32";
                 break;
             case LONG:
@@ -669,6 +670,7 @@ public final class ShapeValueGenerator {
                 case BYTE:
                 case SHORT:
                 case INTEGER:
+                case INT_ENUM:
                 case LONG:
                 case FLOAT:
                 case DOUBLE:

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -767,6 +767,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 locationEncoder.accept(writer, "Short(" + operand + ")");
                 break;
             case INTEGER:
+            case INT_ENUM:
                 locationEncoder.accept(writer, "Integer(" + operand + ")");
                 break;
             case LONG:
@@ -1211,6 +1212,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 writer.write("if err != nil { return err }");
                 return "int16(vv)";
             case INTEGER:
+            case INT_ENUM:
                 writer.addUseImports(SmithyGoDependency.STRCONV);
                 writer.write("vv, err := strconv.ParseInt($L, 0, 32)", operand);
                 writer.write("if err != nil { return err }");

--- a/codegen/smithy-go-codegen/src/main/resources/software/amazon/smithy/go/codegen/smithy-tests/int-enum-shape-test/expected/types/enums.go
+++ b/codegen/smithy-go-codegen/src/main/resources/software/amazon/smithy/go/codegen/smithy-tests/int-enum-shape-test/expected/types/enums.go
@@ -3,7 +3,7 @@
 
 package types
 
-type Number int32
+type Number = int32
 
 // Enum values for Number
 const (
@@ -21,27 +21,6 @@ const (
 	NumberQueen Number = 12
 	NumberKing Number = 13
 )
-
-// Values returns all known values for Number. Note that this can be expanded in
-// the future, and so it is only as up to date as the client. The ordering of this
-// slice is not guaranteed to be stable across updates.
-func (Number) Values() []Number {
-	return []Number{
-		1,
-		2,
-		3,
-		4,
-		5,
-		6,
-		7,
-		8,
-		9,
-		10,
-		11,
-		12,
-		13,
-	}
-}
 
 type Suit string
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

---

*Description of changes:*

Due to type definitions requiring strict casting and implementation
overhead in protocol generation, this commit uses type aliases to
generate intEnums as an intermediate step until migrating back to
type definitions.

This change is backwards compatible except for the removed `Values()`
method that was on intEnum type definitions, but not definable on type
aliases since defining methods on base types (`int32`) is not permitted.

Note: No AWS services use the intEnum shape YET, so for aws-sdk-go-v2, it is backwards compatible.

---

*Testing:*

Temporarily change all repo smithy versions to 1.28.0 (not published at the time of the PR).

1. smithy: `./gradlew clean build check publishToMavenLocal` using this PR: https://github.com/awslabs/smithy/pull/1492
2. smithy-go: `make smithy-clean smithy-build smithy-publish-local smithy-clean`
3. aws-sdk-go-v2: `make`
    - Temporarily change `Makefile` `-fail-fast=false`
    - Protocol Tests related to intEnums pass

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
