### PR TITLE
Remove EP20 references

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main, ep20 ]
+    branches: [ main ]
 
 jobs:
   codegen-test:


### PR DESCRIPTION
All EP20 refs in GH workflows should have been removed in the Github workflows.