### PR TITLE
Fix generate standalone go module unit test

### DIFF
--- a/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GenerateStandaloneGoModuleTest.java
+++ b/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GenerateStandaloneGoModuleTest.java
@@ -99,19 +99,4 @@ public class GenerateStandaloneGoModuleTest {
                     w.write("return \"hello!\"");
                 });
     }
-
-    private static Path getTestOutputDir() {
-        var testWorkspace = System.getenv("SMITHY_GO_TEST_WORKSPACE");
-        if (testWorkspace != null) {
-            return Path.of(testWorkspace).toAbsolutePath();
-        }
-
-        return Path.of(System.getProperty("user.dir"))
-                .resolve("build")
-                .resolve("test-generated")
-                .resolve("go")
-                .resolve("internal")
-                .resolve("testmodule")
-                .toAbsolutePath();
-    }
 }

--- a/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GenerateStandaloneGoModuleTest.java
+++ b/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GenerateStandaloneGoModuleTest.java
@@ -6,6 +6,7 @@ import static software.amazon.smithy.go.codegen.TestUtils.hasGoInstalled;
 import static software.amazon.smithy.go.codegen.TestUtils.makeGoModule;
 import static software.amazon.smithy.go.codegen.TestUtils.testGoModule;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -23,7 +24,7 @@ public class GenerateStandaloneGoModuleTest {
             return;
         }
 
-        var testPath = getTestOutputDir();
+        var testPath = Files.createTempDirectory(getClass().getName());
         LOGGER.warning("generating test suites into " + testPath);
 
         var fileManifest = FileManifest.create(testPath);


### PR DESCRIPTION
This unit test doesnt seem to play nice when run within a directory with a `go.work` file. This fixes that based on the suggestion described in the issue below

Fixes https://github.com/aws/smithy-go/issues/392