### PR TITLE
Add accountID into endpoint2.0 param binding

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParametersResolverGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParametersResolverGenerator.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.go.codegen.auth;
 import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
 
 import java.util.ArrayList;
+import software.amazon.smithy.go.codegen.GoStdlibTypes;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.utils.MapUtils;
@@ -42,7 +43,7 @@ public class AuthParametersResolverGenerator {
         loadResolvers();
 
         return goTemplate("""
-                func $name:L(operation string, input interface{}, options Options) $params:P {
+                func $name:L(operation string, input interface{}, options Options, ctx $context:T) $params:P {
                     params := &$params:T{
                         Operation: operation,
                     }
@@ -55,14 +56,15 @@ public class AuthParametersResolverGenerator {
                 MapUtils.of(
                         "name", FUNC_NAME,
                         "params", AuthParametersGenerator.STRUCT_SYMBOL,
-                        "bindings", generateResolvers()
+                        "bindings", generateResolvers(),
+                        "context", GoStdlibTypes.Context.Context
                 ));
     }
 
     private GoWriter.Writable generateResolvers() {
         return (writer) -> {
             for (var resolver: resolvers) {
-                writer.write("$T(params, input, options)", resolver.resolver());
+                writer.write("$T(params, input, options, ctx)", resolver.resolver());
             }
         };
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParametersResolverGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParametersResolverGenerator.java
@@ -43,7 +43,7 @@ public class AuthParametersResolverGenerator {
         loadResolvers();
 
         return goTemplate("""
-                func $name:L(operation string, input interface{}, options Options, ctx $context:T) $params:P {
+                func $name:L(ctx $context:T, operation string, input interface{}, options Options) $params:P {
                     params := &$params:T{
                         Operation: operation,
                     }
@@ -64,7 +64,7 @@ public class AuthParametersResolverGenerator {
     private GoWriter.Writable generateResolvers() {
         return (writer) -> {
             for (var resolver: resolvers) {
-                writer.write("$T(params, input, options, ctx)", resolver.resolver());
+                writer.write("$T(ctx, params, input, options)", resolver.resolver());
             }
         };
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/ResolveAuthSchemeMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/ResolveAuthSchemeMiddlewareGenerator.java
@@ -66,7 +66,7 @@ public class ResolveAuthSchemeMiddlewareGenerator {
 
     private GoWriter.Writable generateBody() {
         return goTemplate("""
-                params := $1L(m.operation, getOperationInput(ctx), m.options)
+                params := $1L(m.operation, getOperationInput(ctx), m.options, ctx)
                 options, err := m.options.AuthSchemeResolver.ResolveAuthSchemes(ctx, params)
                 if err != nil {
                     return out, metadata, $2T("resolve auth scheme: %w", err)

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/ResolveAuthSchemeMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/ResolveAuthSchemeMiddlewareGenerator.java
@@ -66,7 +66,7 @@ public class ResolveAuthSchemeMiddlewareGenerator {
 
     private GoWriter.Writable generateBody() {
         return goTemplate("""
-                params := $1L(m.operation, getOperationInput(ctx), m.options, ctx)
+                params := $1L(ctx, m.operation, getOperationInput(ctx), m.options)
                 options, err := m.options.AuthSchemeResolver.ResolveAuthSchemes(ctx, params)
                 if err != nil {
                     return out, metadata, $2T("resolve auth scheme: %w", err)

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointMiddlewareGenerator.java
@@ -126,7 +126,7 @@ public final class EndpointMiddlewareGenerator {
 
     private GoWriter.Writable generateResolveEndpoint() {
         return goTemplate("""
-                params := bindEndpointParams(getOperationInput(ctx), m.options)
+                params := bindEndpointParams(getOperationInput(ctx), m.options, ctx)
                 endpt, err := m.options.EndpointResolverV2.ResolveEndpoint(ctx, *params)
                 if err != nil {
                     return out, metadata, $1T("failed to resolve service endpoint, %w", err)

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointMiddlewareGenerator.java
@@ -126,7 +126,7 @@ public final class EndpointMiddlewareGenerator {
 
     private GoWriter.Writable generateResolveEndpoint() {
         return goTemplate("""
-                params := bindEndpointParams(getOperationInput(ctx), m.options, ctx)
+                params := bindEndpointParams(ctx, getOperationInput(ctx), m.options)
                 endpt, err := m.options.EndpointResolverV2.ResolveEndpoint(ctx, *params)
                 if err != nil {
                     return out, metadata, $1T("failed to resolve service endpoint, %w", err)

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointParameterBindingsGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointParameterBindingsGenerator.java
@@ -56,7 +56,7 @@ public class EndpointParameterBindingsGenerator {
                     bindEndpointParams(*EndpointParameters)
                 }
 
-                func bindEndpointParams(input interface{}, options Options) *EndpointParameters {
+                func bindEndpointParams(input interface{}, options Options, ctx context.Context) *EndpointParameters {
                     params := &EndpointParameters{}
 
                     $builtinBindings:W

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointParameterBindingsGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointParameterBindingsGenerator.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
+import software.amazon.smithy.go.codegen.GoStdlibTypes;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter;
@@ -56,7 +57,7 @@ public class EndpointParameterBindingsGenerator {
                     bindEndpointParams(*EndpointParameters)
                 }
 
-                func bindEndpointParams(input interface{}, options Options, ctx context.Context) *EndpointParameters {
+                func bindEndpointParams(ctx $context:T, input interface{}, options Options) *EndpointParameters {
                     params := &EndpointParameters{}
 
                     $builtinBindings:W
@@ -71,6 +72,7 @@ public class EndpointParameterBindingsGenerator {
                 }
                 """,
                 MapUtils.of(
+                        "context", GoStdlibTypes.Context.Context,
                         "builtinBindings", generateBuiltinBindings(),
                         "clientContextBindings", generateClientContextBindings()
                 ));


### PR DESCRIPTION
During the ep2.0 resolution, the accountID param is retrieved from ctx's credentials, thus in this PR, the ctx is added as a new param into endpoint binding func codegen.