### PR TITLE
fix: request compression codegen for resource operations

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/requestcompression/RequestCompression.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/requestcompression/RequestCompression.java
@@ -35,7 +35,6 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.RequestCompressionTrait;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.MapUtils;
@@ -81,13 +80,12 @@ public final class RequestCompression implements GoIntegration {
             GoDelegator goDelegator
     ) {
         ServiceShape service = settings.getService(model);
-        for (ShapeId operationID : service.getAllOperations()) {
-            OperationShape operation = model.expectShape(operationID, OperationShape.class);
+        TopDownIndex.of(model).getContainedOperations(service).forEach(operation -> {
             if (!operation.hasTrait(RequestCompressionTrait.class)) {
-                continue;
+                return;
             }
             goDelegator.useShapeWriter(operation, writeMiddlewareHelper(symbolProvider, operation));
-        }
+        });
     }
 
 


### PR DESCRIPTION
We MUST iterate over operations with `TopDownIndex.getContainedOperations` rather than `ServiceShape.getAllOperations`, the latter only covers operations listed in the service shape's `operations` list and will miss anything that's listed as part of a `resource` on the service.

We missed this in the original implementation with the protocol tests because the operations that use the compression trait there are actually in the `operations` list of the service shape.