### PR TITLE
prevent nil pointer deref in ErrorCode() method of generated structs

### DIFF
--- a/.changelog/935d5acf9da941a2b1b8b326494e5c33.json
+++ b/.changelog/935d5acf9da941a2b1b8b326494e5c33.json
@@ -1,0 +1,8 @@
+{
+    "id": "935d5acf-9da9-41a2-b1b8-b326494e5c33",
+    "type": "bugfix",
+    "description": "Prevent nil pointer dereference when accessing code in generated error structs.",
+    "modules": [
+        "."
+    ]
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
@@ -175,7 +175,7 @@ final class StructureGenerator implements Runnable {
         String errorCode = protocolGenerator == null ? shape.getId().getName(service)
                 : protocolGenerator.getErrorCode(service, shape);
         writer.openBlock("func (e *$L) ErrorCode() string {", "}", structureSymbol.getName(), () -> {
-            writer.openBlock("if e.ErrorCodeOverride == nil {", "}", () -> {
+            writer.openBlock("if e == nil || e.ErrorCodeOverride == nil {", "}", () -> {
                 writer.write("return $S", errorCode);
             });
             writer.write("return *e.ErrorCodeOverride");


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
