### PR TITLE
Make middleware name getters public

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointMiddlewareGenerator.java
@@ -463,12 +463,12 @@ public final class EndpointMiddlewareGenerator {
         };
     }
 
-    private static String getAddEndpointMiddlewareFuncName(String operationName) {
+    public static String getAddEndpointMiddlewareFuncName(String operationName) {
         return String.format("add%sResolveEndpointMiddleware", operationName);
     }
 
 
-    private static String getMiddlewareObjectName(String operationName) {
+    public static String getMiddlewareObjectName(String operationName) {
         return String.format("op%sResolveEndpointMiddleware", operationName);
     }
 


### PR DESCRIPTION
These names need to be used by other middlewares. So they cannot be private