### PR TITLE
codegen: add Options() method to read copied client config

### DIFF
--- a/.changelog/966e9ee62f384f2aa660c8bac175addb.json
+++ b/.changelog/966e9ee62f384f2aa660c8bac175addb.json
@@ -1,0 +1,8 @@
+{
+    "id": "966e9ee6-2f38-4f2a-a660-c8bac175addb",
+    "type": "feature",
+    "description": "Expose Options() method on generated service clients.",
+    "modules": [
+        "."
+    ]
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
@@ -152,6 +152,23 @@ public final class GoWriter extends AbstractCodeWriter<GoWriter> {
         return goDocTemplate(contents, new HashMap<>());
     }
 
+    /**
+     * Auto-formats a multi-paragraph string as a doc writable (including line wrapping).
+     * @param contents The docs.
+     * @return writer for formatted docs.
+     */
+    public static Writable autoDocTemplate(String contents) {
+        return GoWriter.ChainWritable.of(
+                Arrays.stream(contents.split("\n\n"))
+                        .map(it -> docParagraphWriter(it.replace("\n", " ")))
+                        .toList()
+        ).compose(false);
+    }
+
+    private static GoWriter.Writable docParagraphWriter(String paragraph) {
+        return writer -> writer.writeDocs(paragraph).writeDocs("");
+    }
+
     @SafeVarargs
     public static Writable goDocTemplate(String contents, Map<String, Object>... args) {
         validateTemplateArgsNotNull(args);

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.go.codegen;
 
+import static software.amazon.smithy.go.codegen.GoWriter.autoDocTemplate;
 import static software.amazon.smithy.go.codegen.GoWriter.emptyGoTemplate;
 import static software.amazon.smithy.go.codegen.GoWriter.goDocTemplate;
 import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
@@ -95,6 +96,7 @@ final class ServiceGenerator implements Runnable {
                 generateMetadata(),
                 generateClient(),
                 generateNew(),
+                generateGetOptions(),
                 generateInvokeOperation(),
                 generateInputContextFuncs(),
                 generateAddProtocolFinalizerMiddleware()
@@ -221,6 +223,20 @@ final class ServiceGenerator implements Runnable {
                                         .toList()
                         ).compose()
                 ));
+    }
+
+    private GoWriter.Writable generateGetOptions() {
+        var docs = autoDocTemplate("""
+                Options returns a copy of the client configuration.
+
+                Callers SHOULD NOT perform mutations on any inner structures within client config. Config overrides
+                should instead be made on a per-operation basis through functional options.""");
+        return goTemplate("""
+                $W
+                func (c $P) Options() $L {
+                    return c.options.Copy()
+                }
+                """, docs, symbolProvider.toSymbol(service), ClientOptions.NAME);
     }
 
     private GoWriter.Writable generateConfigFieldResolver(ConfigFieldResolver resolver) {

--- a/endpoints/private/rulesfn/strings.go
+++ b/endpoints/private/rulesfn/strings.go
@@ -1,6 +1,5 @@
 package rulesfn
 
-
 // Substring returns the substring of the input provided. If the start or stop
 // indexes are not valid for the input nil will be returned. If errors occur
 // they will be added to the provided [ErrorCollector].


### PR DESCRIPTION
Generates a getter for `Options` on service clients, which returns a copy of client config.