### PR TITLE
encoding/json: fix dropped error

### DIFF
--- a/encoding/json/decoder_util.go
+++ b/encoding/json/decoder_util.go
@@ -25,6 +25,9 @@ func DiscardUnknownField(decoder *json.Decoder) error {
 	if _, ok := v.(json.Delim); ok {
 		for decoder.More() {
 			err = DiscardUnknownField(decoder)
+			if err != nil {
+				return err
+			}
 		}
 		endToken, err := decoder.Token()
 		if err != nil {


### PR DESCRIPTION
This picks up a dropped `err` variable in `encoding/json`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
