### PR TITLE
implement `Request.GetBody` to support retry in HTTP Client

### DIFF
--- a/transport/http/request_test.go
+++ b/transport/http/request_test.go
@@ -118,6 +118,7 @@ func TestRequestSetStream(t *testing.T) {
 		expectNilStream        bool
 		expectNilBody          bool
 		expectReqContentLength int64
+		expectGetBody          bool
 	}{
 		"nil stream": {
 			expectNilStream: true,
@@ -141,6 +142,7 @@ func TestRequestSetStream(t *testing.T) {
 			expectNilStream:        false,
 			expectNilBody:          false,
 			expectReqContentLength: -1,
+			expectGetBody:          true,
 		},
 		"unseekable stream": {
 			reader:                 bytes.NewBuffer([]byte("abc123")),
@@ -148,6 +150,7 @@ func TestRequestSetStream(t *testing.T) {
 			expectNilStream:        false,
 			expectNilBody:          false,
 			expectReqContentLength: 6,
+			expectGetBody:          true,
 		},
 		"seekable stream": {
 			reader:                 bytes.NewReader([]byte("abc123")),
@@ -156,6 +159,7 @@ func TestRequestSetStream(t *testing.T) {
 			expectSeekable:         true,
 			expectNilBody:          false,
 			expectReqContentLength: 6,
+			expectGetBody:          true,
 		},
 		"offset seekable stream": {
 			reader: func() io.Reader {
@@ -169,6 +173,7 @@ func TestRequestSetStream(t *testing.T) {
 			expectNilStream:        false,
 			expectNilBody:          false,
 			expectReqContentLength: 5,
+			expectGetBody:          true,
 		},
 		"NoBody stream": {
 			reader:          http.NoBody,
@@ -215,6 +220,9 @@ func TestRequestSetStream(t *testing.T) {
 			}
 			if e, a := c.expectContentLength, req.ContentLength; e != a {
 				t.Errorf("expect %v request content-length, got %v", e, a)
+			}
+			if e, a := c.expectGetBody, r.GetBody != nil; e != a {
+				t.Errorf("expect %v request GetBody, got %v", e, a)
 			}
 		})
 	}


### PR DESCRIPTION
related: https://github.com/aws/aws-sdk-go-v2/discussions/2008

net/http:
https://github.com/golang/go/blob/638e0d36d2a6b2efce0550978bf48e7df1166a0b/src/net/http/client.go#L508-L538

net/http2:
https://github.com/golang/net/blob/a600b3518eed7a9a4e24380b4b249cb986d9b64d/http2/transport.go#L610-L644

> By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Yes.