### PR TITLE
feat: sra i&a: add sigv4a and reorder operation phases

### DIFF
--- a/auth/identity.go
+++ b/auth/identity.go
@@ -24,3 +24,24 @@ type IdentityResolver interface {
 type IdentityResolverOptions interface {
 	GetIdentityResolver(schemeID string) IdentityResolver
 }
+
+// AnonymousIdentity is a sentinel to indicate no identity.
+type AnonymousIdentity struct{}
+
+var _ Identity = (*AnonymousIdentity)(nil)
+
+// Expiration returns the zero value for time, as anonymous identity never
+// expires.
+func (*AnonymousIdentity) Expiration() time.Time {
+	return time.Time{}
+}
+
+// AnonymousIdentityResolver returns AnonymousIdentity.
+type AnonymousIdentityResolver struct{}
+
+var _ IdentityResolver = (*AnonymousIdentityResolver)(nil)
+
+// GetIdentity returns AnonymousIdentity.
+func (*AnonymousIdentityResolver) GetIdentity(ctx context.Context, _ smithy.Properties) (Identity, error) {
+	return &AnonymousIdentity{}, nil
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStdlibTypes.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStdlibTypes.java
@@ -38,4 +38,8 @@ public final class GoStdlibTypes {
             public static final Symbol Response = SmithyGoDependency.NET_HTTP.pointableSymbol("Response");
         }
     }
+
+    public static final class Path {
+        public static final Symbol Join = SmithyGoDependency.PATH.valueSymbol("Join");
+    }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
@@ -854,6 +854,10 @@ public final class GoWriter extends AbstractCodeWriter<GoWriter> {
                 && !Prelude.isPreludeShape(member.getTarget());
     }
 
+    public void write(Writable w) {
+        write("$W", w);
+    }
+
     @Override
     public String toString() {
         String contents = super.toString();

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SetOperationInputContextMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SetOperationInputContextMiddleware.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen;
+
+import static software.amazon.smithy.go.codegen.GoStackStepMiddlewareGenerator.createSerializeStepMiddleware;
+import static software.amazon.smithy.go.codegen.GoWriter.emptyGoTemplate;
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+
+/**
+ * Middleware to set the final operation input on the context at the start of the serialize step such that protocol
+ * middlewares in later phases can use it.
+ */
+public class SetOperationInputContextMiddleware {
+    public static final String MIDDLEWARE_NAME = "setOperationInputMiddleware";
+    public static final String MIDDLEWARE_ID = "setOperationInput";
+
+    public GoWriter.Writable generate() {
+        return createSerializeStepMiddleware(MIDDLEWARE_NAME, MiddlewareIdentifier.string(MIDDLEWARE_ID))
+                .asWritable(generateBody(), emptyGoTemplate());
+    }
+
+    private GoWriter.Writable generateBody() {
+        return goTemplate("""
+                ctx = setOperationInput(ctx, in.Parameters)
+                return next.HandleSerialize(ctx, in)
+                """);
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoTypes.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoTypes.java
@@ -59,6 +59,10 @@ public final class SmithyGoTypes {
             public static final Symbol NewStackRequest = SmithyGoDependency.SMITHY_HTTP_TRANSPORT.valueSymbol("NewStackRequest");
             public static final Symbol NewClientHandler = SmithyGoDependency.SMITHY_HTTP_TRANSPORT.valueSymbol("NewClientHandler");
 
+            public static final Symbol JoinPath = SmithyGoDependency.SMITHY_HTTP_TRANSPORT.valueSymbol("JoinPath");
+
+            public static final Symbol GetHostnameImmutable = SmithyGoDependency.SMITHY_HTTP_TRANSPORT.valueSymbol("GetHostnameImmutable");
+
             public static final Symbol AuthScheme = SmithyGoDependency.SMITHY_HTTP_TRANSPORT.valueSymbol("AuthScheme");
             public static final Symbol SchemeIDAnonymous = SmithyGoDependency.SMITHY_HTTP_TRANSPORT.valueSymbol("SchemeIDAnonymous");
             public static final Symbol NewAnonymousScheme = SmithyGoDependency.SMITHY_HTTP_TRANSPORT.valueSymbol("NewAnonymousScheme");
@@ -70,6 +74,11 @@ public final class SmithyGoTypes {
 
             public static final Symbol SigV4Properties = SmithyGoDependency.SMITHY_HTTP_TRANSPORT.pointableSymbol("SigV4Properties");
             public static final Symbol SigV4AProperties = SmithyGoDependency.SMITHY_HTTP_TRANSPORT.pointableSymbol("SigV4AProperties");
+
+            public static final Symbol GetSigV4SigningName = SmithyGoDependency.SMITHY_HTTP_TRANSPORT.valueSymbol("GetSigV4SigningName");
+            public static final Symbol GetSigV4SigningRegion = SmithyGoDependency.SMITHY_HTTP_TRANSPORT.valueSymbol("GetSigV4SigningName");
+            public static final Symbol GetSigV4ASigningName = SmithyGoDependency.SMITHY_HTTP_TRANSPORT.valueSymbol("GetSigV4ASigningName");
+            public static final Symbol GetSigV4ASigningRegions = SmithyGoDependency.SMITHY_HTTP_TRANSPORT.valueSymbol("GetSigV4ASigningRegions");
 
             public static final Symbol SetSigV4SigningName = SmithyGoDependency.SMITHY_HTTP_TRANSPORT.valueSymbol("SetSigV4SigningName");
             public static final Symbol SetSigV4SigningRegion = SmithyGoDependency.SMITHY_HTTP_TRANSPORT.valueSymbol("SetSigV4SigningRegion");
@@ -84,6 +93,7 @@ public final class SmithyGoTypes {
         public static final Symbol Option = SmithyGoDependency.SMITHY_AUTH.pointableSymbol("Option");
         public static final Symbol IdentityResolver = SmithyGoDependency.SMITHY_AUTH.valueSymbol("IdentityResolver");
         public static final Symbol Identity = SmithyGoDependency.SMITHY_AUTH.valueSymbol("Identity");
+        public static final Symbol AnonymousIdentityResolver = SmithyGoDependency.SMITHY_AUTH.pointableSymbol("AnonymousIdentityResolver");
         public static final Symbol GetAuthOptions = SmithyGoDependency.SMITHY_AUTH.valueSymbol("GetAuthOptions");
         public static final Symbol SetAuthOptions = SmithyGoDependency.SMITHY_AUTH.valueSymbol("SetAuthOptions");
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolUtils.java
@@ -193,17 +193,13 @@ public final class SymbolUtils {
                 .orElse(false);
     }
 
-    public static Symbol.Builder getPackageSymbol(
-        String importPath, String symbolName, String namespaceAlias, boolean pointable
-    ) {
-        Symbol.Builder builder;
-        if (pointable) {
-            builder = SymbolUtils.createPointableSymbolBuilder(symbolName);
-        } else {
-            builder = SymbolUtils.createValueSymbolBuilder(symbolName);
-        }
-
-        // TODO this doesn't seem right
-        return builder.namespace(importPath, "/").putProperty(SymbolUtils.NAMESPACE_ALIAS, namespaceAlias);
+    /**
+     * Builds a symbol within the context of the package in which codegen is taking place.
+     *
+     * @param name Symbol name.
+     * @return The built symbol.
+     */
+    public static Symbol buildPackageSymbol(String name) {
+        return Symbol.builder().name(name).build();
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/GetIdentityMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/GetIdentityMiddlewareGenerator.java
@@ -35,15 +35,17 @@ public class GetIdentityMiddlewareGenerator {
         this.context = context;
     }
 
-    public static GoWriter.Writable generateAddMiddleware() {
+    public static GoWriter.Writable generateAddToProtocolFinalizers() {
         return goTemplate("""
-                err = stack.Finalize.Add(&$L{
-                    options: options,
-                }, $T)
-                if err != nil {
-                    return err
+                if err := stack.Finalize.Insert(&$L{options: options}, $S, $T); err != nil {
+                    return $T("add $L: %v", err)
                 }
-                """, MIDDLEWARE_NAME, SmithyGoTypes.Middleware.Before);
+                """,
+                MIDDLEWARE_NAME,
+                ResolveAuthSchemeMiddlewareGenerator.MIDDLEWARE_ID,
+                SmithyGoTypes.Middleware.After,
+                GoStdlibTypes.Fmt.Errorf,
+                MIDDLEWARE_ID);
     }
 
     public GoWriter.Writable generate() {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/SigV4aTrait.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/SigV4aTrait.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.auth;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AbstractTrait;
+
+/**
+ * Fake trait for aws.auth#sigv4a until smithy adds it.
+ */
+public final class SigV4aTrait extends AbstractTrait {
+    public static final ShapeId ID = ShapeId.from("aws.auth#sigv4a");
+
+    public SigV4aTrait() {
+        super(ID, Node.objectNode());
+    }
+
+    @Override
+    protected Node createNode() {
+        return Node.objectNode();
+    }
+
+    @Override
+    public boolean isSynthetic() {
+        return true;
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/SignRequestMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/SignRequestMiddlewareGenerator.java
@@ -23,6 +23,7 @@ import software.amazon.smithy.go.codegen.GoStdlibTypes;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.MiddlewareIdentifier;
 import software.amazon.smithy.go.codegen.SmithyGoTypes;
+import software.amazon.smithy.go.codegen.endpoints.EndpointMiddlewareGenerator;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.utils.MapUtils;
 
@@ -36,13 +37,17 @@ public class SignRequestMiddlewareGenerator {
         this.context = context;
     }
 
-    public static GoWriter.Writable generateAddMiddleware() {
+    public static GoWriter.Writable generateAddToProtocolFinalizers() {
         return goTemplate("""
-                err = stack.Finalize.Add(&$L{}, $T)
-                if err != nil {
-                    return err
+                if err := stack.Finalize.Insert(&$L{}, $S, $T); err != nil {
+                    return $T("add $L: %v", err)
                 }
-                """, MIDDLEWARE_NAME, SmithyGoTypes.Middleware.Before);
+                """,
+                MIDDLEWARE_NAME,
+                EndpointMiddlewareGenerator.MIDDLEWARE_ID,
+                SmithyGoTypes.Middleware.After,
+                GoStdlibTypes.Fmt.Errorf,
+                MIDDLEWARE_ID);
     }
 
     public GoWriter.Writable generate() {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ConfigFieldResolver.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ConfigFieldResolver.java
@@ -120,7 +120,14 @@ public final class ConfigFieldResolver {
         /**
          * Indicates that the resolver targets config fields after customer mutation.
          */
-        FINALIZATION
+        FINALIZATION,
+
+        /**
+         * Indicates that the resolver targets config fields after the client has been instantiated. Resolvers with this
+         * target can then take a reference to the instantiated client in existing Options, but CANNOT modify fields on
+         * Options since it is passed to the already-existing client by value.
+         */
+        FINALIZATION_WITH_CLIENT
     }
 
     public static class Builder implements SmithyBuilder<ConfigFieldResolver> {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/auth/SigV4aDefinition.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/auth/SigV4aDefinition.java
@@ -25,21 +25,22 @@ import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 
 /**
- * Implements codegen for smithy.api#noAuth.
+ * Implements codegen for aws.auth#sigv4a.
  */
-public class AnonymousDefinition implements AuthSchemeDefinition {
+public class SigV4aDefinition implements AuthSchemeDefinition {
+    // FUTURE: reference modeled sigv4a trait
+
     @Override
-    public GoWriter.Writable generateServiceOption(ProtocolGenerator.GenerationContext c, ServiceShape s) {
-        return goTemplate("$T(),", SmithyGoTypes.Transport.Http.NewAnonymousOption);
+    public GoWriter.Writable generateServiceOption(
+            ProtocolGenerator.GenerationContext context, ServiceShape service
+    ) {
+        return goTemplate("$T(),", SmithyGoTypes.Transport.Http.NewSigV4AOption);
     }
 
     @Override
-    public GoWriter.Writable generateOperationOption(ProtocolGenerator.GenerationContext c, OperationShape o) {
-        return goTemplate("$T(),", SmithyGoTypes.Transport.Http.NewAnonymousOption);
-    }
-
-    @Override
-    public GoWriter.Writable generateOptionsIdentityResolver() {
-        return goTemplate("&$T{}", SmithyGoTypes.Auth.AnonymousIdentityResolver);
+    public GoWriter.Writable generateOperationOption(
+            ProtocolGenerator.GenerationContext context, OperationShape operation
+    ) {
+        return goTemplate("$T(),", SmithyGoTypes.Transport.Http.NewSigV4AOption);
     }
 }


### PR DESCRIPTION
* Add sigv4a auth definition
  * There's a temporary sigv4a "trait" which is used downstream, to be replaced by the real thing at the time it's added
* Reorder operation phasing: auth resolution, identity retrieval, endpoint resolution, and signing now occur in that order at the beginning of the finalize phase
  * The operation input is now stored on the context at the beginning of serialize to be accessed as necessary by later phases
  * "resolve endpoint" middleware is now always generated and simply empty without a ruleset. A large number of components index off of it (both here and in the SDK downstream), better to have it be an "explicit" phase to not have to worry about it being there for stack operations
  * Path merging behavior now occurs as part of endpoint resolution, since that happens after serialization
* Add anonymous identity and resolver
* Give `ConfigFieldResolver` a new target for finalizing post-client creation (reverting the behavior of the old "finalize" to happen before client creation such that option modifications actually persist)