### PR TITLE
chore: bump min go to 1.20 and remove 95% of the go-cmp dependency

### DIFF
--- a/.changelog/5974e1d2ba434e1fba73f9632f9b1063.json
+++ b/.changelog/5974e1d2ba434e1fba73f9632f9b1063.json
@@ -1,0 +1,8 @@
+{
+    "id": "5974e1d2-ba43-4e1f-ba73-f9632f9b1063",
+    "type": "feature",
+    "description": "Bump minimum Go version to 1.20 per our language support policy.",
+    "modules": [
+        "."
+    ]
+}

--- a/.github/workflows/api_diff_check.yml
+++ b/.github/workflows/api_diff_check.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.16
+        go-version: "1.20"
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go-version: [1.19]
+        go-version: ["1.20"]
     env:
       JAVA_TOOL_OPTIONS: "-Xmx2g"
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ["1.19", "1.20", "1.21"]
+        go-version: ["1.20", "1.21", "1.22"]
     steps:
     - uses: actions/checkout@v2
 

--- a/auth/bearer/middleware_test.go
+++ b/auth/bearer/middleware_test.go
@@ -2,14 +2,12 @@ package bearer
 
 import (
 	"context"
-	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 
 	smithyhttp "github.com/aws/smithy-go/transport/http"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestSignHTTPSMessage(t *testing.T) {
@@ -65,13 +63,14 @@ func TestSignHTTPSMessage(t *testing.T) {
 				t.Fatalf("expect no error, got %v", err)
 			}
 
-			options := []cmp.Option{
-				cmpopts.IgnoreUnexported(smithyhttp.Request{}),
-				cmpopts.IgnoreUnexported(http.Request{}),
-			}
+			expect := c.expectMessage.(*smithyhttp.Request)
 
-			if diff := cmp.Diff(c.expectMessage, message, options...); diff != "" {
-				t.Errorf("expect match\n%s", diff)
+			actual, ok := message.(*smithyhttp.Request)
+			if !ok {
+				t.Fatalf("*smithyhttp.Request != %T", actual)
+			}
+			if !reflect.DeepEqual(expect.Header, actual.Header) {
+				t.Errorf("%v != %v", expect.Header, actual.Header)
 			}
 		})
 	}

--- a/auth/bearer/token_cache_test.go
+++ b/auth/bearer/token_cache_test.go
@@ -9,8 +9,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 var _ TokenProvider = (*TokenCache)(nil)
@@ -33,8 +31,8 @@ func TestTokenCache_cache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expect no error, got %v", err)
 	}
-	if diff := cmp.Diff(expectToken, token); diff != "" {
-		t.Errorf("expect token match\n%s", diff)
+	if expectToken != token {
+		t.Errorf("expect token match: %v != %v", expectToken, token)
 	}
 
 	for i := 0; i < 100; i++ {
@@ -42,8 +40,8 @@ func TestTokenCache_cache(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expect no error, got %v", err)
 		}
-		if diff := cmp.Diff(expectToken, token); diff != "" {
-			t.Errorf("expect token match\n%s", diff)
+		if expectToken != token {
+			t.Errorf("expect token match: %v != %v", expectToken, token)
 		}
 	}
 }
@@ -66,8 +64,8 @@ func TestTokenCache_cacheConcurrent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expect no error, got %v", err)
 	}
-	if diff := cmp.Diff(expectToken, token); diff != "" {
-		t.Errorf("expect token match\n%s", diff)
+	if expectToken != token {
+		t.Errorf("expect token match: %v != %v", expectToken, token)
 	}
 
 	for i := 0; i < 100; i++ {
@@ -78,8 +76,8 @@ func TestTokenCache_cacheConcurrent(t *testing.T) {
 			if err != nil {
 				t.Fatalf("expect no error, got %v", err)
 			}
-			if diff := cmp.Diff(expectToken, token); diff != "" {
-				t.Errorf("expect token match\n%s", diff)
+			if expectToken != token {
+				t.Errorf("expect token match: %v != %v", expectToken, token)
 			}
 		})
 	}
@@ -115,8 +113,8 @@ func TestTokenCache_expired(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expect no error, got %v", err)
 		}
-		if diff := cmp.Diff(expectToken, token); diff != "" {
-			t.Errorf("expect token match\n%s", diff)
+		if expectToken != token {
+			t.Errorf("expect token match: %v != %v", expectToken, token)
 		}
 	}
 	if e, a := 1, int(atomic.LoadInt32(retrievedCount)); e != a {
@@ -132,8 +130,8 @@ func TestTokenCache_expired(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expect no error, got %v", err)
 	}
-	if diff := cmp.Diff(refreshedToken, token); diff != "" {
-		t.Errorf("expect refreshed token match\n%s", diff)
+	if refreshedToken != token {
+		t.Errorf("expect refreshed token match: %v != %v", refreshedToken, token)
 	}
 	if e, a := 2, int(atomic.LoadInt32(retrievedCount)); e != a {
 		t.Errorf("expect %v provider calls, got %v", e, a)
@@ -192,8 +190,9 @@ func TestTokenCache_cancelled(t *testing.T) {
 		if err != nil {
 			t.Errorf("expect no error, got %v", err)
 		} else {
-			if diff := cmp.Diff(Token{Value: "abc123"}, token); diff != "" {
-				t.Errorf("expect token retrieve match\n%s", diff)
+			expect := Token{Value: "abc123"}
+			if expect != token {
+				t.Errorf("expect token retrieve match: %v != %v", expect, token)
 			}
 		}
 	}()
@@ -284,8 +283,8 @@ func TestTokenCache_asyncRefresh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expect no error, got %v", err)
 	}
-	if diff := cmp.Diff(expectToken, token); diff != "" {
-		t.Errorf("expect token match\n%s", diff)
+	if expectToken != token {
+		t.Errorf("expect token match: %v != %v", expectToken, token)
 	}
 
 	// 2-5: Offset time for subsequent calls to retrieve to trigger asynchronous
@@ -299,8 +298,8 @@ func TestTokenCache_asyncRefresh(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expect no error, got %v", err)
 		}
-		if diff := cmp.Diff(expectToken, token); diff != "" {
-			t.Errorf("expect token match\n%s", diff)
+		if expectToken != token {
+			t.Errorf("expect token match: %v != %v", expectToken, token)
 		}
 	}
 	// Wait for all async refreshes to complete
@@ -317,8 +316,8 @@ func TestTokenCache_asyncRefresh(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expect no error, got %v", err)
 		}
-		if diff := cmp.Diff(expectToken, token); diff != "" {
-			t.Errorf("expect token match\n%s", diff)
+		if expectToken != token {
+			t.Errorf("expect token match: %v != %v", expectToken, token)
 		}
 		testWaitAsyncRefreshDone(provider)
 	}
@@ -329,8 +328,8 @@ func TestTokenCache_asyncRefresh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expect no error, got %v", err)
 	}
-	if diff := cmp.Diff(refreshedToken, token); diff != "" {
-		t.Errorf("expect refreshed token match\n%s", diff)
+	if refreshedToken != token {
+		t.Errorf("expect refreshed token match: %v != %v", refreshedToken, token)
 	}
 }
 
@@ -374,8 +373,8 @@ func TestTokenCache_asyncRefreshWithMinDelay(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expect no error, got %v", err)
 	}
-	if diff := cmp.Diff(expectToken, token); diff != "" {
-		t.Errorf("expect token match\n%s", diff)
+	if expectToken != token {
+		t.Errorf("expect token match: %v != %v", expectToken, token)
 	}
 
 	// 2-5: Offset time for subsequent calls to retrieve to trigger asynchronous
@@ -389,8 +388,8 @@ func TestTokenCache_asyncRefreshWithMinDelay(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expect no error, got %v", err)
 		}
-		if diff := cmp.Diff(expectToken, token); diff != "" {
-			t.Errorf("expect token match\n%s", diff)
+		if expectToken != token {
+			t.Errorf("expect token match: %v != %v", expectToken, token)
 		}
 		// Wait for all async refreshes to complete ensure not deduped
 		testWaitAsyncRefreshDone(provider)
@@ -411,8 +410,8 @@ func TestTokenCache_asyncRefreshWithMinDelay(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expect no error, got %v", err)
 	}
-	if diff := cmp.Diff(expectToken, token); diff != "" {
-		t.Errorf("expect token match\n%s", diff)
+	if expectToken != token {
+		t.Errorf("expect token match: %v != %v", expectToken, token)
 	}
 	// Wait for all async refreshes to complete ensure not deduped
 	testWaitAsyncRefreshDone(provider)
@@ -423,8 +422,8 @@ func TestTokenCache_asyncRefreshWithMinDelay(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expect no error, got %v", err)
 	}
-	if diff := cmp.Diff(refreshedToken, token); diff != "" {
-		t.Errorf("expect refreshed token match\n%s", diff)
+	if refreshedToken != token {
+		t.Errorf("expect refreshed token match: %v != %v", refreshedToken, token)
 	}
 }
 
@@ -468,8 +467,8 @@ func TestTokenCache_disableAsyncRefresh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expect no error, got %v", err)
 	}
-	if diff := cmp.Diff(expectToken, token); diff != "" {
-		t.Errorf("expect token match\n%s", diff)
+	if expectToken != token {
+		t.Errorf("expect token match: %v != %v", expectToken, token)
 	}
 
 	// Update time into refresh window before token expires
@@ -499,8 +498,8 @@ func TestTokenCache_disableAsyncRefresh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expect no error, got %v", err)
 	}
-	if diff := cmp.Diff(refreshedToken, token); diff != "" {
-		t.Errorf("expect refreshed token match\n%s", diff)
+	if refreshedToken != token {
+		t.Errorf("expect refreshed token match: %v != %v", refreshedToken, token)
 	}
 }
 

--- a/document/json/decoder_test.go
+++ b/document/json/decoder_test.go
@@ -2,13 +2,13 @@ package json_test
 
 import (
 	"math/big"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/aws/smithy-go/document"
 	"github.com/aws/smithy-go/document/internal/serde"
 	"github.com/aws/smithy-go/document/json"
-	"github.com/google/go-cmp/cmp"
 )
 
 var decodeArrayTestCases = map[string]testCase{
@@ -153,14 +153,11 @@ func testDecodeJSONInterface(t *testing.T, tt testCase) {
 	if err := d.DecodeJSONInterface(MustJSONUnmarshal(tt.json, !tt.disableJSONNumber), tt.actual); (err != nil) != tt.wantErr {
 		t.Errorf("DecodeJSONInterface() error = %v, wantErr %v", err, tt.wantErr)
 	}
-	if diff := cmp.Diff(
-		serde.PtrToValue(tt.want),
-		serde.PtrToValue(tt.actual),
-		cmp.AllowUnexported(StructA{}, StructB{}),
-		cmp.Comparer(cmpBigFloat()),
-		cmp.Comparer(cmpBigInt()),
-	); len(diff) > 0 {
-		t.Error(diff)
+
+	expect := serde.PtrToValue(tt.want)
+	actual := serde.PtrToValue(tt.actual)
+	if !reflect.DeepEqual(expect, actual) {
+		t.Errorf("%v != %v", expect, actual)
 	}
 }
 

--- a/document/json/encoder_test.go
+++ b/document/json/encoder_test.go
@@ -1,12 +1,12 @@
 package json_test
 
 import (
-	"github.com/aws/smithy-go/document"
-	"github.com/aws/smithy-go/document/internal/serde"
-	"github.com/aws/smithy-go/document/json"
-	"github.com/google/go-cmp/cmp"
+	"reflect"
 	"testing"
 	"time"
+
+	"github.com/aws/smithy-go/document"
+	"github.com/aws/smithy-go/document/json"
 )
 
 func TestEncoder_Encode(t *testing.T) {
@@ -79,15 +79,10 @@ func testEncode(t *testing.T, tt testCase) {
 		t.Errorf("Encode() error = %v, wantErr %v", err, tt.wantErr)
 	}
 
+	expect := MustJSONUnmarshal(tt.json, !tt.disableJSONNumber)
 	got := MustJSONUnmarshal(encodeBytes, !tt.disableJSONNumber)
 
-	if diff := cmp.Diff(
-		serde.PtrToValue(MustJSONUnmarshal(tt.json, !tt.disableJSONNumber)),
-		serde.PtrToValue(got),
-		cmp.AllowUnexported(StructA{}, StructB{}),
-		cmp.Comparer(cmpBigFloat()),
-		cmp.Comparer(cmpBigInt()),
-	); len(diff) > 0 {
-		t.Error(diff)
+	if !reflect.DeepEqual(expect, got) {
+		t.Errorf("%v != %v", expect, got)
 	}
 }

--- a/document/json/shared_test.go
+++ b/document/json/shared_test.go
@@ -426,7 +426,9 @@ var sharedNumberTestCases = map[string]testCase{
 			return &x
 		}(),
 		want: func() *big.Float {
-			return big.NewFloat(math.MaxFloat64)
+			// this is slightly different than big.NewFloat(math.MaxFloat64)
+			x, _ := (&big.Float{}).SetString(strconv.FormatFloat(math.MaxFloat64, 'e', -1, 64))
+			return x
 		}(),
 	},
 	"float64 to big.Float": {

--- a/encoding/xml/xml_decoder_test.go
+++ b/encoding/xml/xml_decoder_test.go
@@ -4,10 +4,9 @@ import (
 	"bytes"
 	"encoding/xml"
 	"io"
+	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestXMLNodeDecoder_Token(t *testing.T) {
@@ -107,8 +106,8 @@ func TestXMLNodeDecoder_Token(t *testing.T) {
 				t.Fatalf("expected a valid end element token for the xml document, got none")
 			}
 
-			if diff := cmp.Diff(c.expectedStartElement, token); len(diff) != 0 {
-				t.Fatalf("Found diff : (-expected,+actual), \n %v", diff)
+			if !reflect.DeepEqual(c.expectedStartElement, token) {
+				t.Fatalf("Found diff : %v != %v", c.expectedStartElement, token)
 			}
 		})
 	}
@@ -133,8 +132,10 @@ func TestXMLNodeDecoder_TokenExample(t *testing.T) {
 		t.Fatalf("Expected no error, got %v", err)
 
 	}
-	if diff := cmp.Diff(token, xml.StartElement{Name: xml.Name{Local: "Response"}, Attr: []xml.Attr{}}); len(diff) != 0 {
-		t.Fatalf("Found diff : (-expected,+actual), \n %v", diff)
+
+	expect := xml.StartElement{Name: xml.Name{Local: "Response"}, Attr: []xml.Attr{}}
+	if !reflect.DeepEqual(expect, token) {
+		t.Fatalf("Found diff : %v != %v", expect, token)
 	}
 	if done {
 		t.Fatalf("expected decoding to not be done yet")
@@ -149,8 +150,10 @@ func TestXMLNodeDecoder_TokenExample(t *testing.T) {
 		t.Fatalf("Expected no error, got %v", err)
 
 	}
-	if diff := cmp.Diff(token, xml.StartElement{Name: xml.Name{Local: ""}, Attr: nil}); len(diff) != 0 {
-		t.Fatalf("Found diff : (-expected,+actual), \n %v", diff)
+
+	expect = xml.StartElement{Name: xml.Name{Local: ""}, Attr: nil}
+	if !reflect.DeepEqual(expect, token) {
+		t.Fatalf("Found diff : %v != %v", expect, token)
 	}
 	if done {
 		t.Fatalf("expected decoding to not be done yet")
@@ -163,8 +166,9 @@ func TestXMLNodeDecoder_TokenExample(t *testing.T) {
 		t.Fatalf("Expected no error, got %v", err)
 
 	}
-	if diff := cmp.Diff(token, xml.StartElement{Name: xml.Name{Local: ""}, Attr: nil}); len(diff) != 0 {
-		t.Fatalf("Found diff : (-expected,+actual), \n %v", diff)
+
+	if !reflect.DeepEqual(expect, token) {
+		t.Fatalf("%v != %v", expect, token)
 	}
 	if !done {
 		t.Fatalf("expected decoding to be done as we fetched the end element </Struct>")
@@ -225,8 +229,8 @@ func TestXMLNodeDecoder_Value(t *testing.T) {
 				}
 			}
 
-			if diff := cmp.Diff(c.expectedValue, token); len(diff) != 0 {
-				t.Fatalf("Found diff : (-expected,+actual), \n %v", diff)
+			if !reflect.DeepEqual(c.expectedValue, token) {
+				t.Fatalf("%v != %v", c.expectedValue, token)
 			}
 		})
 	}
@@ -321,8 +325,8 @@ func Test_FetchXMLRootElement(t *testing.T) {
 				}
 			}
 
-			if diff := cmp.Diff(c.expectedStartElement, st); len(diff) != 0 {
-				t.Fatalf("Found diff : (-expected,+actual), \n %v", diff)
+			if !reflect.DeepEqual(c.expectedStartElement, st) {
+				t.Fatalf("Found diff : %v != %v", c.expectedStartElement, st)
 			}
 		})
 	}

--- a/endpoints/private/rulesfn/uri_test.go
+++ b/endpoints/private/rulesfn/uri_test.go
@@ -2,7 +2,6 @@ package rulesfn
 
 import (
 	"testing"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestURIEncode(t *testing.T) {
@@ -32,8 +31,8 @@ func TestURIEncode(t *testing.T) {
 
 func TestParseURL(t *testing.T) {
 	cases := map[string]struct {
-		input     string
-		expect    *URL
+		input  string
+		expect *URL
 	}{
 		"https hostname with no path": {
 			input: "https://example.com",
@@ -63,11 +62,11 @@ func TestParseURL(t *testing.T) {
 			},
 		},
 		"invalid port": {
-			input:     "https://example.com:abc",
+			input:  "https://example.com:abc",
 			expect: nil,
 		},
 		"with query": {
-			input:     "https://example.com:8443?foo=bar&faz=baz",
+			input:  "https://example.com:8443?foo=bar&faz=baz",
 			expect: nil,
 		},
 		"ip4 URL": {
@@ -146,8 +145,8 @@ func TestParseURL(t *testing.T) {
 				t.Fatalf("expect result, got none")
 			}
 
-			if diff := cmp.Diff(c.expect, actual); diff != "" {
-				t.Errorf("expect URL to match\n%s", diff)
+			if *c.expect != *actual {
+				t.Errorf("%v != %v", *c.expect, *actual)
 			}
 		})
 	}
@@ -169,7 +168,7 @@ func TestIsValidHostLabel(t *testing.T) {
 			expect:          true,
 		},
 		"multiple labels no split": {
-			input:     "abc.123-",
+			input:  "abc.123-",
 			expect: false,
 		},
 		"multiple labels with split": {
@@ -180,18 +179,18 @@ func TestIsValidHostLabel(t *testing.T) {
 		"multiple labels with split invalid label": {
 			input:           "abc.123-...",
 			allowSubDomains: true,
-			expect: false,
+			expect:          false,
 		},
 		"max length host label": {
 			input:  "012345678901234567890123456789012345678901234567890123456789123",
 			expect: true,
 		},
 		"too large host label": {
-			input:     "0123456789012345678901234567890123456789012345678901234567891234",
+			input:  "0123456789012345678901234567890123456789012345678901234567891234",
 			expect: false,
 		},
 		"too small host label": {
-			input:     "",
+			input:  "",
 			expect: false,
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/aws/smithy-go
 
-go 1.19
+go 1.20
 
 require github.com/google/go-cmp v0.5.8

--- a/io/ringbuffer_test.go
+++ b/io/ringbuffer_test.go
@@ -2,7 +2,6 @@ package io
 
 import (
 	"bytes"
-	"github.com/google/go-cmp/cmp"
 	"io"
 	"io/ioutil"
 	"strconv"
@@ -456,8 +455,8 @@ func TestRingBufferWriteRead(t *testing.T) {
 				return
 			}
 
-			if diff := cmp.Diff(tt.Expected, actual); len(diff) > 0 {
-				t.Error(diff)
+			if string(tt.Expected) != string(actual) {
+				t.Errorf("%v != %v", string(tt.Expected), string(actual))
 				return
 			}
 		})

--- a/middleware/ordered_group_test.go
+++ b/middleware/ordered_group_test.go
@@ -3,8 +3,6 @@ package middleware
 import (
 	"reflect"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestOrderedIDsAdd(t *testing.T) {
@@ -220,8 +218,9 @@ func TestRelativeOrder_insert(t *testing.T) {
 		t.Error("expect error, got nil")
 	}
 
-	if diff := cmp.Diff([]string{"foo", "fob", "bar", "bas", "bat", "baz"}, ro.order); len(diff) > 0 {
-		t.Error(diff)
+	expect := []string{"foo", "fob", "bar", "bas", "bat", "baz"}
+	if !reflect.DeepEqual(expect, ro.order) {
+		t.Errorf("%v != %v", expect, ro.order)
 	}
 }
 

--- a/middleware/stack_test.go
+++ b/middleware/stack_test.go
@@ -1,10 +1,9 @@
 package middleware
 
 import (
+	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestStackList(t *testing.T) {
@@ -32,8 +31,8 @@ func TestStackList(t *testing.T) {
 		"fifth",
 	}
 
-	if diff := cmp.Diff(expect, actual); len(diff) != 0 {
-		t.Errorf("expect and actual stack list differ\n%s", diff)
+	if !reflect.DeepEqual(expect, actual) {
+		t.Errorf("expect and actual stack list differ: %v != %v", expect, actual)
 	}
 }
 
@@ -63,7 +62,7 @@ func TestStackString(t *testing.T) {
 		"",
 	}, "\n")
 
-	if diff := cmp.Diff(expect, actual); len(diff) != 0 {
-		t.Errorf("expect and actual stack list differ\n%s", diff)
+	if !reflect.DeepEqual(expect, actual) {
+		t.Errorf("expect and actual stack list differ: %v != %v", expect, actual)
 	}
 }

--- a/testing/xml/sort_test.go
+++ b/testing/xml/sort_test.go
@@ -3,8 +3,6 @@ package xml
 import (
 	"bytes"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestSortXML(t *testing.T) {
@@ -15,7 +13,7 @@ func TestSortXML(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if diff := cmp.Diff(sortedXML, expectedsortedXML); len(diff) != 0 {
-		t.Fatalf("found diff: %v", diff)
+	if expectedsortedXML != sortedXML {
+		t.Fatalf("found diff: %v != %v", expectedsortedXML, sortedXML)
 	}
 }

--- a/transport/http/headerlist_test.go
+++ b/transport/http/headerlist_test.go
@@ -1,10 +1,9 @@
 package http
 
 import (
+	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestSplitHeaderListValues(t *testing.T) {
@@ -100,8 +99,8 @@ func TestSplitHeaderListValues(t *testing.T) {
 				t.Fatalf("expect no error, %v", err)
 			}
 
-			if diff := cmp.Diff(c.Expect, actual); len(diff) != 0 {
-				t.Errorf("expect match\n%s", diff)
+			if !reflect.DeepEqual(c.Expect, actual) {
+				t.Errorf("%v != %v", c.Expect, actual)
 			}
 		})
 	}
@@ -180,8 +179,8 @@ func TestSplitHTTPDateTimestampHeaderListValues(t *testing.T) {
 				t.Fatalf("expect no error, got %v", err)
 			}
 
-			if diff := cmp.Diff(c.Expect, actual); len(diff) != 0 {
-				t.Errorf("expect values to match\n,%s", diff)
+			if !reflect.DeepEqual(c.Expect, actual) {
+				t.Errorf("%v != %v", c.Expect, actual)
 			}
 		})
 	}

--- a/transport/http/middleware_headers_test.go
+++ b/transport/http/middleware_headers_test.go
@@ -3,11 +3,11 @@ package http_test
 import (
 	"context"
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestAddHeaderValue(t *testing.T) {
@@ -27,12 +27,15 @@ func TestAddHeaderValue(t *testing.T) {
 
 	handler := middleware.DecorateHandler(middleware.HandlerFunc(func(ctx context.Context, input interface{}) (output interface{}, metadata middleware.Metadata, err error) {
 		req := input.(*smithyhttp.Request)
-		if diff := cmp.Diff(req.Header, http.Header{
+
+		expect := http.Header{
 			"Foo": []string{"fooValue"},
 			"Bar": []string{"firstValue", "secondValue"},
-		}); len(diff) > 0 {
-			t.Errorf(diff)
 		}
+		if !reflect.DeepEqual(expect, req.Header) {
+			t.Errorf("%v != %v", expect, req.Header)
+		}
+
 		return output, metadata, err
 	}), stack)
 	_, _, err = handler.Handle(context.Background(), nil)
@@ -54,11 +57,14 @@ func TestSetHeaderValue(t *testing.T) {
 
 	handler := middleware.DecorateHandler(middleware.HandlerFunc(func(ctx context.Context, input interface{}) (output interface{}, metadata middleware.Metadata, err error) {
 		req := input.(*smithyhttp.Request)
-		if diff := cmp.Diff(req.Header, http.Header{
+
+		expect := http.Header{
 			"Foo": []string{"secondValue"},
-		}); len(diff) > 0 {
-			t.Errorf(diff)
 		}
+		if !reflect.DeepEqual(expect, req.Header) {
+			t.Errorf("%v != %v", expect, req.Header)
+		}
+
 		return output, metadata, err
 	}), stack)
 	_, _, err = handler.Handle(context.Background(), nil)

--- a/transport/http/middleware_http_logging_test.go
+++ b/transport/http/middleware_http_logging_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/smithy-go/logging"
 	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
-	"github.com/google/go-cmp/cmp"
 )
 
 type mockLogger struct {
@@ -154,8 +153,9 @@ func TestRequestResponseLogger(t *testing.T) {
 				t.Fatal("expect error, got nil")
 			}
 
-			if diff := cmp.Diff(tt.ExpectedLog, string(logger.Bytes())); len(diff) > 0 {
-				t.Error(diff)
+			actual := string(logger.Bytes())
+			if tt.ExpectedLog != actual {
+				t.Errorf("%v != %v", tt.ExpectedLog, actual)
 			}
 		})
 	}


### PR DESCRIPTION
With the release of go 1.22, we're bumping our minimum versions to 1.20.

This patch also removes most of the use of the `go-cmp` external dependency. We can't remove it completely yet because the assertion utility that generated event tests use downstream depends on it. That will have to be re-evaluated/untangled in a future patch.