### PR TITLE
fix: correct error wrapping in auth codegen

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/GetIdentityMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/GetIdentityMiddlewareGenerator.java
@@ -76,7 +76,7 @@ public class GetIdentityMiddlewareGenerator {
 
                 identity, err := resolver.GetIdentity(ctx, rscheme.IdentityProperties)
                 if err != nil {
-                    return out, metadata, $errorf:T("get identity: %v", err)
+                    return out, metadata, $errorf:T("get identity: %w", err)
                 }
 
                 ctx = setIdentity(ctx, identity)

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/ResolveAuthSchemeMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/ResolveAuthSchemeMiddlewareGenerator.java
@@ -39,7 +39,7 @@ public class ResolveAuthSchemeMiddlewareGenerator {
     public static GoWriter.Writable generateAddToProtocolFinalizers() {
         return goTemplate("""
                 if err := stack.Finalize.Add(&$L{operation: operation, options: options}, $T); err != nil {
-                    return $T("add $L: %v", err)
+                    return $T("add $L: %w", err)
                 }
                 """,
                 MIDDLEWARE_NAME,
@@ -69,7 +69,7 @@ public class ResolveAuthSchemeMiddlewareGenerator {
                 params := $1L(m.operation, getOperationInput(ctx), m.options)
                 options, err := m.options.AuthSchemeResolver.ResolveAuthSchemes(ctx, params)
                 if err != nil {
-                    return out, metadata, $2T("resolve auth scheme: %v", err)
+                    return out, metadata, $2T("resolve auth scheme: %w", err)
                 }
 
                 scheme, ok := m.selectScheme(options)

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/SignRequestMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/SignRequestMiddlewareGenerator.java
@@ -40,7 +40,7 @@ public class SignRequestMiddlewareGenerator {
     public static GoWriter.Writable generateAddToProtocolFinalizers() {
         return goTemplate("""
                 if err := stack.Finalize.Insert(&$L{}, $S, $T); err != nil {
-                    return $T("add $L: %v", err)
+                    return $T("add $L: %w", err)
                 }
                 """,
                 MIDDLEWARE_NAME,
@@ -82,7 +82,7 @@ public class SignRequestMiddlewareGenerator {
                 }
 
                 if err := signer.SignRequest(ctx, req, identity, rscheme.SignerProperties); err != nil {
-                    return out, metadata, $errorf:T("sign request: %v", err)
+                    return out, metadata, $errorf:T("sign request: %w", err)
                 }
 
                 return next.HandleFinalize(ctx, in)


### PR DESCRIPTION
`%w` is the formatter for wrapping errors in `fmt.Errorf`, NOT `%v`. Fix all instances of this in auth codegen.

Related: https://github.com/aws/aws-sdk-go-v2/issues/2400