### PR TITLE
add codegen support for string array and operation context params in endpoint bindings

### DIFF
--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,2 +1,2 @@
-smithyVersion=1.49.0
+smithyVersion=1.50.0
 smithyGradleVersion=0.7.0

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGenerator.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen;
+
+import static software.amazon.smithy.go.codegen.util.ShapeUtil.STRING_SHAPE;
+import static software.amazon.smithy.go.codegen.util.ShapeUtil.expectMember;
+import static software.amazon.smithy.go.codegen.util.ShapeUtil.listOf;
+import static software.amazon.smithy.utils.StringUtils.capitalize;
+
+import java.util.List;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.jmespath.JmespathExpression;
+import software.amazon.smithy.jmespath.ast.FieldExpression;
+import software.amazon.smithy.jmespath.ast.FunctionExpression;
+import software.amazon.smithy.jmespath.ast.ProjectionExpression;
+import software.amazon.smithy.jmespath.ast.Subexpression;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Traverses a JMESPath expression, producing a series of statements that evaluate the entire expression. The generator
+ * is shape-aware and the return indicates the underlying shape being referenced in the final result.
+ * <br/>
+ * Note that the use of writer.write() here is deliberate, it's easier to structure the code in that way instead of
+ * trying to recursively compose/organize Writable templates.
+ */
+@SmithyInternalApi
+public class GoJmespathExpressionGenerator {
+    private final GoCodegenContext ctx;
+    private final GoWriter writer;
+    private final Shape input;
+    private final JmespathExpression root;
+
+    private int idIndex = 1;
+
+    public GoJmespathExpressionGenerator(GoCodegenContext ctx, GoWriter writer, Shape input, JmespathExpression expr) {
+        this.ctx = ctx;
+        this.writer = writer;
+        this.input = input;
+        this.root = expr;
+    }
+
+    public Result generate(String ident) {
+        writer.write("v1 := $L", ident);
+        return visit(root, input);
+    }
+
+    private Result visit(JmespathExpression expr, Shape current) {
+        if (expr instanceof FunctionExpression) {
+            return visitFunction((FunctionExpression) expr, current);
+        } else if (expr instanceof FieldExpression) {
+            return visitField((FieldExpression) expr, current);
+        } else if (expr instanceof Subexpression) {
+            return visitSub((Subexpression) expr, current);
+        } else if (expr instanceof ProjectionExpression) {
+            return visitProjection((ProjectionExpression) expr, current);
+        } else {
+            throw new CodegenException("unhandled jmespath expression " + expr.getClass().getSimpleName());
+        }
+    }
+
+    private Result visitProjection(ProjectionExpression expr, Shape current) {
+        var left = visit(expr.getLeft(), current);
+
+        // left of projection HAS to be an array by spec, otherwise something is wrong
+        if (!left.shape.isListShape()) {
+            throw new CodegenException("left side of projection did not create a list");
+        }
+
+        var leftMember = expectMember(ctx.model(), (ListShape) left.shape);
+
+        // We have to know the element type for the list that we're generating, use a dummy writer to "peek" ahead and
+        // get the traversal result
+        var lookahead = new GoJmespathExpressionGenerator(ctx, new GoWriter(""), leftMember, expr.getRight())
+                .generate("v");
+
+        ++idIndex;
+        writer.write("""
+                var v$L []$P
+                for _, v := range $L {""", idIndex, ctx.symbolProvider().toSymbol(lookahead.shape), left.ident);
+
+        // new scope inside loop, but now we actually want to write the contents
+        // projected.shape is the _member_ of the resulting list
+        var projected = new GoJmespathExpressionGenerator(ctx, writer, leftMember, expr.getRight())
+                .generate("v");
+
+        writer.write("v$1L = append(v$1L, $2L)", idIndex, projected.ident);
+        writer.write("}");
+
+        return new Result(listOf(projected.shape), "v" + idIndex);
+    }
+
+    private Result visitSub(Subexpression expr, Shape current) {
+        var left = visit(expr.getLeft(), current);
+        return visit(expr.getRight(), left.shape);
+    }
+
+    private Result visitField(FieldExpression expr, Shape current) {
+        ++idIndex;
+        writer.write("v$L := v$L.$L", idIndex, idIndex - 1, capitalize(expr.getName()));
+        return new Result(expectMember(ctx.model(), current, expr.getName()), "v" + idIndex);
+    }
+
+    private Result visitFunction(FunctionExpression expr, Shape current) {
+        return switch (expr.name) {
+            case "keys" -> visitKeysFunction(expr.arguments, current);
+            default -> throw new CodegenException("unsupported function " + expr.name);
+        };
+    }
+
+    private Result visitKeysFunction(List<JmespathExpression> args, Shape current) {
+        if (args.size() != 1) {
+            throw new CodegenException("unexpected keys() arg length " + args.size());
+        }
+
+        var arg = visit(args.get(0), current);
+        ++idIndex;
+        writer.write("""
+                var v$1L []string
+                for k := range $2L {
+                    v$1L = append(v$1L, k)
+                }""", idIndex, arg.ident);
+
+        return new Result(listOf(STRING_SHAPE), "v" + idIndex);
+    }
+
+    public record Result(Shape shape, String ident) {}
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -116,7 +116,7 @@ public final class SmithyGoDependency {
     }
 
     private static GoDependency goJmespath(String relativePath) {
-        return relativePackage(GO_JMESPATH_SOURCE_PATH, relativePath, Versions.GO_JMESPATH, null);
+        return relativePackage(GO_JMESPATH_SOURCE_PATH, relativePath, Versions.GO_JMESPATH, "jmespath");
     }
 
     private static GoDependency relativePackage(

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolUtils.java
@@ -227,4 +227,11 @@ public final class SymbolUtils {
     public static Symbol pointerTo(Symbol symbol) {
         return symbol.toBuilder().putProperty(POINTABLE, true).build();
     }
+
+    public static Symbol sliceOf(Symbol symbol) {
+        return symbol.toBuilder()
+                .putProperty(GO_SLICE, true)
+                .putProperty(GO_ELEMENT_TYPE, symbol)
+                .build();
+    }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointTestsGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointTestsGenerator.java
@@ -21,6 +21,7 @@ import static software.amazon.smithy.go.codegen.GoWriter.goDocTemplate;
 import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
 import static software.amazon.smithy.go.codegen.GoWriter.joinWritables;
 import static software.amazon.smithy.go.codegen.endpoints.EndpointParametersGenerator.getExportedParameterName;
+import static software.amazon.smithy.go.codegen.util.NodeUtil.writableStringSlice;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -148,16 +149,12 @@ public final class EndpointTestsGenerator {
 
     private GoWriter.Writable generateParameterValue(Node value) {
         return switch (value.getType()) {
-            case STRING -> (GoWriter w) -> {
-                w.write("$T($S)",
-                        SymbolUtils.createValueSymbolBuilder("String", SmithyGoDependency.SMITHY_PTR).build(),
-                        value.expectStringNode().getValue());
-            };
-            case BOOLEAN -> (GoWriter w) -> {
-                w.write("$T($L)",
-                        SymbolUtils.createValueSymbolBuilder("Bool", SmithyGoDependency.SMITHY_PTR).build(),
-                        value.expectBooleanNode().getValue());
-            };
+            case STRING -> goTemplate("$T($S)",
+                    SmithyGoDependency.SMITHY_PTR.func("String"), value.expectStringNode().getValue());
+            case BOOLEAN -> goTemplate("$T($L)",
+                    SmithyGoDependency.SMITHY_PTR.func("Bool"), value.expectBooleanNode().getValue());
+            // only array parameter type is STRING_ARRAY
+            case ARRAY -> writableStringSlice(value.expectArrayNode());
             default -> throw new CodegenException("Unhandled member type: " + value.getType());
         };
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/util/NodeUtil.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/util/NodeUtil.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.util;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.model.node.ArrayNode;
+
+public final class NodeUtil {
+    private NodeUtil() {}
+
+    public static GoWriter.Writable writableStringSlice(ArrayNode node) {
+        return goTemplate("[]string{$W}", GoWriter.ChainWritable.of(
+                node.getElements().stream()
+                        .map(it -> goTemplate("$S,", it.expectStringNode().getValue()))
+                        .toList()
+        ).compose(false));
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/util/ShapeUtil.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/util/ShapeUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.util;
+
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.CollectionShape;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.StringShape;
+
+public final class ShapeUtil {
+    public static final StringShape STRING_SHAPE = StringShape.builder()
+            .id("smithy.go.synthetic#String")
+            .build();
+
+    private ShapeUtil() {}
+
+    public static ListShape listOf(Shape member) {
+        return ListShape.builder()
+                .id("smithy.go.synthetic#" + member.getId().getName() + "List")
+                .member(member.getId())
+                .build();
+    }
+
+    public static Shape expectMember(Model model, Shape shape, String memberName) {
+        var optMember = shape.getMember(memberName);
+        if (optMember.isEmpty()) {
+            throw new CodegenException("expected member " + memberName + " in shape " + shape);
+        }
+
+        var member = optMember.get();
+        return model.expectShape(member.getTarget());
+    }
+
+    public static Shape expectMember(Model model, CollectionShape shape) {
+        return model.expectShape(shape.getMember().getTarget());
+    }
+}


### PR DESCRIPTION
* Add a `GoCodegenContext` field to `CodegenVisitor` and pass it down. This context object contains a handful of principal codegen resources which everything generally needs, and passing it simplifies a lot of constructor calls (observe the difference in `OperationGenerator`. This matches the new `DirectedCodegen` pattern.
* Adds a basic JMESpath expression generator. This is used for the new "operation context params" binding trait but lays the groundwork for getting rid of runtime jmespath in the future (#238).
* Add support for STRING_ARRAY type of endpoint parameter
* Add support for jmespath-based operation context params