### PR TITLE
add 'sync/atomic' to the list of Go dependecies

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -43,6 +43,7 @@ public final class SmithyGoDependency {
     public static final GoDependency ERRORS = stdlib("errors");
     public static final GoDependency XML = stdlib("encoding/xml");
     public static final GoDependency SYNC = stdlib("sync");
+    public static final GoDependency ATOMIC = stdlib("sync/atomic");
     public static final GoDependency PATH = stdlib("path");
     public static final GoDependency LOG = stdlib("log");
     public static final GoDependency OS = stdlib("os");


### PR DESCRIPTION
*Issue #, if available:*
Related to aws-sdk-go-v2#2321

*Description of changes:*
Add sync/atomic definition, so it can be used on clock skew detection

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
