### PR TITLE
Add Go Synthetic Trait equality methods

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/Synthetic.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/Synthetic.java
@@ -56,6 +56,25 @@ public final class Synthetic extends AbstractTrait implements ToSmithyBuilder<Sy
     }
 
     @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        } else if (!(other instanceof Synthetic)) {
+            return false;
+        } else {
+            Synthetic b = (Synthetic) other;
+            return toShapeId().equals(b.toShapeId()) && archetype.equals(b.getArchetype());
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return toShapeId().hashCode() * 17 + Node.objectNode()
+            .withOptionalMember(ARCHETYPE, archetype.map(ShapeId::toString).map(Node::from))
+            .hashCode();
+    }
+
+    @Override
     public SmithyBuilder<Synthetic> toBuilder() {
         Builder builder = builder();
         getArchetype().ifPresent(builder::archetype);


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

When using smithy diff or trait comparisons for the Go `Synthetic`
trait, the following exception is thrown in the `createNode()`
implementation:

```text
"attempted to serialize runtime only trait"
```

This is due to inheriting from `AbstractTrait`'s equality methods which
use the `ToNode()` method which calls the `createNode()` method.

This change adds an `equals()` and `hashCode()` implementation for the
Go `Synthetic` trait that does not use `ToNode()` or `createNode()`.

`ToNode()` cannot be overriden since `AbstractTrait`'s implementation is
marked as `final`.

*Testing:*

1. Running `make smithy-clean smithy-build smithy-publish-local smithy-clean` succeeded.
2. Running `make generate` in aws/aws-sdk-go-v2 produced no diffs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
