### PR TITLE
Add time.Duration to the list of Go Stdlib Types

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStdlibTypes.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStdlibTypes.java
@@ -35,6 +35,7 @@ public final class GoStdlibTypes {
 
     public static final class Time {
         public static final Symbol Time = SmithyGoDependency.TIME.pointableSymbol("Time");
+        public static final Symbol Duration = SmithyGoDependency.TIME.valueSymbol("Duration");
     }
 
     public static final class Encoding {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adds `time.Duration` to the list of Go standard types. This will be used by later PRs 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
