### PR TITLE
Path element replace token can match with different suffixes

### DIFF
--- a/encoding/httpbinding/path_replace.go
+++ b/encoding/httpbinding/path_replace.go
@@ -26,7 +26,19 @@ func replacePathElement(path, fieldBuf []byte, key, val string, escape bool) ([]
 	fieldBuf = append(fieldBuf, uriTokenStart)
 	fieldBuf = append(fieldBuf, key...)
 
-	start := bytes.Index(path, fieldBuf)
+	completeFieldBuf := make([]byte, len(fieldBuf))
+	copy(completeFieldBuf, fieldBuf)
+	completeFieldBuf = append(completeFieldBuf, uriTokenStop)
+
+	skipFieldBuf := make([]byte, len(fieldBuf))
+	copy(skipFieldBuf, fieldBuf)
+	skipFieldBuf = append(skipFieldBuf, uriTokenSkip)
+	skipFieldBuf = append(skipFieldBuf, uriTokenStop)
+
+	start := bytes.Index(path, completeFieldBuf)
+	if start == -1 {
+		start = bytes.Index(path, skipFieldBuf)
+	}
 	end := start + len(fieldBuf)
 	if start < 0 || len(path[end:]) == 0 {
 		// TODO what to do about error?

--- a/encoding/httpbinding/path_replace_test.go
+++ b/encoding/httpbinding/path_replace_test.go
@@ -40,6 +40,12 @@ func TestPathReplace(t *testing.T) {
 			ExpRawPath: []byte("/reallylongvaluegoesheregrowingarray/{key+}"),
 			Key:        "bucket", Val: "reallylongvaluegoesheregrowingarray",
 		},
+		{
+			Orig:       []byte("/{bucketkey}/{bucket}"),
+			ExpPath:    []byte("/{bucketkey}/value"),
+			ExpRawPath: []byte("/{bucketkey}/value"),
+			Key:        "bucket", Val: "value",
+		},
 	}
 
 	var buffer [64]byte


### PR DESCRIPTION
*Issue #, if available:*

This issue prevents the go aws sdk from making calls to service catalogue

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
