### PR TITLE
Update URI encoding to support URL.RawPath consistently

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointMiddlewareGenerator.java
@@ -463,12 +463,12 @@ public final class EndpointMiddlewareGenerator {
         };
     }
 
-    private static String getAddEndpointMiddlewareFuncName(String operationName) {
+    public static String getAddEndpointMiddlewareFuncName(String operationName) {
         return String.format("add%sResolveEndpointMiddleware", operationName);
     }
 
 
-    private static String getMiddlewareObjectName(String operationName) {
+    public static String getMiddlewareObjectName(String operationName) {
         return String.format("op%sResolveEndpointMiddleware", operationName);
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -268,11 +268,20 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.write("");
             writer.write("opPath, opQuery := httpbinding.SplitURI($S)", httpTrait.getUri());
             writer.write("request.URL.Path = smithyhttp.JoinPath(request.URL.Path, opPath)");
+            writer.write("""
+                if request.URL.RawPath != "" {
+                    request.URL.RawPath = smithyhttp.JoinPath(request.URL.RawPath, opPath)
+                }
+                """);
             writer.write("request.URL.RawQuery = smithyhttp.JoinRawQuery(request.URL.RawQuery, opQuery)");
             writer.write("request.Method = $S", httpTrait.getMethod());
-            writer.write(
-                "restEncoder, err := httpbinding.NewEncoder(request.URL.Path, request.URL.RawPath, "
-                    + "request.URL.RawQuery, request.Header)");
+            writer.write("""
+                restEncoder, err := httpbinding.NewEncoder(
+                    request.URL.Path,
+                    request.URL.RawPath,
+                    request.URL.RawQuery,
+                    request.Header)
+                """);
             writer.openBlock("if err != nil {", "}", () -> {
                 writer.write("return out, metadata, &smithy.SerializationError{Err: err}");
             });

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -270,8 +270,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.write("request.URL.Path = smithyhttp.JoinPath(request.URL.Path, opPath)");
             writer.write("request.URL.RawQuery = smithyhttp.JoinRawQuery(request.URL.RawQuery, opQuery)");
             writer.write("request.Method = $S", httpTrait.getMethod());
-            writer.write("restEncoder, err := httpbinding.NewEncoder(request.URL.Path, request.URL.RawQuery, "
-                    + "request.Header)");
+            writer.write(
+                "restEncoder, err := httpbinding.NewEncoder(request.URL.Path, request.URL.RawPath, "
+                    + "request.URL.RawQuery, request.Header)");
             writer.openBlock("if err != nil {", "}", () -> {
                 writer.write("return out, metadata, &smithy.SerializationError{Err: err}");
             });

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
@@ -180,7 +180,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
                          }""");
             writer.write("request.Request.Method = \"POST\"");
             writer.write("httpBindingEncoder, err := httpbinding.NewEncoder(request.URL.Path, "
-                         + "request.URL.RawQuery, request.Header)");
+                         + "request.URL.RawPath, request.URL.RawQuery, request.Header)");
             writer.openBlock("if err != nil {", "}", () -> {
                 writer.write("return out, metadata, &smithy.SerializationError{Err: err}");
             });

--- a/encoding/httpbinding/encode.go
+++ b/encoding/httpbinding/encode.go
@@ -29,7 +29,7 @@ type Encoder struct {
 // NewEncoder creates a new encoder from the passed in request. All query and
 // header values will be added on top of the request's existing values. Overwriting
 // duplicate values.
-func NewEncoder(path, query string, headers http.Header) (*Encoder, error) {
+func NewEncoder(path, rawPath string, query string, headers http.Header) (*Encoder, error) {
 	parseQuery, err := url.ParseQuery(query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse query string: %w", err)
@@ -37,7 +37,7 @@ func NewEncoder(path, query string, headers http.Header) (*Encoder, error) {
 
 	e := &Encoder{
 		path:    []byte(path),
-		rawPath: []byte(path),
+		rawPath: []byte(rawPath),
 		query:   parseQuery,
 		header:  headers.Clone(),
 	}

--- a/encoding/httpbinding/encode.go
+++ b/encoding/httpbinding/encode.go
@@ -29,7 +29,7 @@ type Encoder struct {
 // NewEncoder creates a new encoder from the passed in request. All query and
 // header values will be added on top of the request's existing values. Overwriting
 // duplicate values.
-func NewEncoder(path, rawPath string, query string, headers http.Header) (*Encoder, error) {
+func NewEncoder(path, rawPath, query string, headers http.Header) (*Encoder, error) {
 	parseQuery, err := url.ParseQuery(query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse query string: %w", err)

--- a/encoding/httpbinding/uri.go
+++ b/encoding/httpbinding/uri.go
@@ -23,8 +23,9 @@ func (u URIValue) modifyURI(value string) (err error) {
 	if err != nil {
 		return err
 	}
-	*u.rawPath, *u.buffer, err = replacePathElement(*u.rawPath, *u.buffer, u.key, value, true)
-	return err
+	return nil
+	// *u.rawPath, *u.buffer, err = replacePathElement(*u.rawPath, *u.buffer, u.key, value, true)
+	// return err
 }
 
 // Boolean encodes v as a URI string value

--- a/encoding/httpbinding/uri.go
+++ b/encoding/httpbinding/uri.go
@@ -19,13 +19,15 @@ func newURIValue(path *[]byte, rawPath *[]byte, buffer *[]byte, key string) URIV
 }
 
 func (u URIValue) modifyURI(value string) (err error) {
+	if len(*u.rawPath) == 0 {
+		*u.rawPath = append([]byte(nil), *u.path...)
+	}
 	*u.path, *u.buffer, err = replacePathElement(*u.path, *u.buffer, u.key, value, false)
 	if err != nil {
 		return err
 	}
-	return nil
-	// *u.rawPath, *u.buffer, err = replacePathElement(*u.rawPath, *u.buffer, u.key, value, true)
-	// return err
+	*u.rawPath, *u.buffer, err = replacePathElement(*u.rawPath, *u.buffer, u.key, value, true)
+	return err
 }
 
 // Boolean encodes v as a URI string value


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

NOTE: This change hasn't been thoroughly tested.

`URL.RawPath` is not consistently updated during serialization. The changes in this PR update the `RawPath` when `Path` is updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
