### PR TITLE
Fix time parsing for non-GMT timezone

### DIFF
--- a/time/time.go
+++ b/time/time.go
@@ -14,12 +14,15 @@ const (
 	dateTimeFormatInputNoZ = "2006-01-02T15:04:05.999999999"
 	dateTimeFormatOutput   = "2006-01-02T15:04:05.999Z"
 
-	// httpDateFormat is a date time defined by RFC 7231#section-7.1.1.1
-	// IMF-fixdate with no UTC offset.
-	httpDateFormat = "Mon, 02 Jan 2006 15:04:05 GMT"
+	// httpDateFormatOutputGMT is a date time defined by
+	// RFC 7231#section-7.1.1.1 IMF-fixdate with no UTC offset.
+	// This format is always applied to UTC location, but must set GMT
+	// as timezone for RFC compatibility.
+	httpDateFormatOutputGMT = "Mon, 02 Jan 2006 15:04:05 GMT"
+
 	// Additional formats needed for compatibility.
-	httpDateFormatSingleDigitDay             = "Mon, _2 Jan 2006 15:04:05 GMT"
-	httpDateFormatSingleDigitDayTwoDigitYear = "Mon, _2 Jan 06 15:04:05 GMT"
+	httpDateFormatSingleDigitDay             = "Mon, _2 Jan 2006 15:04:05 MST"
+	httpDateFormatSingleDigitDayTwoDigitYear = "Mon, _2 Jan 06 15:04:05 MST"
 )
 
 var millisecondFloat = big.NewFloat(1e3)
@@ -47,7 +50,7 @@ func ParseDateTime(value string) (time.Time, error) {
 //
 // Example: Tue, 29 Apr 2014 18:30:38 GMT
 func FormatHTTPDate(value time.Time) string {
-	return value.UTC().Format(httpDateFormat)
+	return value.UTC().Format(httpDateFormatOutputGMT)
 }
 
 // ParseHTTPDate parses a string as a http-date, (RFC 7231#section-7.1.1.1 IMF-fixdate)
@@ -55,7 +58,7 @@ func FormatHTTPDate(value time.Time) string {
 // Example: Tue, 29 Apr 2014 18:30:38 GMT
 func ParseHTTPDate(value string) (time.Time, error) {
 	return tryParse(value,
-		httpDateFormat,
+		time.RFC1123,
 		httpDateFormatSingleDigitDay,
 		httpDateFormatSingleDigitDayTwoDigitYear,
 		time.RFC850,

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -119,6 +119,18 @@ func TestParseHTTPDate(t *testing.T) {
 			date:   "Fri, 15 Feb 2021 19:12:15 GMT",
 			expect: time.Date(2021, 2, 15, 19, 12, 15, 0, time.UTC),
 		},
+		"with leading zero on day UTC": {
+			date:   "Fri, 05 Feb 2021 19:12:15 UTC",
+			expect: time.Date(2021, 2, 5, 19, 12, 15, 0, time.UTC),
+		},
+		"without leading zero on day UTC": {
+			date:   "Fri, 5 Feb 2021 19:12:15 UTC",
+			expect: time.Date(2021, 2, 5, 19, 12, 15, 0, time.UTC),
+		},
+		"with double digit day UTC": {
+			date:   "Fri, 15 Feb 2021 19:12:15 UTC",
+			expect: time.Date(2021, 2, 15, 19, 12, 15, 0, time.UTC),
+		},
 		"RFC850": {
 			date:   "Friday, 05-Feb-21 19:12:15 UTC",
 			expect: time.Date(2021, 2, 5, 19, 12, 15, 0, time.UTC),
@@ -165,7 +177,7 @@ func TestParseHTTPDate(t *testing.T) {
 			if result.IsZero() {
 				t.Fatalf("expected non-zero timestamp")
 			}
-			if tt.expect != result {
+			if !tt.expect.Equal(result) {
 				t.Fatalf("expected %q, got %q", tt.expect, result)
 			}
 		})


### PR DESCRIPTION
Replace httpDateFormat with time.RFC1123 in ParseHTTPDate() for parsing responses not using GMT. The stdlib time package uses MST for the timezone in the format strings. Having GMT in the format string is only valid if the time string to be parsed is also GMT.

This was causing the following parse errors for a HeadObject Last-Modified time value when response was in UTC: parsing time "Thu, 01 Jan 1970 00:00:00 UTC" as "Mon, 02 Jan 2006 15:04:05 GMT": cannot parse "UTC" as " GMT"#012

This also adds test cases for UTC date strings.

httpDateFormat renamed to httpDateFormatOutputGMT to clarify this is for output formatting compatible with RFC requiring GMT timezone. This should not be used to parse input strings.

*Description of changes:*

- replace httpDateFormat with time.RFC1123 in ParseHTTPDate for non-GMT compatible parsing
- fix httpDateFormatSingleDigitDay and httpDateFormatSingleDigitDayTwoDigitYear timezone for time parsing
- rename httpDateFormat to httpDateFormatOutputGMT to clarify use for output format only
- add tests to include non-GMT formatted date strings

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
