### PR TITLE
Add `ErrorCodeOverride` to error structs

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
@@ -122,6 +122,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
                 .put("ErrorFault", "ErrorFault_")
                 .put("Unwrap", "Unwrap_")
                 .put("Error", "Error_")
+                .put("ErrorCodeOverride", "ErrorCodeOverride_")
                 .build();
 
         errorMemberEscaper = ReservedWordSymbolProvider.builder()

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
@@ -368,11 +368,16 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         });
         writer.write("");
 
-        Set<StructureShape> errorShapes = HttpProtocolGeneratorUtils.generateErrorDispatcher(
-                context, operation, responseType, this::writeErrorMessageCodeDeserializer,
-                this::getOperationErrors);
+        Set<StructureShape> errorShapes = generateErrorShapes(context, operation, responseType);
         deserializingErrorShapes.addAll(errorShapes);
         deserializingDocumentShapes.addAll(errorShapes);
+    }
+
+    protected Set<StructureShape> generateErrorShapes(
+        GenerationContext context, OperationShape operation, Symbol responseType) {
+        return HttpProtocolGeneratorUtils.generateErrorDispatcher(
+                context, operation, responseType, this::writeErrorMessageCodeDeserializer,
+                this::getOperationErrors);
     }
 
     /**


### PR DESCRIPTION
*Description of changes:*
Makes changes to AwsJson protocol generator.
* Introduces `ErrorCodeOverride` field to error structs
* Returns `ErrorCodeOverride` if not empty. Else returns default error code
* Introduces `generateErrorShape` method to allow override default error block for unmodeled errors

For example, AWS code bases would have something like the following to override `generateErrorShape`:

```java
    @Override
    protected Set<StructureShape> generateErrorShapes(
        GenerationContext context, OperationShape operation, Symbol responseType) {
        if (isAwsQueryCompatibleTraitFound(context)) {
            return HttpProtocolGeneratorUtils.generateErrorDispatcher(
                context, operation, responseType, this::writeErrorMessageCodeDeserializer,
                this::getOperationErrors, (writer) -> AwsJsonRpc1_0.awsQueryCompatibleDefaultBlockWriter(writer));
        } else {
            return HttpProtocolGeneratorUtils.generateErrorDispatcher(
                context, operation, responseType, this::writeErrorMessageCodeDeserializer,
                this::getOperationErrors);
        }
    }

    private static void awsQueryCompatibleDefaultBlockWriter(GoWriter writer) {
        writer.openBlock("default:", "", () -> {
            writer.openBlock("genericError := &smithy.GenericAPIError{", "}", () -> {
                    writer.write("Code: getAwsQueryErrorCode(response),");
                writer.write("Message: errorMessage,");
            });
            writer.write("return genericError");
        });
    }
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
