### PR TITLE
Add standard lib functions with utility error construct

### DIFF
--- a/codegen/smithy-go-codegen/build.gradle.kts
+++ b/codegen/smithy-go-codegen/build.gradle.kts
@@ -22,8 +22,9 @@ extra["moduleName"] = "software.amazon.smithy.go.codegen"
 dependencies {
     api("software.amazon.smithy:smithy-codegen-core:$smithyVersion")
     implementation("software.amazon.smithy:smithy-waiters:$smithyVersion")
-    api("com.atlassian.commonmark:commonmark:0.15.2")
-    api("org.jsoup:jsoup:1.14.1")
+    implementation("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
+    api("com.atlassian.commonmark:commonmark:0.17.0")
+    api("org.jsoup:jsoup:1.15.3")
     api("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
@@ -101,6 +101,26 @@ public final class GoWriter extends AbstractCodeWriter<GoWriter> {
     // TODO to try to find programming bugs.
 
     /**
+     * Joins multiple writables together within a single writable without newlines between writables in the list.
+     *
+     * @param writables list of writables to join
+     * @param separator separator between writables
+     * @return new writable
+     */
+    public static Writable joinWritables(List<Writable> writables, String separator) {
+        return (GoWriter w) -> {
+            for (int i = 0; i < writables.size(); i++) {
+                var writable = writables.get(i);
+                var sep = separator;
+                if (i == writables.size() - 1) {
+                    sep = "";
+                }
+                w.writeInline("$W" + sep, writable);
+            }
+        };
+    }
+
+    /**
      * Returns a Writable for the string and args to be composed inline to another writer's contents.
      *
      * @param contents string to write.

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -61,6 +61,8 @@ public final class SmithyGoDependency {
     public static final GoDependency SMITHY_DOCUMENT_JSON = smithy("document/json", "smithydocumentjson");
     public static final GoDependency SMITHY_SYNC = smithy("sync", "smithysync");
     public static final GoDependency SMITHY_AUTH_BEARER = smithy("auth/bearer");
+    public static final GoDependency SMITHY_ENDPOINT_RULESFN = smithy("endpoint/rulesfn");
+    public static final GoDependency SMITHY_ENDPOINT_AWSRULESFN = smithy("endpoint/awsrulesfn");
 
     public static final GoDependency GO_CMP = goCmp("cmp");
     public static final GoDependency GO_CMP_OPTIONS = goCmp("cmp/cmpopts");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/ExpressionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/ExpressionGenerator.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.endpoints;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goBlockTemplate;
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.SymbolUtils;
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.rulesengine.language.syntax.Identifier;
+import software.amazon.smithy.rulesengine.language.syntax.expr.Expression;
+import software.amazon.smithy.rulesengine.language.syntax.expr.Literal;
+import software.amazon.smithy.rulesengine.language.syntax.expr.Reference;
+import software.amazon.smithy.rulesengine.language.syntax.expr.Template;
+import software.amazon.smithy.rulesengine.language.syntax.fn.FunctionDefinition;
+import software.amazon.smithy.rulesengine.language.syntax.fn.GetAttr;
+import software.amazon.smithy.rulesengine.language.visit.ExpressionVisitor;
+import software.amazon.smithy.rulesengine.language.visit.TemplateVisitor;
+import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.StringUtils;
+
+final class ExpressionGenerator {
+    private final Scope scope;
+
+    ExpressionGenerator(Scope scope) {
+        this.scope = scope;
+    }
+
+    public GoWriter.Writable generate(Expression expr) {
+        var exprOrRef = expr;
+        var optExprIdent = scope.getIdent(expr);
+        if (optExprIdent.isPresent()) {
+            exprOrRef = new Reference(Identifier.of(optExprIdent.get()), SourceLocation.NONE);
+        }
+        return exprOrRef.accept(new ExprGeneratorVisitor(scope));
+    }
+
+    private record ExprGeneratorVisitor(Scope scope) implements ExpressionVisitor<GoWriter.Writable> {
+
+        @Override
+        public GoWriter.Writable visitLiteral(Literal literal) {
+            return literal.accept(new LiteralGeneratorVisitor(scope));
+        }
+
+        @Override
+        public GoWriter.Writable visitRef(Reference ref) {
+            return goTemplate(ref.getName().toString());
+        }
+
+        @Override
+        public GoWriter.Writable visitGetAttr(GetAttr getAttr) {
+            var target = new ExpressionGenerator(scope).generate(getAttr.getTarget());
+            var path = (GoWriter.Writable) (GoWriter w) -> {
+                getAttr.getPath().stream().toList().forEach((part) -> {
+                    if (part instanceof GetAttr.Part.Key) {
+                        w.writeInline(".$L", getBuiltinMemberName(((GetAttr.Part.Key) part).key()));
+                    } else if (part instanceof GetAttr.Part.Index) {
+                        w.writeInline(".Get($L)", ((GetAttr.Part.Index) part).index());
+                    }
+                });
+            };
+
+            return (GoWriter w) -> w.writeInline("$W$W", target, path);
+        }
+
+        @Override
+        public GoWriter.Writable visitIsSet(Expression expr) {
+            return (GoWriter w) -> {
+                w.write("$W != nil", new ExpressionGenerator(scope).generate(expr));
+            };
+        }
+
+        @Override
+        public GoWriter.Writable visitNot(Expression expr) {
+            return (GoWriter w) -> {
+                w.write("!($W)", new ExpressionGenerator(scope).generate(expr));
+            };
+        }
+
+        @Override
+        public GoWriter.Writable visitBoolEquals(Expression left, Expression right) {
+            return (GoWriter w) -> {
+                var generator = new ExpressionGenerator(scope);
+                w.write("$W == $W", generator.generate(left), generator.generate(right));
+            };
+        }
+
+        @Override
+        public GoWriter.Writable visitStringEquals(Expression left, Expression right) {
+            return (GoWriter w) -> {
+                var generator = new ExpressionGenerator(scope);
+                w.write("$W == $W", generator.generate(left), generator.generate(right));
+            };
+        }
+
+        @Override
+        public GoWriter.Writable visitLibraryFunction(FunctionDefinition fnDef, List<Expression> args) {
+            return new FnGenerator(scope).generate(fnDef, args);
+        }
+    }
+
+    private record LiteralGeneratorVisitor(Scope scope) implements Literal.Vistor<GoWriter.Writable> {
+
+        @Override
+        public GoWriter.Writable visitBool(boolean b) {
+            return goTemplate(String.valueOf(b));
+        }
+
+        @Override
+        public GoWriter.Writable visitString(Template value) {
+            Stream<GoWriter.Writable> parts = value.accept(
+                    new TemplateGeneratorVisitor((expr) -> new ExpressionGenerator(scope).generate(expr)));
+
+            return (GoWriter w) -> {
+                parts.forEach((p) -> w.write("$W", p));
+            };
+        }
+
+        @Override
+        public GoWriter.Writable visitRecord(Map<Identifier, Literal> members) {
+            return goBlockTemplate("map[string]interface{}{", "}",
+                    (w) -> {
+                        members.forEach((k, v) -> {
+                            w.write("$S: $W,", k.getName().toString(), new ExpressionGenerator(scope).generate(v));
+                        });
+                    });
+        }
+
+        @Override
+        public GoWriter.Writable visitTuple(List<Literal> members) {
+            return goBlockTemplate("[]interface{}{", "}",
+                    (w) -> {
+                        members.forEach((v) -> w.write("$W,", new ExpressionGenerator(scope).generate(v)));
+                    });
+        }
+
+        @Override
+        public GoWriter.Writable visitInteger(int i) {
+            return goTemplate(String.valueOf(i));
+        }
+    }
+
+    private record TemplateGeneratorVisitor(
+            Function<Expression, GoWriter.Writable> generator) implements TemplateVisitor<GoWriter.Writable> {
+
+        @Override
+        public GoWriter.Writable visitStaticTemplate(String s) {
+            return (GoWriter w) -> w.write("$S", s);
+        }
+
+        @Override
+        public GoWriter.Writable visitSingleDynamicTemplate(Expression expr) {
+            return this.generator.apply(expr);
+        }
+
+        @Override
+        public GoWriter.Writable visitStaticElement(String s) {
+            return (GoWriter w) -> {
+                w.write("out.WriteString($S)", s);
+            };
+        }
+
+        @Override
+        public GoWriter.Writable visitDynamicElement(Expression expr) {
+            return (GoWriter w) -> {
+                w.write("out.WriteString($W)", this.generator.apply(expr));
+            };
+        }
+
+        @Override
+        public GoWriter.Writable startMultipartTemplate() {
+            return goTemplate("""
+                    func() string {
+                        var out $stringsBuilder:T
+                    """,
+                    MapUtils.of(
+                            "stringsBuilder", SymbolUtils.createValueSymbolBuilder("Builder",
+                                    SmithyGoDependency.STRINGS).build()));
+        }
+
+        @Override
+        public GoWriter.Writable finishMultipartTemplate() {
+            return goTemplate("""
+                        return out.String()
+                    }()
+                    """);
+        }
+    }
+
+    private static String getBuiltinMemberName(Identifier ident) {
+        return StringUtils.capitalize(ident.getName().toString());
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/FnGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/FnGenerator.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.endpoints;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+import static software.amazon.smithy.go.codegen.GoWriter.joinWritables;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.SymbolUtils;
+import software.amazon.smithy.rulesengine.language.syntax.expr.Expression;
+import software.amazon.smithy.rulesengine.language.syntax.fn.FunctionDefinition;
+import software.amazon.smithy.utils.MapUtils;
+
+public class FnGenerator {
+    private final Scope scope;
+    private final FnProvider fnProvider;
+
+    FnGenerator(Scope scope) {
+        this.scope = scope;
+        this.fnProvider = new BuiltInFnProvider();
+    }
+
+    GoWriter.Writable generate(FunctionDefinition fnDef, List<Expression> fnArgs) {
+        var goFn = fnProvider.fnFor(fnDef.getId());
+
+        List<GoWriter.Writable> writableFnArgs = new ArrayList<>();
+        fnArgs.forEach((expr) -> {
+            writableFnArgs.add(new ExpressionGenerator(scope).generate(expr));
+        });
+
+        // Add error collector as last parameter in all builtin functions so that
+        // unexpected or failed endpoint resolution can be investigated.
+        writableFnArgs.add((GoWriter w) -> w.write("ec"));
+
+        return goTemplate("$fn:T($args:W)", MapUtils.of(
+                "fn", goFn,
+                "args", joinWritables(writableFnArgs, ", ")));
+    }
+
+    interface FnProvider {
+        Symbol fnFor(String name);
+    }
+
+    static class BuiltInFnProvider implements FnProvider {
+
+        @Override
+        public Symbol fnFor(String name) {
+            return switch (name) {
+                case "aws.partition" -> SymbolUtils.createValueSymbolBuilder("GetPartition",
+                        SmithyGoDependency.SMITHY_ENDPOINT_AWSRULESFN).build();
+                case "aws.parseArn" -> SymbolUtils.createValueSymbolBuilder("ParseARN",
+                        SmithyGoDependency.SMITHY_ENDPOINT_AWSRULESFN).build();
+                case "aws.isVirtualHostableS3Bucket" ->
+                    SymbolUtils.createValueSymbolBuilder("IsVirtualHostableS3Bucket",
+                            SmithyGoDependency.SMITHY_ENDPOINT_AWSRULESFN).build();
+                case "isValidHostLabel" -> SymbolUtils.createValueSymbolBuilder("IsValidHostLabel",
+                        SmithyGoDependency.SMITHY_ENDPOINT_RULESFN).build();
+                case "parseURL" -> SymbolUtils.createValueSymbolBuilder("ParseURL",
+                        SmithyGoDependency.SMITHY_ENDPOINT_RULESFN).build();
+                case "substring" -> SymbolUtils.createValueSymbolBuilder("SubString",
+                        SmithyGoDependency.SMITHY_ENDPOINT_RULESFN).build();
+                case "uriEncode" -> SymbolUtils.createValueSymbolBuilder("URIEncode",
+                        SmithyGoDependency.SMITHY_ENDPOINT_RULESFN).build();
+
+                default -> SymbolUtils.createValueSymbolBuilder("TODO_" + name).build();
+            };
+        }
+    }
+
+    static boolean isBuiltInFnResultOptional(FunctionDefinition fn) {
+        return switch (fn.getId()) {
+            case "aws.partition" -> true;
+            case "aws.parseArn" -> true;
+            case "isValidHostLabel" -> true;
+            case "aws.isVirtualHostableS3Bucket" -> true;
+            case "parseURL" -> true;
+            case "substring" -> true;
+            case "uriEncode" -> false;
+
+            default -> false;
+        };
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/Scope.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/Scope.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.endpoints;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import software.amazon.smithy.rulesengine.language.syntax.expr.Expression;
+
+class Scope {
+    private final Map<Expression, String> mapping;
+
+    Scope(Map<Expression, String> mapping) {
+        this.mapping = mapping;
+    }
+
+    static Scope empty() {
+        return new Scope(new HashMap<>());
+    }
+
+    Optional<String> getIdent(Expression expr) {
+        if (!mapping.containsKey(expr)) {
+            return Optional.empty();
+        }
+        return Optional.of(mapping.get(expr));
+    }
+
+    Scope withMember(Expression expr, String name) {
+        Map<Expression, String> newMapping = new HashMap<>(mapping);
+        newMapping.put(expr, name);
+        return new Scope(newMapping);
+    }
+
+    Scope withIdent(Expression expr, String name) {
+        var newMapping = new HashMap<>(mapping);
+        newMapping.put(expr, name);
+        return new Scope(newMapping);
+    }
+}

--- a/error/endpoints/error_collector.go
+++ b/error/endpoints/error_collector.go
@@ -1,0 +1,49 @@
+package endpoints
+
+import "strings"
+
+// ErrorCollector provides collection of errors that occurred while evaluating
+// endpoint rule functions.
+type ErrorCollector struct {
+	errs []error
+}
+
+// NewErrorCollector returns an initialized [ErrorCollector] that errors can be
+// added to.
+func NewErrorCollector() *ErrorCollector {
+	return &ErrorCollector{}
+}
+
+// AddError adds an error to the list of errors in the [ErrorCollector].
+func (ec *ErrorCollector) AddError(err ...error) {
+	ec.errs = append(ec.errs, err...)
+}
+
+// IsEmpty returns true if the [ErrorCollector] has errors. Returns false
+// otherwise.
+func (ec *ErrorCollector) IsEmpty() bool {
+	return len(ec.errs) == 0
+}
+
+func (ec *ErrorCollector) Error() string {
+	var out strings.Builder
+	for i, err := range ec.errs {
+		out.WriteString(err.Error())
+		if i < len(ec.errs)-1 {
+			out.WriteRune('\n')
+		}
+	}
+	return "built in endpoint errors\n" + out.String()
+}
+
+// FnError provides a error wrapper for errors that occur while evaluating
+// endpoint rule functions.
+type FnError struct {
+	Name string
+	Err  error
+}
+
+func (e FnError) Unwrap() error { return e.Err }
+func (e FnError) Error() string {
+	return "endpoint helper " + e.Name + ", " + e.Err.Error()
+}

--- a/internal/endpoints/rulesfn/doc.go
+++ b/internal/endpoints/rulesfn/doc.go
@@ -1,0 +1,4 @@
+// Package rulesfn provides endpoint rule functions for evaluating endpoint
+// resolution rules.
+
+package rulesfn

--- a/internal/endpoints/rulesfn/strings.go
+++ b/internal/endpoints/rulesfn/strings.go
@@ -1,0 +1,39 @@
+package rulesfn
+
+import (
+	"fmt"
+	smithyerrep "github.com/aws/smithy-go/error/endpoints"
+)
+
+// Substring returns the substring of the input provided. If the start or stop
+// indexes are not valid for the input nil will be returned. If errors occur
+// they will be added to the provided [ErrorCollector].
+func SubString(input string, start, stop int, reverse bool, ec *smithyerrep.ErrorCollector) *string {
+	if start < 0 || stop < 1 || start >= stop || len(input) < stop {
+		ec.AddError(smithyerrep.FnError{
+			Name: "SubString",
+			Err: fmt.Errorf("indexes overlap, or invalid index, %q[%v:%v](reversed:%t)",
+				input, start, stop, reverse),
+		})
+		return nil
+	}
+
+	for _, r := range input {
+		if r > 127 {
+			ec.AddError(smithyerrep.FnError{
+				Name: "SubString",
+				Err:  fmt.Errorf("input contains non-ASCII characters, %q", input),
+			})
+			return nil
+		}
+	}
+
+	if !reverse {
+		v := input[start:stop]
+		return &v
+	}
+
+	rStart := len(input) - stop
+	rStop := len(input) - start
+	return SubString(input, rStart, rStop, false, ec)
+}

--- a/internal/endpoints/rulesfn/strings_test.go
+++ b/internal/endpoints/rulesfn/strings_test.go
@@ -1,0 +1,71 @@
+package rulesfn
+
+import (
+	"strings"
+	"testing"
+	smithyerrep "github.com/aws/smithy-go/error/endpoints"
+	"github.com/aws/smithy-go/ptr"
+)
+
+func TestSubStrin(t *testing.T) {
+	cases := map[string]struct {
+		input       string
+		start, stop int
+		reverse     bool
+		expect      *string
+		expectErr   string
+	}{
+		"prefix": {
+			input: "abcde", start: 0, stop: 3, reverse: false,
+			expect: ptr.String("abc"),
+		},
+		"prefix max-ascii": {
+			input: "abcde\u007F", start: 0, stop: 3, reverse: false,
+			expect: ptr.String("abc"),
+		},
+		"suffix reverse": {
+			input: "abcde", start: 0, stop: 3, reverse: true,
+			expect: ptr.String("cde"),
+		},
+		"too long": {
+			input: "ab", start: 0, stop: 3, reverse: false,
+			expectErr: "indexes overlap, or invalid index,",
+		},
+		"invalid start index": {
+			input: "ab", start: -1, stop: 3, reverse: false,
+			expectErr: "indexes overlap, or invalid index,",
+		},
+		"invalid stop index": {
+			input: "ab", start: 0, stop: 0, reverse: false,
+			expectErr: "indexes overlap, or invalid index,",
+		},
+		"non-ascii": {
+			input: "ab🐱", start: 0, stop: 1, reverse: false,
+			expectErr: "input contains non-ASCII characters,",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			ec := smithyerrep.NewErrorCollector()
+			actual := SubString(c.input, c.start, c.stop, c.reverse, ec)
+			if c.expect == nil {
+				if actual != nil {
+					t.Fatalf("expect no result, got %v", *actual)
+				}
+				if e, a := c.expectErr, ec.Error(); !strings.Contains(a, e) {
+					t.Errorf("expect %q error in %q", e, a)
+				}
+				return
+			}
+
+			if actual == nil {
+				t.Fatalf("expect result, got none")
+			}
+
+			if e, a := *c.expect, *actual; e != a {
+				t.Errorf("expect %q, got %q", e, a)
+			}
+		})
+	}
+}

--- a/internal/endpoints/rulesfn/uri.go
+++ b/internal/endpoints/rulesfn/uri.go
@@ -1,0 +1,132 @@
+package rulesfn
+
+import (
+	"fmt"
+	"net/netip"
+	"net/url"
+	"strings"
+	smithyerrep "github.com/aws/smithy-go/error/endpoints"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+// IsValidHostLabel returns if the input is a single valid [RFC 1123] host
+// label. If allowSubDomains is true, will allow validation to include nested
+// host labels. Returns false if the input is not a valid host label. If errors
+// occur they will be added to the provided [ErrorCollector].
+//
+// [RFC 1123]: https://www.ietf.org/rfc/rfc1123.txt
+func IsValidHostLabel(input string, allowSubDomains bool, ec *smithyerrep.ErrorCollector) bool {
+	var labels []string
+	if allowSubDomains {
+		labels = strings.Split(input, ".")
+	} else {
+		labels = []string{input}
+	}
+
+	for i, label := range labels {
+		if !smithyhttp.ValidHostLabel(label) {
+			ec.AddError(smithyerrep.FnError{
+				Name: "IsValidHostLabel",
+				Err:  fmt.Errorf("host label %d is invalid, %q", i, label),
+			})
+			return false
+		}
+	}
+
+	return true
+}
+
+// ParseURL returns a [URL] if the provided string could be parsed. Returns nil
+// if the string could not be parsed. Any parsing error will be added to the
+// [ErrorCollector].
+//
+// If the input URL string contains an IP6 address with a zone index. The
+// returned [builtin.URL.Authority] value will contain the percent escaped (%)
+// zone index separator.
+func ParseURL(input string, ec *smithyerrep.ErrorCollector) *URL {
+	u, err := url.Parse(input)
+	if err != nil {
+		ec.AddError(smithyerrep.FnError{
+			Name: "ParseURL",
+			Err:  fmt.Errorf("failed to parse URL, %q, %w", input, err),
+		})
+		return nil
+	}
+
+	if u.RawQuery != "" {
+		ec.AddError(smithyerrep.FnError{
+			Name: "ParseURL",
+			Err:  fmt.Errorf("URL must not include query string, %q", input),
+		})
+		return nil
+	}
+
+	if u.Scheme != "http" && u.Scheme != "https" {
+		ec.AddError(smithyerrep.FnError{
+			Name: "ParseURL",
+			Err:  fmt.Errorf("URL contains invalid scheme, %q", u.Scheme),
+		})
+		return nil
+	}
+
+	normalizedPath := u.Path
+	if !strings.HasPrefix(normalizedPath, "/") {
+		normalizedPath = "/" + normalizedPath
+	}
+	if !strings.HasSuffix(normalizedPath, "/") {
+		normalizedPath = normalizedPath + "/"
+	}
+
+	// IP6 hosts may have zone indexes that need to be escaped to be valid in a
+	// URI. The Go URL parser will unescape the `%25` into `%`. This needs to
+	// be reverted since the returned URL will be used in string builders.
+	authority := strings.ReplaceAll(u.Host, "%", "%25")
+
+	var isIP bool
+	if _, err = netip.ParseAddr(u.Hostname()); err == nil {
+		isIP = true
+	}
+
+	return &URL{
+		Scheme:         u.Scheme,
+		Authority:      authority,
+		Path:           u.Path,
+		NormalizedPath: normalizedPath,
+		IsIp:           isIP,
+	}
+}
+
+// URL provides the structure describing the parts of a parsed URL returned by
+// [ParseURL].
+type URL struct {
+	Scheme         string
+	Authority      string
+	Path           string
+	NormalizedPath string
+	IsIp           bool
+}
+
+// URIEncode returns an percent-encoded [RFC3986 section 2.1] version of the
+// input string.
+//
+// [RFC3986 section 2.1]: https://www.rfc-editor.org/rfc/rfc3986#section-2.1
+func URIEncode(input string, ec *smithyerrep.ErrorCollector) string {
+	var output strings.Builder
+	for _, c := range []byte(input) {
+		if validPercentEncodedChar(c) {
+			output.WriteByte(c)
+			continue
+		}
+
+		fmt.Fprintf(&output, "%%%X", c)
+	}
+
+	return output.String()
+}
+
+func validPercentEncodedChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') ||
+		c == '-' || c == '_' || c == '.' || c == '~'
+}

--- a/internal/endpoints/rulesfn/uri_test.go
+++ b/internal/endpoints/rulesfn/uri_test.go
@@ -1,0 +1,226 @@
+package rulesfn
+
+import (
+	"strings"
+	"testing"
+	smithyerrep "github.com/aws/smithy-go/error/endpoints"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestURIEncode(t *testing.T) {
+	cases := map[string]struct {
+		input  string
+		expect string
+	}{
+		"no encoding": {
+			input:  "a-zA-Z0-9-_.~",
+			expect: "a-zA-Z0-9-_.~",
+		},
+		"with encoding": {
+			input:  "🐛 becomes 🦋",
+			expect: "%F0%9F%90%9B%20becomes%20%F0%9F%A6%8B",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			ec := smithyerrep.NewErrorCollector()
+			actual := URIEncode(c.input, ec)
+			if e, a := c.expect, actual; e != a {
+				t.Errorf("expect `%v` encoding, got `%v`", e, a)
+			}
+			if !ec.IsEmpty() {
+				t.Errorf("expect error collector empty, got %v", ec)
+			}
+		})
+	}
+}
+
+func TestParseURL(t *testing.T) {
+	cases := map[string]struct {
+		input     string
+		expect    *URL
+		expectErr string
+	}{
+		"https hostname with no path": {
+			input: "https://example.com",
+			expect: &URL{
+				Scheme:         "https",
+				Authority:      "example.com",
+				Path:           "",
+				NormalizedPath: "/",
+			},
+		},
+		"http hostname with no path": {
+			input: "http://example.com",
+			expect: &URL{
+				Scheme:         "http",
+				Authority:      "example.com",
+				Path:           "",
+				NormalizedPath: "/",
+			},
+		},
+		"https hostname with port with path": {
+			input: "https://example.com:80/foo/bar",
+			expect: &URL{
+				Scheme:         "https",
+				Authority:      "example.com:80",
+				Path:           "/foo/bar",
+				NormalizedPath: "/foo/bar/",
+			},
+		},
+		"invalid port": {
+			input:     "https://example.com:abc",
+			expectErr: "invalid port \":abc\"",
+		},
+		"with query": {
+			input:     "https://example.com:8443?foo=bar&faz=baz",
+			expectErr: "URL must not include query string",
+		},
+		"ip4 URL": {
+			input: "https://127.0.0.1",
+			expect: &URL{
+				Scheme:         "https",
+				Authority:      "127.0.0.1",
+				Path:           "",
+				NormalizedPath: "/",
+				IsIp:           true,
+			},
+		},
+		"ip4 URL with port": {
+			input: "https://127.0.0.1:8443",
+			expect: &URL{
+				Scheme:         "https",
+				Authority:      "127.0.0.1:8443",
+				Path:           "",
+				NormalizedPath: "/",
+				IsIp:           true,
+			},
+		},
+		"ip6 short": {
+			input: "https://[fe80::1]",
+			expect: &URL{
+				Scheme:         "https",
+				Authority:      "[fe80::1]",
+				Path:           "",
+				NormalizedPath: "/",
+				IsIp:           true,
+			},
+		},
+		"ip6 short with interface": {
+			input: "https://[fe80::1%25en0]",
+			expect: &URL{
+				Scheme:         "https",
+				Authority:      "[fe80::1%25en0]",
+				Path:           "",
+				NormalizedPath: "/",
+				IsIp:           true,
+			},
+		},
+		"ip6 short with port": {
+			input: "https://[fe80::1]:8443",
+			expect: &URL{
+				Scheme:         "https",
+				Authority:      "[fe80::1]:8443",
+				Path:           "",
+				NormalizedPath: "/",
+				IsIp:           true,
+			},
+		},
+		"ip6 short with port with interface": {
+			input: "https://[fe80::1%25en0]:8443",
+			expect: &URL{
+				Scheme:         "https",
+				Authority:      "[fe80::1%25en0]:8443",
+				Path:           "",
+				NormalizedPath: "/",
+				IsIp:           true,
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			ec := smithyerrep.NewErrorCollector()
+			actual := ParseURL(c.input, ec)
+			if c.expect == nil {
+				if actual != nil {
+					t.Fatalf("expect no result, got %v", *actual)
+				}
+				if e, a := c.expectErr, ec.Error(); !strings.Contains(a, e) {
+					t.Errorf("expect %q error in %q", e, a)
+				}
+				return
+			}
+
+			if actual == nil {
+				t.Fatalf("expect result, got none")
+			}
+
+			if diff := cmp.Diff(c.expect, actual); diff != "" {
+				t.Errorf("expect URL to match\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIsValidHostLabel(t *testing.T) {
+	cases := map[string]struct {
+		input           string
+		allowSubDomains bool
+		expect          bool
+		expectErr       string
+	}{
+		"single label no split": {
+			input:  "abc123-",
+			expect: true,
+		},
+		"single label with split": {
+			input:           "abc123-",
+			allowSubDomains: true,
+			expect:          true,
+		},
+		"multiple labels no split": {
+			input:     "abc.123-",
+			expectErr: `host label 0 is invalid, "abc.123-"`,
+		},
+		"multiple labels with split": {
+			input:           "abc.123-",
+			allowSubDomains: true,
+			expect:          true,
+		},
+		"multiple labels with split invalid label": {
+			input:           "abc.123-...",
+			allowSubDomains: true,
+			expectErr:       `host label 2 is invalid, ""`,
+		},
+		"max length host label": {
+			input:  "012345678901234567890123456789012345678901234567890123456789123",
+			expect: true,
+		},
+		"too large host label": {
+			input:     "0123456789012345678901234567890123456789012345678901234567891234",
+			expectErr: `host label 0 is invalid, "0123456789012345678901234567890123456789012345678901234567891234"`,
+		},
+		"too small host label": {
+			input:     "",
+			expectErr: `host label 0 is invalid, ""`,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			ec := smithyerrep.NewErrorCollector()
+			actual := IsValidHostLabel(c.input, c.allowSubDomains, ec)
+			if !c.expect {
+				if e, a := c.expectErr, ec.Error(); !strings.Contains(a, e) {
+					t.Errorf("expect %q error in %q", e, a)
+				}
+			}
+
+			if e, a := c.expect, actual; e != a {
+				t.Fatalf("expect %v valid host label, got %v", e, a)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds generic standard library functions for endpoints2.0.

* An error/endpoints package was added in order to contain a utility ErrorCollector class that can provide detailed logging for errors encountered in rule evaluation. It was made public so that the additional SDK functions can depend on this as well.
* The standard library functions were added in an internal package as required by the EP20 SEP.