### PR TITLE
pass through unrecognized signer names as-is

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/AuthSchemePropertyGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/AuthSchemePropertyGenerator.java
@@ -39,7 +39,7 @@ public class AuthSchemePropertyGenerator {
         return switch (name) {
             case "sigv4" -> "aws.auth#sigv4";
             case "sigv4a" -> "aws.auth#sigv4a";
-            default -> throw new IllegalStateException("Unexpected value: " + name);
+            default -> name;
         };
     }
 


### PR DESCRIPTION
Endpoint resolution spec explicitly says we're not supposed to error on unrecognized signer names, this is a minor regression from the merge of #469. This change restores the intended behavior.