### PR TITLE
Add deprecated option to config field resolvers

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -212,10 +212,12 @@ final class ServiceGenerator implements Runnable {
                 writeWithHelperFunction(writer, configField);
             });
 
-        getAllConfigFields().stream().filter(ConfigField::getWithHelper).filter(Predicate.not(ConfigField::isDeprecated))
+        getAllConfigFields().stream().filter(ConfigField::getWithHelper).filter(
+            Predicate.not(ConfigField::isDeprecated))
                 .forEach(configField -> {
                     writer.writeDocs(
-                            String.format("With%s returns a functional option for setting the Client's %s option.",
+                            String.format(
+                                "With%s returns a functional option for setting the Client's %s option.",
                                     configField.getName(), configField.getName()));
                     writeWithHelperFunction(writer, configField);
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ConfigField.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ConfigField.java
@@ -74,6 +74,13 @@ public class ConfigField implements ToSmithyBuilder<ConfigField> {
         return Optional.ofNullable(deprecated);
     }
 
+    /**
+     * @return Returns if the config option is deprecated.
+     */
+    public Boolean isDeprecated() {
+        return getDeprecated().isPresent();
+    }
+
     @Override
     public SmithyBuilder<ConfigField> toBuilder() {
         return builder().type(type).name(name).documentation(documentation).withHelper(withHelper);

--- a/middleware/metadata.go
+++ b/middleware/metadata.go
@@ -1,10 +1,10 @@
 package middleware
 
-import "github.com/aws/smithy-go"
-
 // MetadataReader provides an interface for reading metadata from the
 // underlying metadata container.
-type MetadataReader = smithy.PropertiesReader
+type MetadataReader interface {
+	Get(key interface{}) interface{}
+}
 
 // Metadata provides storing and reading metadata values. Keys may be any
 // comparable value type. Get and set will panic if key is not a comparable
@@ -13,4 +13,53 @@ type MetadataReader = smithy.PropertiesReader
 // Metadata uses lazy initialization, and Set method must be called as an
 // addressable value, or pointer. Not doing so may cause key/value pair to not
 // be set.
-type Metadata = smithy.Properties
+type Metadata struct {
+	values map[interface{}]interface{}
+}
+
+// Get attempts to retrieve the value the key points to. Returns nil if the
+// key was not found.
+//
+// Panics if key type is not comparable.
+func (m Metadata) Get(key interface{}) interface{} {
+	return m.values[key]
+}
+
+// Clone creates a shallow copy of Metadata entries, returning a new Metadata
+// value with the original entries copied into it.
+func (m Metadata) Clone() Metadata {
+	vs := make(map[interface{}]interface{}, len(m.values))
+	for k, v := range m.values {
+		vs[k] = v
+	}
+
+	return Metadata{
+		values: vs,
+	}
+}
+
+// Set stores the value pointed to by the key. If a value already exists at
+// that key it will be replaced with the new value.
+//
+// Set method must be called as an addressable value, or pointer. If Set is not
+// called as an addressable value or pointer, the key value pair being set may
+// be lost.
+//
+// Panics if the key type is not comparable.
+func (m *Metadata) Set(key, value interface{}) {
+	if m.values == nil {
+		m.values = map[interface{}]interface{}{}
+	}
+	m.values[key] = value
+}
+
+// Has returns whether the key exists in the metadata.
+//
+// Panics if the key type is not comparable.
+func (m Metadata) Has(key interface{}) bool {
+	if m.values == nil {
+		return false
+	}
+	_, ok := m.values[key]
+	return ok
+}


### PR DESCRIPTION
This utility may be necessary for consumers if they want to deprecated a With helper function that corresponds to a config field