### PR TITLE
Fix url encoding issues with ep20

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -270,8 +270,26 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.write("request.URL.Path = smithyhttp.JoinPath(request.URL.Path, opPath)");
             writer.write("request.URL.RawQuery = smithyhttp.JoinRawQuery(request.URL.RawQuery, opQuery)");
             writer.write("request.Method = $S", httpTrait.getMethod());
-            writer.write("restEncoder, err := httpbinding.NewEncoder(request.URL.Path, request.URL.RawQuery, "
-                    + "request.Header)");
+            writer.write(
+                """
+                var restEncoder $P
+                if request.URL.RawPath == "" {
+                    restEncoder, err = $T(request.URL.Path, request.URL.RawQuery, request.Header)
+                } else {
+                    request.URL.RawPath = $T(request.URL.RawPath, opPath)
+                    restEncoder, err = $T(request.URL.Path, request.URL.RawPath, request.URL.RawQuery, request.Header)
+                }
+                """,
+                SymbolUtils.createPointableSymbolBuilder(
+                    "Encoder", SmithyGoDependency.SMITHY_HTTP_BINDING).build(),
+                SymbolUtils.createValueSymbolBuilder(
+                    "NewEncoder", SmithyGoDependency.SMITHY_HTTP_BINDING).build(),
+                SymbolUtils.createValueSymbolBuilder(
+                    "JoinPath", SmithyGoDependency.SMITHY_HTTP_TRANSPORT).build(),
+                SymbolUtils.createValueSymbolBuilder(
+                    "NewHTTPBindingEncoder", SmithyGoDependency.SMITHY_HTTP_BINDING).build()
+            );
+
             writer.openBlock("if err != nil {", "}", () -> {
                 writer.write("return out, metadata, &smithy.SerializationError{Err: err}");
             });
@@ -291,7 +309,6 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             // archetype.
             if (!CodegenUtils.isStubSynthetic(ProtocolUtils.expectInput(model, operation))) {
                 Optional<EventStreamInfo> eventStreamInfo = EventStreamIndex.of(model).getInputInfo(operation);
-
                 // document bindings vs payload bindings vs event streams
                 HttpBindingIndex httpBindingIndex = HttpBindingIndex.of(model);
                 boolean hasDocumentBindings = httpBindingIndex

--- a/encoding/httpbinding/encode.go
+++ b/encoding/httpbinding/encode.go
@@ -26,10 +26,17 @@ type Encoder struct {
 	header http.Header
 }
 
-// NewEncoder creates a new encoder from the passed in request. All query and
+// NewEncoder creates a new encoder from the passed in request. It assumes that
+// raw path contains no valuable information at this point, so it passes in path
+// as path and raw path for subsequent trans
+func NewEncoder(path, query string, headers http.Header) (*Encoder, error) {
+	return NewHTTPBindingEncoder(path, path, query, headers)
+}
+
+// NewHTTPBindingEncoder creates a new encoder from the passed in request. All query and
 // header values will be added on top of the request's existing values. Overwriting
 // duplicate values.
-func NewEncoder(path, query string, headers http.Header) (*Encoder, error) {
+func NewHTTPBindingEncoder(path, rawPath, query string, headers http.Header) (*Encoder, error) {
 	parseQuery, err := url.ParseQuery(query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse query string: %w", err)
@@ -37,7 +44,7 @@ func NewEncoder(path, query string, headers http.Header) (*Encoder, error) {
 
 	e := &Encoder{
 		path:    []byte(path),
-		rawPath: []byte(path),
+		rawPath: []byte(rawPath),
 		query:   parseQuery,
 		header:  headers.Clone(),
 	}


### PR DESCRIPTION
Fix path and raw path inconsistencies with url encoding. For context, a lot of path style unit tests were failing prior to this PR.