### PR TITLE
generate auth params and bindings

### DIFF
--- a/codegen/smithy-go-codegen/build.gradle.kts
+++ b/codegen/smithy-go-codegen/build.gradle.kts
@@ -21,6 +21,7 @@ extra["moduleName"] = "software.amazon.smithy.go.codegen"
 
 dependencies {
     api("software.amazon.smithy:smithy-codegen-core:$smithyVersion")
+    api("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-waiters:$smithyVersion")
     api("com.atlassian.commonmark:commonmark:0.15.2")
     api("org.jsoup:jsoup:1.14.1")

--- a/codegen/smithy-go-codegen/build.gradle.kts
+++ b/codegen/smithy-go-codegen/build.gradle.kts
@@ -21,7 +21,6 @@ extra["moduleName"] = "software.amazon.smithy.go.codegen"
 
 dependencies {
     api("software.amazon.smithy:smithy-codegen-core:$smithyVersion")
-    api("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-waiters:$smithyVersion")
     api("com.atlassian.commonmark:commonmark:0.15.2")
     api("org.jsoup:jsoup:1.14.1")

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -247,6 +247,11 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
                 protocolGenerator.generateEndpointResolution(context);
             });
 
+            writers.useFileWriter("auth.go", settings.getModuleName(), writer -> {
+                ProtocolGenerator.GenerationContext context = contextBuilder.writer(writer).build();
+                protocolGenerator.generateAuth(context);
+            });
+
             writers.useFileWriter("endpoints_test.go", settings.getModuleName(), writer -> {
                 ProtocolGenerator.GenerationContext context = contextBuilder.writer(writer).build();
                 protocolGenerator.generateEndpointResolutionTests(context);

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoUniverseTypes.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoUniverseTypes.java
@@ -21,32 +21,33 @@ import software.amazon.smithy.codegen.core.Symbol;
  * Collection of Symbol constants for golang universe types.
  * See <a href="https://go.dev/ref/spec#Predeclared_identifiers">predeclared identifiers</a>.
  */
+@SuppressWarnings("checkstyle:ConstantName")
 public final class GoUniverseTypes {
-    public static Symbol tAny = universe("any");
-    public static Symbol tBool = universe("bool");
-    public static Symbol tByte = universe("byte");
-    public static Symbol tComparable = universe("comparable");
+    public static final Symbol Any = universe("any");
+    public static final Symbol Bool = universe("bool");
+    public static final Symbol Byte = universe("byte");
+    public static final Symbol Comparable = universe("comparable");
 
-    public static Symbol tComplex64 = universe("complex64");
-    public static Symbol tComplex128 = universe("complex128");
-    public static Symbol tError = universe("error");
-    public static Symbol tFloat32 = universe("float32");
-    public static Symbol tFloat64 = universe("float64");
+    public static final Symbol Complex64 = universe("complex64");
+    public static final Symbol Complex128 = universe("complex128");
+    public static final Symbol Error = universe("error");
+    public static final Symbol Float32 = universe("float32");
+    public static final Symbol Float64 = universe("float64");
 
-    public static Symbol tInt = universe("int");
-    public static Symbol tInt8 = universe("int8");
-    public static Symbol tInt16 = universe("int16");
-    public static Symbol tInt32 = universe("int32");
-    public static Symbol tInt64 = universe("int64");
-    public static Symbol tRune = universe("rune");
-    public static final Symbol STRING = universe("string");
+    public static final Symbol Int = universe("int");
+    public static final Symbol Int8 = universe("int8");
+    public static final Symbol Int16 = universe("int16");
+    public static final Symbol Int32 = universe("int32");
+    public static final Symbol Int64 = universe("int64");
+    public static final Symbol Rune = universe("rune");
+    public static final Symbol String = universe("string");
 
-    public static Symbol tUint = universe("uint");
-    public static Symbol tUint8 = universe("uint8");
-    public static Symbol tUint16 = universe("uint16");
-    public static Symbol tUint32 = universe("uint32");
-    public static Symbol tUint64 = universe("uint64");
-    public static Symbol tUintptr = universe("uintptr");
+    public static final Symbol Uint = universe("uint");
+    public static final Symbol Uint8 = universe("uint8");
+    public static final Symbol Uint16 = universe("uint16");
+    public static final Symbol Uint32 = universe("uint32");
+    public static final Symbol Uint64 = universe("uint64");
+    public static final Symbol Uintptr = universe("uintptr");
 
     private GoUniverseTypes() {}
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoUniverseTypes.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoUniverseTypes.java
@@ -39,7 +39,7 @@ public final class GoUniverseTypes {
     public static Symbol tInt32 = universe("int32");
     public static Symbol tInt64 = universe("int64");
     public static Symbol tRune = universe("rune");
-    public static Symbol tString = universe("string");
+    public static final Symbol STRING = universe("string");
 
     public static Symbol tUint = universe("uint");
     public static Symbol tUint8 = universe("uint8");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -130,6 +130,15 @@ public final class OperationGenerator implements Runnable {
                 .renderStructure(() -> {
                 }, true);
 
+        writer.write("""
+                            func (*$T) operationName() string {
+                                return $S
+                            }
+                            """,
+                inputSymbol,
+                operationSymbol.getName()
+        );
+
         // The output structure gets a metadata member added.
         Symbol metadataSymbol = SymbolUtils.createValueSymbolBuilder("Metadata", SmithyGoDependency.SMITHY_MIDDLEWARE)
                 .build();

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -131,10 +131,10 @@ public final class OperationGenerator implements Runnable {
                 }, true);
 
         writer.write("""
-                            func (*$T) operationName() string {
-                                return $S
-                            }
-                            """,
+                func (*$T) operationName() string {
+                    return $S
+                }
+                """,
                 inputSymbol,
                 operationSymbol.getName()
         );

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthGenerator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.auth;
+
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
+
+/**
+ * Entry point into smithy client auth generation.
+ */
+public class AuthGenerator {
+    private final ProtocolGenerator.GenerationContext context;
+
+    public AuthGenerator(ProtocolGenerator.GenerationContext context) {
+        this.context = context;
+    }
+
+    public void generate() {
+        if (context.getWriter().isEmpty()) {
+            throw new CodegenException("writer is required");
+        }
+
+        context.getWriter().get()
+                .write("$W", new AuthParametersGenerator(context).generate())
+                .write("")
+                .write("$W", new AuthParametersResolverGenerator(context).generate());
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParameter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParameter.java
@@ -22,12 +22,12 @@ public record AuthParameter(String name, String docs, Symbol type) {
     public static final AuthParameter OPERATION = new AuthParameter(
             "Operation",
             "The name of the operation being invoked.",
-            GoUniverseTypes.STRING
+            GoUniverseTypes.String
     );
 
     public static final AuthParameter REGION = new AuthParameter(
             "Region",
             "The region in which the operation is being invoked.",
-            GoUniverseTypes.STRING
+            GoUniverseTypes.String
     );
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParameter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParameter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.auth;
+
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.GoUniverseTypes;
+
+public record AuthParameter(String name, String docs, Symbol type) {
+    public static final AuthParameter OPERATION = new AuthParameter(
+            "Operation",
+            "The name of the operation being invoked.",
+            GoUniverseTypes.STRING
+    );
+
+    public static final AuthParameter REGION = new AuthParameter(
+            "Region",
+            "The region in which the operation is being invoked.",
+            GoUniverseTypes.STRING
+    );
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParametersGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParametersGenerator.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.auth;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goDocTemplate;
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+
+import java.util.ArrayList;
+import software.amazon.smithy.aws.traits.auth.SigV4Trait;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SymbolUtils;
+import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.MapUtils;
+
+/**
+ * Generates auth scheme resolver parameters.
+ * By default, the only field that exists universally is the name of the operation being invoked. Services that use
+ * SigV4[A] will also have a field for the region.
+ * Additional parameters can be loaded via GoIntegration.
+ */
+public class AuthParametersGenerator {
+    public static final String STRUCT_NAME = "AuthResolverParameters";
+
+    public static final Symbol STRUCT_SYMBOL = SymbolUtils.createPointableSymbolBuilder(STRUCT_NAME).build();
+
+    private final ProtocolGenerator.GenerationContext context;
+
+    private final ArrayList<AuthParameter> fields = new ArrayList<>(
+            ListUtils.of(AuthParameter.OPERATION)
+    );
+
+    public AuthParametersGenerator(ProtocolGenerator.GenerationContext context) {
+        this.context = context;
+    }
+
+    public GoWriter.Writable generate() {
+        loadFields();
+
+        return goTemplate(
+                """
+                        $doc:W
+                        type $name:L struct {
+                            $fields:W
+                        }
+                        """,
+                MapUtils.of(
+                        "doc", generateDocs(),
+                        "name", STRUCT_NAME,
+                        "fields", generateFields()
+                )
+        );
+    }
+
+    private GoWriter.Writable generateDocs() {
+        return goDocTemplate(
+                "$name:L contains the set of inputs necessary for auth scheme resolution.",
+                MapUtils.of("name", STRUCT_NAME)
+        );
+    }
+
+    private GoWriter.Writable generateFields() {
+        return (writer) -> {
+            for (var field: fields) {
+                writer.write("""
+                        $W
+                        $L $P
+                        """,
+                        goDocTemplate(field.docs()),
+                        field.name(),
+                        field.type()
+                );
+            }
+        };
+    }
+
+    private void loadFields() {
+        if (context.getService().hasTrait(SigV4Trait.class)) {
+            fields.add(AuthParameter.REGION);
+        }
+
+        for (var integration: context.getIntegrations()) {
+            var plugins = integration.getClientPlugins().stream().filter(it ->
+                    it.matchesService(context.getModel(), context.getService())).toList();
+            for (var plugin: plugins) {
+                fields.addAll(plugin.getAuthParameters());
+            }
+        }
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParametersGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParametersGenerator.java
@@ -19,7 +19,6 @@ import static software.amazon.smithy.go.codegen.GoWriter.goDocTemplate;
 import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
 
 import java.util.ArrayList;
-import software.amazon.smithy.aws.traits.auth.SigV4Trait;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.SymbolUtils;
@@ -89,10 +88,6 @@ public class AuthParametersGenerator {
     }
 
     private void loadFields() {
-        if (context.getService().hasTrait(SigV4Trait.class)) {
-            fields.add(AuthParameter.REGION);
-        }
-
         for (var integration: context.getIntegrations()) {
             var plugins = integration.getClientPlugins().stream().filter(it ->
                     it.matchesService(context.getModel(), context.getService())).toList();

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParametersResolver.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParametersResolver.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.auth;
+
+import software.amazon.smithy.codegen.core.Symbol;
+
+public record AuthParametersResolver(Symbol resolver) { }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParametersResolverGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParametersResolverGenerator.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.auth;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+
+import java.util.ArrayList;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SymbolUtils;
+import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
+import software.amazon.smithy.utils.MapUtils;
+
+/**
+ * Generates a single method which binds auth scheme resolver parameters from operation input and client options.
+ * The only value bound by default is the operation name. Generators must load additional bindings through
+ * GoIntegration.
+ */
+public class AuthParametersResolverGenerator {
+    public static final String FUNC_NAME = "bindAuthResolverParams";
+
+    public static final Symbol FUNC_SYMBOL = SymbolUtils.createValueSymbolBuilder(FUNC_NAME).build();
+
+    private final ProtocolGenerator.GenerationContext context;
+
+    private final ArrayList<AuthParametersResolver> resolvers = new ArrayList<>();
+
+    public AuthParametersResolverGenerator(ProtocolGenerator.GenerationContext context) {
+        this.context = context;
+    }
+
+    public GoWriter.Writable generate() {
+        loadBindings();
+
+        var paramsSymbol = SymbolUtils.createPointableSymbolBuilder(AuthParametersGenerator.STRUCT_NAME).build();
+
+        return goTemplate("""
+                $operationNamer:W
+
+                func $name:L(input interface{}, options Options) $params:P {
+                    params := &$params:T{
+                        Operation: input.(operationNamer).operationName(),
+                    }
+
+                    $bindings:W
+
+                    return params
+                }
+                """,
+                MapUtils.of(
+                        "name", FUNC_NAME,
+                        "operationNamer", generateOperationNamer(),
+                        "params", paramsSymbol,
+                        "bindings", generateBindings()
+                ));
+    }
+
+    private GoWriter.Writable generateOperationNamer() {
+        return (writer) -> {
+            writer.write("""
+                    type operationNamer interface {
+                        operationName() string
+                    }
+                    """);
+        };
+    }
+
+    private GoWriter.Writable generateBindings() {
+        return (writer) -> {
+            for (var resolver: resolvers) {
+                writer.write("$T(params, input, options)", resolver.resolver());
+            }
+        };
+    }
+
+    private void loadBindings() {
+        for (var integration: context.getIntegrations()) {
+            var plugins = integration.getClientPlugins().stream().filter(it ->
+                    it.matchesService(context.getModel(), context.getService())).toList();
+            for (var plugin: plugins) {
+                resolvers.addAll(plugin.getAuthParameterResolvers());
+            }
+        }
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParametersResolverGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParametersResolverGenerator.java
@@ -43,9 +43,7 @@ public class AuthParametersResolverGenerator {
     }
 
     public GoWriter.Writable generate() {
-        loadBindings();
-
-        var paramsSymbol = SymbolUtils.createPointableSymbolBuilder(AuthParametersGenerator.STRUCT_NAME).build();
+        loadResolvers();
 
         return goTemplate("""
                 $operationNamer:W
@@ -63,8 +61,8 @@ public class AuthParametersResolverGenerator {
                 MapUtils.of(
                         "name", FUNC_NAME,
                         "operationNamer", generateOperationNamer(),
-                        "params", paramsSymbol,
-                        "bindings", generateBindings()
+                        "params", AuthParametersGenerator.STRUCT_SYMBOL,
+                        "bindings", generateResolvers()
                 ));
     }
 
@@ -78,7 +76,7 @@ public class AuthParametersResolverGenerator {
         };
     }
 
-    private GoWriter.Writable generateBindings() {
+    private GoWriter.Writable generateResolvers() {
         return (writer) -> {
             for (var resolver: resolvers) {
                 writer.write("$T(params, input, options)", resolver.resolver());
@@ -86,7 +84,7 @@ public class AuthParametersResolverGenerator {
         };
     }
 
-    private void loadBindings() {
+    private void loadResolvers() {
         for (var integration: context.getIntegrations()) {
             var plugins = integration.getClientPlugins().stream().filter(it ->
                     it.matchesService(context.getModel(), context.getService())).toList();

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
@@ -29,6 +29,7 @@ import software.amazon.smithy.go.codegen.GoDelegator;
 import software.amazon.smithy.go.codegen.GoSettings;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.Synthetic;
+import software.amazon.smithy.go.codegen.auth.AuthGenerator;
 import software.amazon.smithy.go.codegen.endpoints.EndpointResolutionGenerator;
 import software.amazon.smithy.go.codegen.endpoints.FnGenerator;
 import software.amazon.smithy.model.Model;
@@ -479,6 +480,15 @@ public interface ProtocolGenerator {
     default void generateEndpointResolutionTests(GenerationContext context) {
         var generator = new EndpointResolutionGenerator(new FnGenerator.DefaultFnProvider());
         generator.generateTests(context);
+    }
+
+    /**
+     * Generates smithy client auth components.
+     *
+     * @param context The generation context.
+     */
+    default void generateAuth(GenerationContext context) {
+        new AuthGenerator(context).generate();
     }
 
     /**

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/RuntimeClientPlugin.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/RuntimeClientPlugin.java
@@ -21,6 +21,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiPredicate;
+import software.amazon.smithy.go.codegen.auth.AuthParameter;
+import software.amazon.smithy.go.codegen.auth.AuthParametersResolver;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
@@ -43,6 +45,8 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
     private final Set<ConfigFieldResolver> configFieldResolvers;
     private final Set<ClientMember> clientMembers;
     private final Set<ClientMemberResolver> clientMemberResolvers;
+    private final Set<AuthParameter> authParameters;
+    private final Set<AuthParametersResolver> authParameterResolvers;
     private final MiddlewareRegistrar registerMiddleware;
 
     private RuntimeClientPlugin(Builder builder) {
@@ -52,6 +56,8 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         registerMiddleware = builder.registerMiddleware;
         clientMembers = builder.clientMembers;
         clientMemberResolvers = builder.clientMemberResolvers;
+        authParameters = builder.authParameters;
+        authParameterResolvers = builder.authParameterResolvers;
         configFieldResolvers = builder.configFieldResolvers;
     }
 
@@ -83,6 +89,22 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
      */
     public Set<ClientMemberResolver> getClientMemberResolvers() {
         return clientMemberResolvers;
+    }
+
+    /**
+     * Gets the auth parameters that will be added by this plugin.
+     * @return the auth parameters.
+     */
+    public Set<AuthParameter> getAuthParameters() {
+        return authParameters;
+    }
+
+    /**
+     * Gets the auth parameter resolvers that will be added by this plugin.
+     * @return the auth parameter resolvers.
+     */
+    public Set<AuthParametersResolver> getAuthParameterResolvers() {
+        return authParameterResolvers;
     }
 
     /**
@@ -192,6 +214,8 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         private Set<ConfigFieldResolver> configFieldResolvers = new HashSet<>();
         private Set<ClientMember> clientMembers = new HashSet<>();
         private Set<ClientMemberResolver> clientMemberResolvers = new HashSet<>();
+        private Set<AuthParameter> authParameters = new HashSet<>();
+        private Set<AuthParametersResolver> authParameterResolvers = new HashSet<>();
         private MiddlewareRegistrar registerMiddleware;
 
         @Override
@@ -401,6 +425,28 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
          */
         public Builder addClientMemberResolver(ClientMemberResolver clientMemberResolver) {
             this.clientMemberResolvers.add(clientMemberResolver);
+            return this;
+        }
+
+        /**
+         * Adds a field to the auth parameters.
+         *
+         * @param param The field.
+         * @return Returns the builder.
+         */
+        public Builder addAuthParameter(AuthParameter param) {
+            this.authParameters.add(param);
+            return this;
+        }
+
+        /**
+         * Adds a resolver for fields on auth parameters.
+         *
+         * @param resolver The auth field resolver.
+         * @return Returns the builder.
+         */
+        public Builder addAuthParameterResolver(AuthParametersResolver resolver) {
+            this.authParameterResolvers.add(resolver);
             return this;
         }
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/SigV4AuthParameters.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/SigV4AuthParameters.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.integration;
+
+import java.util.List;
+import software.amazon.smithy.go.codegen.auth.AuthParameter;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.utils.ListUtils;
+
+/**
+ * Adds the input region as an auth resolution parameter for SigV4x-based services.
+ */
+public class SigV4AuthParameters implements GoIntegration {
+    private boolean isSigV4Service(Model model, ServiceShape service) {
+        return service.hasTrait("aws.auth#sigv4");
+    }
+
+    @Override
+    public List<RuntimeClientPlugin> getClientPlugins() {
+        return ListUtils.of(
+                RuntimeClientPlugin.builder()
+                        .servicePredicate(this::isSigV4Service)
+                        .addAuthParameter(AuthParameter.REGION)
+                        .build()
+        );
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.go.codegen.integration.GoIntegration
+++ b/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.go.codegen.integration.GoIntegration
@@ -8,4 +8,5 @@ software.amazon.smithy.go.codegen.integration.OperationInterfaceGenerator
 software.amazon.smithy.go.codegen.integration.Paginators
 software.amazon.smithy.go.codegen.integration.Waiters
 software.amazon.smithy.go.codegen.integration.ClientLogger
+software.amazon.smithy.go.codegen.integration.SigV4AuthParameters
 software.amazon.smithy.go.codegen.endpoints.EndpointClientPluginsGenerator


### PR DESCRIPTION
* Add code generation for modeled auth resolver parameters.
  * The only "universal" param is the operation name. This is resolved by implementing an `operationName()` interface on input structures.
  * An additional "region" field is generated for sigv4x services.
* Add codegen for auth resolver param bindings.
* Add `GoIntegration` support for loading both auth params and resolvers.