### PR TITLE
Use GoModuleInfo for both ManifestWriter and GoModGenerator

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -255,10 +255,15 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
         List<SymbolDependency> dependencies = writers.getDependencies();
         writers.flushWriters();
 
-        GoModGenerator.writeGoMod(settings, fileManifest, SymbolDependency.gatherDependencies(dependencies.stream()));
+        GoModuleInfo goModuleInfo = new GoModuleInfo.Builder()
+            .goDirective(settings.getGoDirective())
+            .dependencies(dependencies)
+            .build();
+
+        GoModGenerator.writeGoMod(settings, fileManifest, goModuleInfo);
 
         LOGGER.fine("Generating build manifest file");
-        ManifestWriter.writeManifest(settings, model, fileManifest, dependencies);
+        ManifestWriter.writeManifest(settings, model, fileManifest, goModuleInfo);
     }
 
     @Override

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoModuleInfo.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoModuleInfo.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import software.amazon.smithy.codegen.core.SymbolDependency;
+import software.amazon.smithy.utils.BuilderRef;
+import software.amazon.smithy.utils.SmithyBuilder;
+
+public final class GoModuleInfo {
+
+    public static final String DEFAULT_GO_DIRECTIVE = "1.15";
+
+    private List<SymbolDependency> dependencies;
+
+    private List<SymbolDependency> stdLibDependencies;
+    private List<SymbolDependency> nonStdLibDependencies;
+
+    private String goDirective;
+    private Map<String, String> minimumNonStdLibDependencies;
+
+    private GoModuleInfo(Builder builder) {
+        goDirective = SmithyBuilder.requiredState("goDirective", builder.goDirective);
+        dependencies = builder.dependencies.copy();
+
+        // Intermediate dependency information
+        stdLibDependencies = gatherStdLibDependencies();
+        nonStdLibDependencies = gatherNonStdLibDependencies();
+
+        // Module information used by ManifestWriter and GoModGenerator
+        goDirective = calculateMinimumGoDirective();
+        minimumNonStdLibDependencies = gatherMinimumNonStdDependencies();
+    }
+
+    public String getGoDirective() {
+        return goDirective;
+    }
+
+    public Map<String, String> getMinimumNonStdLibDependencies() {
+        return minimumNonStdLibDependencies;
+    }
+
+    private String calculateMinimumGoDirective() {
+        String minimumGoDirective = goDirective;
+        if (minimumGoDirective.compareTo(DEFAULT_GO_DIRECTIVE) < 0) {
+            throw new IllegalArgumentException(
+                "`goDirective` must be greater than or equal to the default go directive ("
+                + DEFAULT_GO_DIRECTIVE + "): " + minimumGoDirective);
+        }
+        for (SymbolDependency dependency : stdLibDependencies) {
+            var otherVersion = dependency.getVersion();
+            if (minimumGoDirective.compareTo(otherVersion) < 0) {
+                minimumGoDirective = otherVersion;
+            }
+        }
+        return minimumGoDirective;
+    }
+
+    private List<SymbolDependency> gatherStdLibDependencies() {
+        return filterDependencies(dependency ->
+            dependency.getDependencyType().equals(GoDependency.Type.STANDARD_LIBRARY.toString()));
+    }
+
+    private List<SymbolDependency> gatherNonStdLibDependencies() {
+        return filterDependencies(dependency ->
+            !dependency.getDependencyType().equals(GoDependency.Type.STANDARD_LIBRARY.toString()));
+    }
+
+    private List<SymbolDependency> filterDependencies(
+        Predicate<SymbolDependency> predicate
+    ) {
+        List<SymbolDependency> filteredDependencies = new ArrayList<>();
+        for (SymbolDependency dependency : dependencies) {
+            if (predicate.test(dependency)) {
+                filteredDependencies.add(dependency);
+            }
+        }
+        return filteredDependencies;
+    }
+
+    private Map<String, String> gatherMinimumNonStdDependencies() {
+        return SymbolDependency.gatherDependencies(nonStdLibDependencies.stream(),
+                GoDependency::mergeByMinimumVersionSelection).entrySet().stream().flatMap(
+                entry -> entry.getValue().entrySet().stream()).collect(
+                Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getVersion(), (a, b) -> b, TreeMap::new));
+    }
+
+    public static class Builder implements SmithyBuilder<GoModuleInfo> {
+        private String goDirective = DEFAULT_GO_DIRECTIVE;
+        private final BuilderRef<List<SymbolDependency>> dependencies = BuilderRef.forList();
+
+        public Builder goDirective(String goDirective) {
+            this.goDirective = goDirective;
+            return this;
+        }
+
+        public Builder dependencies(List<SymbolDependency> dependencies) {
+            this.dependencies.clear();
+            this.dependencies.get().addAll(dependencies);
+            return this;
+        }
+
+        @Override
+        public GoModuleInfo build() {
+            return new GoModuleInfo(this);
+        }
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoSettings.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoSettings.java
@@ -31,8 +31,6 @@ import software.amazon.smithy.model.shapes.ShapeId;
  */
 public final class GoSettings {
 
-    private static final String DEFAULT_GO_DIRECTIVE = "1.15";
-
     private static final String SERVICE = "service";
     private static final String MODULE_NAME = "module";
     private static final String MODULE_DESCRIPTION = "moduleDescription";
@@ -45,7 +43,7 @@ public final class GoSettings {
     private String moduleDescription = "";
     private String moduleVersion;
     private Boolean generateGoMod = false;
-    private String goDirective = DEFAULT_GO_DIRECTIVE;
+    private String goDirective = GoModuleInfo.DEFAULT_GO_DIRECTIVE;
     private ShapeId protocol;
 
     /**
@@ -65,7 +63,7 @@ public final class GoSettings {
                 MODULE_DESCRIPTION, settings.getModuleName() + " client"));
         settings.setModuleVersion(config.getStringMemberOrDefault(MODULE_VERSION, null));
         settings.setGenerateGoMod(config.getBooleanMemberOrDefault(GENERATE_GO_MOD, false));
-        settings.setGoDirective(config.getStringMemberOrDefault(GO_DIRECTIVE, DEFAULT_GO_DIRECTIVE));
+        settings.setGoDirective(config.getStringMemberOrDefault(GO_DIRECTIVE, GoModuleInfo.DEFAULT_GO_DIRECTIVE));
         return settings;
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ManifestWriter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ManifestWriter.java
@@ -21,16 +21,11 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.TreeMap;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.codegen.core.CodegenException;
-import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.BooleanNode;
@@ -38,7 +33,6 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.traits.UnstableTrait;
-import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.SmithyBuilder;
 
 /**
@@ -53,15 +47,13 @@ public final class ManifestWriter {
 
     private final String moduleName;
     private final FileManifest fileManifest;
-    private final List<SymbolDependency> dependencies;
-    private final String goDirective;
+    private final GoModuleInfo goModuleInfo;
     private final boolean isUnstable;
 
     private ManifestWriter(Builder builder) {
         moduleName = SmithyBuilder.requiredState("moduleName", builder.moduleName);
         fileManifest = SmithyBuilder.requiredState("fileManifest", builder.fileManifest);
-        dependencies = builder.dependencies.copy();
-        goDirective = builder.goDirective;
+        goModuleInfo = SmithyBuilder.requiredState("goModuleInfo", builder.goModuleInfo);
         isUnstable = builder.isUnstable;
     }
 
@@ -71,19 +63,18 @@ public final class ManifestWriter {
      * @param settings     the go settings
      * @param model        the smithy model
      * @param fileManifest the file manifest
-     * @param dependencies the list of symbol dependencies
+     * @param goModuleInfo the go module info
      */
     public static void writeManifest(
             GoSettings settings,
             Model model,
             FileManifest fileManifest,
-            List<SymbolDependency> dependencies
+            GoModuleInfo goModuleInfo
     ) {
         builder()
                 .moduleName(settings.getModuleName())
                 .fileManifest(fileManifest)
-                .dependencies(dependencies)
-                .goDirective(settings.getGoDirective())
+                .goModuleInfo(goModuleInfo)
                 .isUnstable(settings.getService(model).getTrait(UnstableTrait.class).isPresent())
                 .build()
                 .writeManifest();
@@ -113,57 +104,33 @@ public final class ManifestWriter {
     }
 
     private Node buildManifestFile() {
-        List<SymbolDependency> nonStdLib = new ArrayList<>();
-        Optional<String> minimumGoVersion = Optional.empty();
+        Map<StringNode, Node> dependencyNodes = gatherDependencyNodes(goModuleInfo.getMinimumNonStdLibDependencies());
+        Collection<String> generatedFiles = gatherGeneratedFiles(fileManifest);
+        return ObjectNode.objectNode(Map.of(
+            StringNode.from("module"), StringNode.from(moduleName),
+            StringNode.from("go"), StringNode.from(goModuleInfo.getGoDirective()),
+            StringNode.from("dependencies"), ObjectNode.objectNode(dependencyNodes),
+            StringNode.from("files"), ArrayNode.fromStrings(generatedFiles),
+            StringNode.from("unstable"), BooleanNode.from(isUnstable)
+        )).withDeepSortedKeys();
+    }
 
-        for (SymbolDependency dependency : dependencies) {
-            if (!dependency.getDependencyType().equals(GoDependency.Type.STANDARD_LIBRARY.toString())) {
-                nonStdLib.add(dependency);
-                continue;
-            }
-
-            var otherVersion = dependency.getVersion();
-            if (minimumGoVersion.isPresent()) {
-                if (minimumGoVersion.get().compareTo(otherVersion) < 0) {
-                    minimumGoVersion = Optional.of(otherVersion);
-                }
-            } else {
-                minimumGoVersion = Optional.of(otherVersion);
-            }
-        }
-
-        Map<StringNode, Node> manifestNodes = new HashMap<>();
-
-        Map<String, String> minimumDependencies = gatherMinimumDependencies(nonStdLib.stream());
-
+    private Map<StringNode, Node> gatherDependencyNodes(Map<String, String> dependencies) {
         Map<StringNode, Node> dependencyNodes = new HashMap<>();
-        for (Map.Entry<String, String> entry : minimumDependencies.entrySet()) {
+        for (Map.Entry<String, String> entry : dependencies.entrySet()) {
             dependencyNodes.put(StringNode.from(entry.getKey()), StringNode.from(entry.getValue()));
         }
+        return dependencyNodes;
+    }
 
+    private static Collection<String> gatherGeneratedFiles(FileManifest fileManifest) {
         Collection<String> generatedFiles = new ArrayList<>();
         Path baseDir = fileManifest.getBaseDir();
         for (Path filePath : fileManifest.getFiles()) {
             generatedFiles.add(baseDir.relativize(filePath).toString());
         }
         generatedFiles = generatedFiles.stream().sorted().collect(Collectors.toList());
-
-        manifestNodes.put(StringNode.from("module"), StringNode.from(moduleName));
-        manifestNodes.put(StringNode.from("go"), StringNode.from(minimumGoVersion.orElse(this.goDirective)));
-        manifestNodes.put(StringNode.from("dependencies"), ObjectNode.objectNode(dependencyNodes));
-        manifestNodes.put(StringNode.from("files"), ArrayNode.fromStrings(generatedFiles));
-        manifestNodes.put(StringNode.from("unstable"), BooleanNode.from(isUnstable));
-
-        return ObjectNode.objectNode(manifestNodes).withDeepSortedKeys();
-    }
-
-    private static Map<String, String> gatherMinimumDependencies(
-            Stream<SymbolDependency> symbolStream
-    ) {
-        return SymbolDependency.gatherDependencies(symbolStream,
-                GoDependency::mergeByMinimumVersionSelection).entrySet().stream().flatMap(
-                entry -> entry.getValue().entrySet().stream()).collect(
-                Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getVersion(), (a, b) -> b, TreeMap::new));
+        return generatedFiles;
     }
 
     public static Builder builder() {
@@ -173,8 +140,7 @@ public final class ManifestWriter {
     public static class Builder implements SmithyBuilder<ManifestWriter> {
         private String moduleName;
         private FileManifest fileManifest;
-        private final BuilderRef<List<SymbolDependency>> dependencies = BuilderRef.forList();
-        private String goDirective;
+        private GoModuleInfo goModuleInfo;
         private boolean isUnstable;
 
         public Builder moduleName(String moduleName) {
@@ -187,14 +153,8 @@ public final class ManifestWriter {
             return this;
         }
 
-        public Builder dependencies(List<SymbolDependency> dependencies) {
-            this.dependencies.clear();
-            this.dependencies.get().addAll(dependencies);
-            return this;
-        }
-
-        public Builder goDirective(String minimumGoVersion) {
-            this.goDirective = minimumGoVersion;
+        public Builder goModuleInfo(GoModuleInfo goModuleInfo) {
+            this.goModuleInfo = goModuleInfo;
             return this;
         }
 

--- a/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GenerateStandaloneGoModuleTest.java
+++ b/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GenerateStandaloneGoModuleTest.java
@@ -1,13 +1,11 @@
 package software.amazon.smithy.go.codegen;
 
 import static software.amazon.smithy.go.codegen.GoWriter.goBlockTemplate;
-import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
 import static software.amazon.smithy.go.codegen.TestUtils.hasGoInstalled;
 import static software.amazon.smithy.go.codegen.TestUtils.makeGoModule;
 import static software.amazon.smithy.go.codegen.TestUtils.testGoModule;
 
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Map;
 import java.util.logging.Logger;
 import org.junit.jupiter.api.Test;
@@ -78,10 +76,15 @@ public class GenerateStandaloneGoModuleTest {
         var dependencies = writers.getDependencies();
         writers.flushWriters();
 
+        var goModuleInfo = new GoModuleInfo.Builder()
+                .goDirective(GoModuleInfo.DEFAULT_GO_DIRECTIVE)
+                .dependencies(dependencies)
+                .build();
+
         ManifestWriter.builder()
                 .moduleName("github.com/aws/smithy-go/internal/testmodule")
                 .fileManifest(fileManifest)
-                .dependencies(dependencies)
+                .goModuleInfo(goModuleInfo)
                 .build()
                 .writeManifest();
 


### PR DESCRIPTION
*Issue #, if available:*

Related to changes in #405

---

*Description of changes:*

Currently, `ManifestWriter` and `GoModGenerator` use different
ways to calculate non-standard library dependencies and
the go directive (minimum go version), which could produce
inconsistencies.
    
This commit updates both writers to use the same source of
information (`GoModuleInfo`) for writing `generated.json`
and `go.mod`.

---

*Testing:*

All tests were done in `smithy-go-codegen-test`:

Test Case| `goDirective` in `smithy-build.json` | `goDirective` in `generated.json` | `goDirective` in `go.mod`
---|---|---|---
`goDirective < default` | `1.12` | `IllegalArgumentException` | `IllegalArgumentException`
`goDirective == default` | `1.15` | `1.15` | `1.15`
`goDirective > default` | `1.18` | `1.18` | `1.18`
`goDirective is undefined` | `undefined` | `1.15` | `1.15`

The `IllegalArgumentException` thrown when `goDirective < default` is:

```text
Projection source failed: java.lang.IllegalArgumentException: `goDirective` must be greater than or equal to the default go directive (1.15): 1.12
software.amazon.smithy.go.codegen.GoModuleInfo.calculateMinimumGoDirective(GoModuleInfo.java:63)
...
```

No codegen diff was produced when testing `aws-sdk-go-v2` code generation (`make generate`).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
