### PR TITLE
fix: disable request body close (as suggested by psmarcin)

### DIFF
--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -75,9 +75,9 @@ func (c ClientHandler) Handle(ctx context.Context, input interface{}) (
 	// HTTP RoundTripper *should* close the request body. But this may not happen in a timely manner.
 	// So instead Smithy *Request Build wraps the body to be sent in a safe closer that will clear the
 	// stream reference so that it can be safely reused.
-	if builtRequest.Body != nil {
+	/*if builtRequest.Body != nil {
 		_ = builtRequest.Body.Close()
-	}
+	}*/
 
 	return &Response{Response: resp}, metadata, err
 }


### PR DESCRIPTION
Disabling closing the request body too soon, as the http client returns a 200 response, but the body has not yet been fully parsed and is being closed too soon, which leads to an error in our tests.

This was suggested by @psmarcin and I am adding this fix to my fork.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
