### PR TITLE
Cast numbers in "uint oob" test error messages to avoid overflows

### DIFF
--- a/encoding/cbor/coerce_test.go
+++ b/encoding/cbor/coerce_test.go
@@ -143,7 +143,7 @@ func TestAsInt32(t *testing.T) {
 		},
 		"uint oob": {
 			In:  Uint(maxv + 1),
-			Err: fmt.Sprintf("cbor uint %d exceeds", maxv+1),
+			Err: fmt.Sprintf("cbor uint %d exceeds", Uint(maxv+1)),
 		},
 		"negint oob": {
 			In:  NegInt(maxv + 2),
@@ -330,7 +330,7 @@ func TestAsFloat64(t *testing.T) {
 		},
 		"uint oob": {
 			In:  Uint(maxv + 1),
-			Err: fmt.Sprintf("cbor uint %d exceeds", maxv+1),
+			Err: fmt.Sprintf("cbor uint %d exceeds", Uint(maxv+1)),
 		},
 		"negint oob": {
 			In:  NegInt(maxv + 2),


### PR DESCRIPTION
*Description of changes:*

For "uint oob" tests in TestAsInt32 and TestAsFloat64 in encoding/cbor/coerce_test.go, cast the number to Uint in the error message just as the number is cast in the test itself, so as to avoid overflows when tested on 32-bit architectures.

Fixes `cannot use maxv + 1 (untyped int constant 2147483648) as int value in argument to fmt.Sprintf (overflows)` in TestAsInt32 and `cannot use maxv + 1 (untyped int constant 18014398509481985) as int value in argument to fmt.Sprintf (overflows)` in TestAsFloat64 on 32-bit platforms.

Detected by Debian CI running on 386; see https://ci.debian.net/packages/g/golang-github-aws-smithy-go/testing/i386/47149094/#L1260

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
