### PR TITLE
upgrade to smithy 1.49

### DIFF
--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,2 +1,2 @@
-smithyVersion=1.47.0
+smithyVersion=1.49.0
 smithyGradleVersion=0.7.0

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolUtils.java
@@ -223,4 +223,8 @@ public final class SymbolUtils {
                 || symbol.getProperty(SymbolUtils.GO_SLICE).isPresent()
                 || symbol.getProperty(SymbolUtils.GO_MAP).isPresent();
     }
+
+    public static Symbol pointerTo(Symbol symbol) {
+        return symbol.toBuilder().putProperty(POINTABLE, true).build();
+    }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointClientPluginsGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointClientPluginsGenerator.java
@@ -15,9 +15,10 @@
 
 package software.amazon.smithy.go.codegen.endpoints;
 
+import static software.amazon.smithy.go.codegen.endpoints.EndpointParametersGenerator.parameterAsSymbol;
+
 import java.util.ArrayList;
 import java.util.List;
-import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.go.codegen.GoSettings;
 import software.amazon.smithy.go.codegen.SymbolUtils;
 import software.amazon.smithy.go.codegen.integration.ConfigField;
@@ -42,16 +43,6 @@ public class EndpointClientPluginsGenerator implements GoIntegration {
 
     private static String getExportedParameterName(Parameter parameter) {
         return StringUtils.capitalize(parameter.getName().getName().getValue());
-    }
-
-    private static Symbol parameterAsSymbol(Parameter parameter) {
-        return switch (parameter.getType()) {
-            case STRING -> SymbolUtils.createPointableSymbolBuilder("string")
-                    .putProperty(SymbolUtils.GO_UNIVERSE_TYPE, true).build();
-
-            case BOOLEAN -> SymbolUtils.createPointableSymbolBuilder("bool")
-                    .putProperty(SymbolUtils.GO_UNIVERSE_TYPE, true).build();
-        };
     }
 
     @Override


### PR DESCRIPTION
Upgrade to smithy 1.49 to pull in fixed ec2query protocol tests: https://github.com/aws/aws-sdk-go-v2/issues/2627

Includes some minor code shuffle/deduping in response to having to check for the new (currently unused) `STRING_ARRAY` endpoint parameter type.