### PR TITLE
Disable Host Prefix in certain case

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointMiddlewareGenerator.java
@@ -222,7 +222,7 @@ public final class EndpointMiddlewareGenerator {
                 "contextBinding", generateContextParamBinding(operationShape, model),
                 "staticContextBinding", generateStaticContextParamBinding(parameters, operationShape),
                 "endpointResolution", generateEndpointResolution(),
-                "postEndpointResolution", generatePostEndpointResolutionHook(settings, model)
+                "postEndpointResolution", generatePostEndpointResolutionHook(settings, model, operationShape)
             )
         );
     }
@@ -411,10 +411,12 @@ public final class EndpointMiddlewareGenerator {
         );
     }
 
-    private GoWriter.Writable generatePostEndpointResolutionHook(GoSettings settings, Model model) {
+    private GoWriter.Writable generatePostEndpointResolutionHook(
+        GoSettings settings, Model model, OperationShape operation
+    ) {
         return (GoWriter writer) -> {
             for (GoIntegration integration : this.integrations) {
-                integration.renderPostEndpointResolutionHook(settings, writer, model);
+                integration.renderPostEndpointResolutionHook(settings, writer, model, Optional.of(operation));
             }
         };
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/EndpointHostPrefixMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/EndpointHostPrefixMiddleware.java
@@ -77,7 +77,8 @@ public class EndpointHostPrefixMiddleware implements GoIntegration {
                         """
                         ctx = $T(ctx, true)
                         """,
-                        SymbolUtils.createPointableSymbolBuilder("DisableEndpointHostPrefix", SmithyGoDependency.SMITHY_HTTP_TRANSPORT).build()
+                        SymbolUtils.createPointableSymbolBuilder(
+                            "DisableEndpointHostPrefix", SmithyGoDependency.SMITHY_HTTP_TRANSPORT).build()
                     );
                     written = true;
                 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/EndpointHostPrefixMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/EndpointHostPrefixMiddleware.java
@@ -30,7 +30,6 @@ import software.amazon.smithy.go.codegen.SymbolUtils;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.pattern.SmithyPattern;
-import software.amazon.smithy.model.pattern.SmithyPattern.Segment;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
@@ -64,30 +63,6 @@ public class EndpointHostPrefixMiddleware implements GoIntegration {
             );
         });
     }
-
-    @Override
-    public void renderPostEndpointResolutionHook(GoSettings settings, GoWriter writer, Model model) {
-        boolean written = false;
-        for (OperationShape operation : endpointPrefixOperations) {
-            EndpointTrait endpointTrait = operation.expectTrait(EndpointTrait.class);
-
-            for (Segment segment : endpointTrait.getHostPrefix().getLabels()) {
-                if (segment.isLabel() && segment.getContent().equals("AccountId") && !written) {
-                    writer.write(
-                        """
-                        ctx = $T(ctx, true)
-                        """,
-                        SymbolUtils.createPointableSymbolBuilder(
-                            "DisableEndpointHostPrefix", SmithyGoDependency.SMITHY_HTTP_TRANSPORT).build()
-                    );
-                    written = true;
-                }
-            }
-
-        }
-
-    }
-
 
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
@@ -26,6 +26,7 @@ import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.TriConsumer;
 import software.amazon.smithy.go.codegen.endpoints.EndpointBuiltInHandler;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
 
 /**
@@ -201,7 +202,8 @@ public interface GoIntegration {
         // pass
     }
 
-    default void renderPostEndpointResolutionHook(GoSettings settings, GoWriter writer, Model model) {
+    default void renderPostEndpointResolutionHook(
+        GoSettings settings, GoWriter writer, Model model, Optional<OperationShape> operation) {
         // pass
     }
 


### PR DESCRIPTION
Instead of using a model filter to completely remove the endpoint host prefix middleware from every operation. Adding a runtime disabler allows for custom v1 resolvers to still use the endpoint host prefix middleware.