### PR TITLE
Add serializers middleware logic for protocol generator awsjson10.

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
@@ -71,7 +71,7 @@ public class AwsJson10ProtocolGenerator implements ProtocolGenerator {
 
     @Override
     public void generateResponseDeserializers(GenerationContext context) {
-        GoWriter writer = context.getWriter().get();
+        var writer = context.getWriter().get();
         var model = context.getModel();
         var ops = model.getOperationShapes();
         for (var op : ops) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
@@ -17,23 +17,28 @@ package software.amazon.smithy.go.codegen.protocol.aws;
 
 import static software.amazon.smithy.go.codegen.ApplicationProtocol.createDefaultHttpApplicationProtocol;
 import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+import static software.amazon.smithy.go.codegen.serde.SerdeUtil.getShapesToSerde;
 
 import java.util.Map;
+import java.util.Set;
 import software.amazon.smithy.aws.traits.protocols.AwsJson1_0Trait;
 import software.amazon.smithy.go.codegen.ApplicationProtocol;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.SmithyGoDependency;
-//import software.amazon.smithy.go.codegen.SmithyGoTypes;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
+import software.amazon.smithy.go.codegen.server.protocol.JsonSerializerGenerator;
 import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
-//import software.amazon.smithy.model.shapes.StructureShape;
-//import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
+
+
+
 
 
 @SmithyInternalApi
 public class AwsJson10ProtocolGenerator implements ProtocolGenerator {
+
     @Override
     public ShapeId getProtocol() {
         return AwsJson1_0Trait.ID;
@@ -49,14 +54,22 @@ public class AwsJson10ProtocolGenerator implements ProtocolGenerator {
         var writer = context.getWriter().get();
         var model = context.getModel();
         var ops = model.getOperationShapes();
+        Set<Shape> shared = new java.util.HashSet<>(Set.of());
         for (var op : ops) {
-            requestSerializerCode(op, writer);
+            var middle = new SerializeMiddleware(this, context, op, writer);
+            writer.write(middle.generateOperationStubs());
+            writer.write("\n");
+            Set<Shape> shapes = getShapesToSerde(context.getModel(), context.getModel().expectShape(
+                    op.getInputShape()));
+            shared.addAll(shapes);
         }
+        var generator = new JsonSerializerGenerator(context.getModel(), context.getSymbolProvider());
+        writer.write(generator.generate(shared));
     }
 
     @Override
     public void generateResponseDeserializers(GenerationContext context) {
-        var writer = context.getWriter().get();
+        GoWriter writer = context.getWriter().get();
         var model = context.getModel();
         var ops = model.getOperationShapes();
         for (var op : ops) {
@@ -84,48 +97,6 @@ public class AwsJson10ProtocolGenerator implements ProtocolGenerator {
         // TODO
     }
 
-    private void requestSerializerCode(OperationShape op, GoWriter writer) {
-        var opName = "awsAwsjson10_serializeOp" + op.toShapeId().getName();;
-
-        /*Struct Definition*/
-        var struct = goTemplate("""
-                type $L struct{
-                }
-                """, opName
-        );
-        writer.write(struct);
-
-
-        /* ID Function */
-        var idFunction = goTemplate("""
-                func (op *$L) ID() string {
-                    return "OperationSerializer"
-                }
-                """, opName
-        );
-        writer.write(idFunction);
-
-        /* Handle Serialize Function */
-        var handleFunction = goTemplate(
-                    """
-                    func (op *$structName:L) HandleSerialize (ctx $context:T, in $input:T, next $handler:T) (
-                    out $output:T, metadata $metadata:T, err error) {
-                        return next.HandleSerialize(ctx, in)
-                    }
-                    """, Map.of(
-                            "context", SmithyGoDependency.CONTEXT.interfaceSymbol("Context"),
-                        "input", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeInput"),
-                        "handler", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeHandler"),
-                        "output", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeOutput"),
-                        "metadata", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("Metadata"),
-                        "structName", opName
-                ));
-        writer.write(handleFunction);
-
-        /* Operation End */
-        writer.write("\n");
-    }
-
     private void responseDeserializerCode(OperationShape op, GoWriter writer) {
         var opName = "awsAwsjson10_deserializeOp" + op.toShapeId().getName();
 
@@ -150,11 +121,11 @@ public class AwsJson10ProtocolGenerator implements ProtocolGenerator {
         //Handle Serialize Function
         var handleFunction = goTemplate(
                 """
-                func (op *$structName:L) HandleDeserialize (ctx $context:T, in $input:T, next $handler:T) (
-                out $output:T, metadata $metadata:T, err error) {
-                    return out, metadata, err
-                }
-                """, Map.of(
+                        func (op *$structName:L) HandleDeserialize (ctx $context:T, in $input:T, next $handler:T) (
+                        out $output:T, metadata $metadata:T, err error) {
+                            return out, metadata, err
+                        }
+                        """, Map.of(
                         "context", SmithyGoDependency.CONTEXT.interfaceSymbol("Context"),
                         "input", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("DeserializeInput"),
                         "handler", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("DeserializeHandler"),
@@ -167,3 +138,4 @@ public class AwsJson10ProtocolGenerator implements ProtocolGenerator {
         writer.write("\n");
     }
 }
+

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
@@ -19,6 +19,7 @@ import static software.amazon.smithy.go.codegen.ApplicationProtocol.createDefaul
 import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
 import static software.amazon.smithy.go.codegen.serde.SerdeUtil.getShapesToSerde;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import software.amazon.smithy.aws.traits.protocols.AwsJson1_0Trait;
@@ -58,7 +59,7 @@ public class AwsJson10ProtocolGenerator implements ProtocolGenerator {
     }
 
     public void generateSharedSerializers(GenerationContext context, GoWriter writer, Set<OperationShape> ops) {
-        Set<Shape> shared = new java.util.HashSet<>(Set.of());
+        Set<Shape> shared = new HashSet<>();
         for (var op : ops) {
             Set<Shape> shapes = getShapesToSerde(context.getModel(), context.getModel().expectShape(
                     op.getInputShape()));

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/SerializeMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/SerializeMiddleware.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.protocol.aws;
+
+import static software.amazon.smithy.go.codegen.GoStackStepMiddlewareGenerator.createSerializeStepMiddleware;
+import static software.amazon.smithy.go.codegen.GoWriter.emptyGoTemplate;
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+import static software.amazon.smithy.go.codegen.server.protocol.JsonSerializerGenerator.getSerializerName;
+
+import java.util.Map;
+import software.amazon.smithy.go.codegen.EventStreamGenerator;
+import software.amazon.smithy.go.codegen.GoStdlibTypes;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.SmithyGoTypes;
+import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
+import software.amazon.smithy.go.codegen.integration.ProtocolUtils;
+import software.amazon.smithy.go.codegen.trait.BackfilledInputOutputTrait;
+import software.amazon.smithy.model.knowledge.EventStreamIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.utils.MapUtils;
+
+
+
+
+
+@SuppressWarnings("checkstyle:RegexpSingleline")
+public class SerializeMiddleware implements GoWriter.Writable {
+    protected final ProtocolGenerator generator;
+    protected final ProtocolGenerator.GenerationContext ctx;
+    protected final OperationShape operation;
+    protected final GoWriter writer;
+
+    protected final StructureShape input;
+    protected final StructureShape output;
+    private final EventStreamIndex eventStreamIndex;
+
+//    private final String SMITHY_PROTOCOL_NAME = "awsjson10";
+    private final String contentType = "application/awsjson10";
+    private String serialName;
+
+    public SerializeMiddleware(
+            ProtocolGenerator generator, ProtocolGenerator.GenerationContext ctx, OperationShape operation,
+            GoWriter writer
+    ) {
+        this.generator = generator;
+        this.ctx = ctx;
+        this.operation = operation;
+        this.writer = writer;
+
+        this.input = ctx.getModel().expectShape(operation.getInputShape(), StructureShape.class);
+        this.output = ctx.getModel().expectShape(operation.getOutputShape(), StructureShape.class);
+        this.eventStreamIndex = EventStreamIndex.of(ctx.getModel());
+    }
+
+    @Override
+    public void accept(GoWriter writer) {
+        var name = ProtocolGenerator.getSerializeMiddlewareName(operation.getId(), ctx.getService(),
+                generator.getProtocolName());
+        var middleware = createSerializeStepMiddleware(name, ProtocolUtils.OPERATION_SERIALIZER_MIDDLEWARE_ID);
+//        writer.write(middleware.asWritable(generateOperationStubs(), emptyGoTemplate()));
+    }
+
+    public GoWriter.Writable generateOperationStubs() {
+        this.serialName = "awsAwsjson10_serializeOp" + this.operation.toShapeId().getName();
+
+        return goTemplate("""
+                
+                type $opName:L struct{
+                }
+                
+                func (op *$opName:L) ID() string {
+                    return "OperationSerializer"
+                }
+                
+                $handleSerialize:W
+                
+                """, Map.of(
+                    "opName", this.serialName,
+                    "handleSerialize", generateHandleSerialize()
+        ));
+    }
+
+    private GoWriter.Writable generateHandleSerialize() {
+        return goTemplate(
+                """
+                        
+                        func (op *$opName:L) HandleSerialize (ctx $context:T, in $input:T, next $handler:T) (
+                        out $output:T, metadata $metadata:T, err error) {
+                        
+                            $body:W
+                        
+                            return next.HandleSerialize(ctx, in)
+                        }
+                        
+                        """, Map.of(
+                        "context", SmithyGoDependency.CONTEXT.interfaceSymbol("Context"),
+                        "input", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeInput"),
+                        "handler", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeHandler"),
+                        "output", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeOutput"),
+                        "metadata", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("Metadata"),
+                        "opName", this.serialName,
+                        "body", generateHandleSerializeBody())
+        );
+    }
+
+    private GoWriter.Writable generateHandleSerializeBody() {
+        return goTemplate("""
+                    $route:W
+    
+                    $serialize:W
+    
+                """,
+                MapUtils.of(
+                        "input", ctx.getSymbolProvider().toSymbol(input),
+                        "request", generator.getApplicationProtocol().getRequestType(),
+                        "route", handleHttp(),
+                        "serialize", handlePayload(),
+                        "errorf", GoStdlibTypes.Fmt.Errorf
+                ));
+    }
+
+    private GoWriter.Writable handleHttp() {
+        return goTemplate("""
+                    input, ok := in.Parameters.($input:P)
+                    if !ok {
+                        return out, metadata, $errorf:T("unexpected input type %T", in.Parameters)
+                    }
+                    _ = input
+                
+                    req, ok := in.Request.($request:P)
+                    if !ok {
+                        return out, metadata, $errorf:T("unexpected transport type %T", in.Request)
+                    }
+                
+                    req.Method = $methodPost:T
+                    req.URL.Path = "/service/$service:L/operation/$operation:L"
+                    req.Header.Set("smithy-protocol", $protocol:S)
+                
+                    $contentTypeHeader:W
+                    $acceptHeader:W
+                
+                """,
+        MapUtils.of(
+                "input", ctx.getSymbolProvider().toSymbol(input),
+                "request", generator.getApplicationProtocol().getRequestType(),
+                "methodPost", GoStdlibTypes.Net.Http.MethodPost,
+                "service", ctx.getService().getId().getName(),
+                "operation", operation.getId().getName(),
+                "protocol", generator.getProtocol(),
+                "contentTypeHeader", setContentTypeHeader(),
+                "acceptHeader", acceptHeader(),
+                "serialize", handlePayload(),
+                "errorf", GoStdlibTypes.Fmt.Errorf
+                ));
+    }
+
+    private GoWriter.Writable handlePayload() {
+        return goTemplate("""
+            
+                jsonEncoder := $encoder:T()
+            
+                err = $serialize:L(input, jsonEncoder.Value)
+                if err != nil {
+                    return out, metadata, &$error:T{Err: err}
+                }
+
+            
+                payload := $reader:T(jsonEncoder.Bytes())
+                if req, err = req.SetStream(payload); err != nil {
+                    return out, metadata, &$error:T{Err: err}
+                }
+
+
+
+                in.Request = req
+            """,
+    MapUtils.of(
+            "serialize", getSerializerName(input),
+            "encoder", SmithyGoTypes.Encoding.Json.NewEncoder,
+            "reader", GoStdlibTypes.Bytes.NewReader,
+            "error", SmithyGoTypes.Smithy.SerializationError
+    ));
+    }
+
+    private GoWriter.Writable setContentTypeHeader() {
+        if (input.hasTrait(BackfilledInputOutputTrait.class)) {
+            return emptyGoTemplate();
+        }
+
+        return goTemplate("""
+                req.Header.Set("Content-Type", $S)
+                """, isInputEventStream() ? EventStreamGenerator.AMZ_CONTENT_TYPE : contentType);
+    }
+
+    private GoWriter.Writable acceptHeader() {
+        return goTemplate("""
+                req.Header.Set("Accept", $S)
+                """, isOutputEventStream() ? EventStreamGenerator.AMZ_CONTENT_TYPE : contentType);
+    }
+
+    private boolean isInputEventStream() {
+        return eventStreamIndex.getInputInfo(operation).isPresent();
+    }
+
+    private boolean isOutputEventStream() {
+        return eventStreamIndex.getOutputInfo(operation).isPresent();
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/SerializeMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/SerializeMiddleware.java
@@ -132,7 +132,7 @@ public class SerializeMiddleware {
                 "request", SMITHY_HTTP_TRANSPORT.pointableSymbol("Request"),
                 "methodPost", GoStdlibTypes.Net.Http.MethodPost,
                 "contentType", contentType,
-                "target", ctx.getService().getId().getName() + operation.getId().getName(),
+                "target", ctx.getService().getId().getName() + '.' + operation.getId().getName(),
                 "errorf", GoStdlibTypes.Fmt.Errorf
                 ));
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/SerializeMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/SerializeMiddleware.java
@@ -29,6 +29,8 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.utils.MapUtils;
 
 public class SerializeMiddleware {
+    public static final String CONTENT_TYPE = "application/x-amz-json-1.0";
+
     protected final ProtocolGenerator.GenerationContext ctx;
     protected final OperationShape operation;
     protected final GoWriter writer;
@@ -37,7 +39,6 @@ public class SerializeMiddleware {
     protected final StructureShape output;
 
     private String serialName;
-    public static final String CONTENT_TYPE = "application/x-amz-json-1.0";
 
     public SerializeMiddleware(
             ProtocolGenerator.GenerationContext ctx, OperationShape operation, GoWriter writer
@@ -50,12 +51,12 @@ public class SerializeMiddleware {
         this.output = ctx.getModel().expectShape(operation.getOutputShape(), StructureShape.class);
     }
 
-    public static String getSerializerName(OperationShape operation) {
+    public static String getMiddlewareName(OperationShape operation) {
         return "awsAwsjson10_serializeOp" + operation.toShapeId().getName();
     }
 
     public GoWriter.Writable generate() {
-        serialName = getSerializerName(operation);
+        serialName = getMiddlewareName(operation);
 
         return goTemplate("""
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/SerializeMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/SerializeMiddleware.java
@@ -15,82 +15,57 @@
 
 package software.amazon.smithy.go.codegen.protocol.aws;
 
-import static software.amazon.smithy.go.codegen.GoStackStepMiddlewareGenerator.createSerializeStepMiddleware;
-import static software.amazon.smithy.go.codegen.GoWriter.emptyGoTemplate;
 import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+import static software.amazon.smithy.go.codegen.SmithyGoDependency.SMITHY_HTTP_TRANSPORT;
 import static software.amazon.smithy.go.codegen.server.protocol.JsonSerializerGenerator.getSerializerName;
 
-import java.util.Map;
-import software.amazon.smithy.go.codegen.EventStreamGenerator;
 import software.amazon.smithy.go.codegen.GoStdlibTypes;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.go.codegen.SmithyGoTypes;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
-import software.amazon.smithy.go.codegen.integration.ProtocolUtils;
-import software.amazon.smithy.go.codegen.trait.BackfilledInputOutputTrait;
-import software.amazon.smithy.model.knowledge.EventStreamIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.utils.MapUtils;
 
-
-
-
-
-@SuppressWarnings("checkstyle:RegexpSingleline")
-public class SerializeMiddleware implements GoWriter.Writable {
-    protected final ProtocolGenerator generator;
+public class SerializeMiddleware {
     protected final ProtocolGenerator.GenerationContext ctx;
     protected final OperationShape operation;
     protected final GoWriter writer;
 
     protected final StructureShape input;
     protected final StructureShape output;
-    private final EventStreamIndex eventStreamIndex;
 
-//    private final String SMITHY_PROTOCOL_NAME = "awsjson10";
-    private final String contentType = "application/awsjson10";
     private String serialName;
 
     public SerializeMiddleware(
-            ProtocolGenerator generator, ProtocolGenerator.GenerationContext ctx, OperationShape operation,
-            GoWriter writer
+            ProtocolGenerator.GenerationContext ctx, OperationShape operation, GoWriter writer
     ) {
-        this.generator = generator;
         this.ctx = ctx;
         this.operation = operation;
         this.writer = writer;
 
         this.input = ctx.getModel().expectShape(operation.getInputShape(), StructureShape.class);
         this.output = ctx.getModel().expectShape(operation.getOutputShape(), StructureShape.class);
-        this.eventStreamIndex = EventStreamIndex.of(ctx.getModel());
     }
 
-    @Override
-    public void accept(GoWriter writer) {
-        var name = ProtocolGenerator.getSerializeMiddlewareName(operation.getId(), ctx.getService(),
-                generator.getProtocolName());
-        var middleware = createSerializeStepMiddleware(name, ProtocolUtils.OPERATION_SERIALIZER_MIDDLEWARE_ID);
-//        writer.write(middleware.asWritable(generateOperationStubs(), emptyGoTemplate()));
-    }
-
-    public GoWriter.Writable generateOperationStubs() {
-        this.serialName = "awsAwsjson10_serializeOp" + this.operation.toShapeId().getName();
+    public GoWriter.Writable generate() {
+        serialName = "awsAwsjson10_serializeOp" + operation.toShapeId().getName();
 
         return goTemplate("""
-                
+
                 type $opName:L struct{
                 }
-                
+
                 func (op *$opName:L) ID() string {
                     return "OperationSerializer"
                 }
-                
+
                 $handleSerialize:W
-                
-                """, Map.of(
-                    "opName", this.serialName,
+
+                """,
+                MapUtils.of(
+                    "opName", serialName,
                     "handleSerialize", generateHandleSerialize()
         ));
     }
@@ -98,22 +73,22 @@ public class SerializeMiddleware implements GoWriter.Writable {
     private GoWriter.Writable generateHandleSerialize() {
         return goTemplate(
                 """
-                        
+
                         func (op *$opName:L) HandleSerialize (ctx $context:T, in $input:T, next $handler:T) (
                         out $output:T, metadata $metadata:T, err error) {
-                        
+
                             $body:W
-                        
+
                             return next.HandleSerialize(ctx, in)
                         }
-                        
-                        """, Map.of(
+
+                        """, MapUtils.of(
                         "context", SmithyGoDependency.CONTEXT.interfaceSymbol("Context"),
                         "input", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeInput"),
                         "handler", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeHandler"),
                         "output", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeOutput"),
                         "metadata", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("Metadata"),
-                        "opName", this.serialName,
+                        "opName", serialName,
                         "body", generateHandleSerializeBody())
         );
     }
@@ -121,71 +96,62 @@ public class SerializeMiddleware implements GoWriter.Writable {
     private GoWriter.Writable generateHandleSerializeBody() {
         return goTemplate("""
                     $route:W
-    
+
                     $serialize:W
-    
+
                 """,
                 MapUtils.of(
-                        "input", ctx.getSymbolProvider().toSymbol(input),
-                        "request", generator.getApplicationProtocol().getRequestType(),
                         "route", handleHttp(),
-                        "serialize", handlePayload(),
-                        "errorf", GoStdlibTypes.Fmt.Errorf
+                        "serialize", handlePayload()
                 ));
     }
 
     private GoWriter.Writable handleHttp() {
+        String contentType = "application/x-amz-json-1.0";
+
         return goTemplate("""
                     input, ok := in.Parameters.($input:P)
                     if !ok {
                         return out, metadata, $errorf:T("unexpected input type %T", in.Parameters)
                     }
                     _ = input
-                
+
                     req, ok := in.Request.($request:P)
                     if !ok {
                         return out, metadata, $errorf:T("unexpected transport type %T", in.Request)
                     }
-                
+
                     req.Method = $methodPost:T
-                    req.URL.Path = "/service/$service:L/operation/$operation:L"
-                    req.Header.Set("smithy-protocol", $protocol:S)
-                
-                    $contentTypeHeader:W
-                    $acceptHeader:W
-                
+                    req.URL.Path = "/"
+                    req.Header.Set("Content-Type", $contentType:S)
+                    req.Header.Set("X-Amz-Target", $target:S)
+
                 """,
         MapUtils.of(
                 "input", ctx.getSymbolProvider().toSymbol(input),
-                "request", generator.getApplicationProtocol().getRequestType(),
+                "request", SMITHY_HTTP_TRANSPORT.pointableSymbol("Request"),
                 "methodPost", GoStdlibTypes.Net.Http.MethodPost,
-                "service", ctx.getService().getId().getName(),
-                "operation", operation.getId().getName(),
-                "protocol", generator.getProtocol(),
-                "contentTypeHeader", setContentTypeHeader(),
-                "acceptHeader", acceptHeader(),
-                "serialize", handlePayload(),
+                "contentType", contentType,
+                "target", ctx.getService().getId().getName() + operation.getId().getName(),
                 "errorf", GoStdlibTypes.Fmt.Errorf
                 ));
     }
 
     private GoWriter.Writable handlePayload() {
         return goTemplate("""
-            
+
                 jsonEncoder := $encoder:T()
-            
+
                 err = $serialize:L(input, jsonEncoder.Value)
                 if err != nil {
                     return out, metadata, &$error:T{Err: err}
                 }
 
-            
                 payload := $reader:T(jsonEncoder.Bytes())
-                if req, err = req.SetStream(payload); err != nil {
+                req, err = req.SetStream(payload)
+                if err != nil {
                     return out, metadata, &$error:T{Err: err}
                 }
-
-
 
                 in.Request = req
             """,
@@ -195,29 +161,5 @@ public class SerializeMiddleware implements GoWriter.Writable {
             "reader", GoStdlibTypes.Bytes.NewReader,
             "error", SmithyGoTypes.Smithy.SerializationError
     ));
-    }
-
-    private GoWriter.Writable setContentTypeHeader() {
-        if (input.hasTrait(BackfilledInputOutputTrait.class)) {
-            return emptyGoTemplate();
-        }
-
-        return goTemplate("""
-                req.Header.Set("Content-Type", $S)
-                """, isInputEventStream() ? EventStreamGenerator.AMZ_CONTENT_TYPE : contentType);
-    }
-
-    private GoWriter.Writable acceptHeader() {
-        return goTemplate("""
-                req.Header.Set("Accept", $S)
-                """, isOutputEventStream() ? EventStreamGenerator.AMZ_CONTENT_TYPE : contentType);
-    }
-
-    private boolean isInputEventStream() {
-        return eventStreamIndex.getInputInfo(operation).isPresent();
-    }
-
-    private boolean isOutputEventStream() {
-        return eventStreamIndex.getOutputInfo(operation).isPresent();
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Update Protocol Generator request serializer generation to a cleaner and complete build.
* Add a new class SerializeMiddleware that handles all generation for request serializers.
* Add support for shared serializers to handle complex input shapes, nested within serializer request generaiton.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
