### PR TITLE
Fix various bugs failing make unit

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointClientPluginsGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointClientPluginsGenerator.java
@@ -97,6 +97,10 @@ public class EndpointClientPluginsGenerator implements GoIntegration {
         : Optional.empty();
         var clientContextParamsTrait = service.getTrait(ClientContextParamsTrait.class);
 
+        if (!rulesetOpt.isPresent()) {
+            return;
+        }
+
         var topDownIndex = TopDownIndex.of(model);
 
         for (ToShapeId operationId : topDownIndex.getContainedOperations(service)) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointMiddlewareGenerator.java
@@ -368,14 +368,20 @@ public final class EndpointMiddlewareGenerator {
                         if (param.getType() == ParameterType.BOOLEAN) {
                             valueWrapper = SymbolUtils.createValueSymbolBuilder(
                                 "Bool", SmithyGoDependency.SMITHY_PTR).build();
+                            writer.write(
+                                "params.$L = $T($L)", paramName, valueWrapper, staticParam.getValue());
                         } else if (param.getType() == ParameterType.STRING) {
                             valueWrapper = SymbolUtils.createValueSymbolBuilder(
                                 "String", SmithyGoDependency.SMITHY_PTR).build();
+                            writer.write(
+                                "params.$L = $T($L)", paramName, valueWrapper, String.format(
+                                    "\"%s\"", staticParam.getValue()
+                                ));
+
                         } else {
                             throw new CodegenException(
                                 String.format("unexpected static context param type: %s", param.getType()));
                         }
-                        writer.write("params.$L = $T($L)", paramName, valueWrapper, staticParam.getValue());
                     }
                 }
             });

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolutionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolutionGenerator.java
@@ -104,7 +104,6 @@ public class EndpointResolutionGenerator {
                     -> writer.write("$W", resolverGenerator.generate(ruleset))
                 );
 
-
         middlewareGenerator.generate(
             context.getSettings(),
             context.getModel(),
@@ -136,7 +135,6 @@ public class EndpointResolutionGenerator {
         context.getWriter()
             .map(
                 (writer) -> {
-                    writer.addUseImports(SmithyGoDependency.NET_URL);
                     return writer.write("$W", testsGenerator.generate(ruleset, testCases));
                 }
             );

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointTestsGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointTestsGenerator.java
@@ -194,7 +194,7 @@ public final class EndpointTestsGenerator {
         var endpoint = expectEndpoint.get();
 
         return goTemplate("""
-                uri, _ := url.Parse($expectURL:S)
+                uri, _ := $urlParse:T($expectURL:S)
 
                 expectEndpoint := $endpointType:T{
                     URI: *uri,
@@ -212,6 +212,7 @@ public final class EndpointTestsGenerator {
                 """,
                 commonCodegenArgs,
                 MapUtils.of(
+                        "urlParse", SymbolUtils.createValueSymbolBuilder("Parse", SmithyGoDependency.NET_URL).build(),
                         "cmpDiff", SymbolUtils.createPointableSymbolBuilder("Diff", SmithyGoDependency.GO_CMP).build(),
                         "expectURL", endpoint.getUrl(),
                         "headers", generateHeaders(endpoint.getHeaders()),


### PR DESCRIPTION
1. only generate middleware if ruleset exists (can be changed later)
2. wrap string values for static context params in quotes
3. fix net url import with symbols