### PR TITLE
Awsjson10 Deserializer Implementation w/o Errors

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -240,5 +240,21 @@ subprojects {
             }
         }
 
+        /*
+         * Spotbugs
+         * ====================================================
+         */
+        apply(plugin = "com.github.spotbugs")
+
+        // We don't need to lint tests.
+        tasks["spotbugsTest"].enabled = false
+
+        // Configure the bug filter for spotbugs.
+        tasks.withType<com.github.spotbugs.snom.SpotBugsTask>().configureEach {
+            effort.set(com.github.spotbugs.snom.Effort.MAX)
+            excludeFilter.set(file("${project.rootDir}/config/spotbugs/filter.xml"))
+            reports.maybeCreate("xml").isEnabled = false
+            reports.maybeCreate("html").isEnabled = true
+        }
     }
 }

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -240,21 +240,5 @@ subprojects {
             }
         }
 
-        /*
-         * Spotbugs
-         * ====================================================
-         */
-        apply(plugin = "com.github.spotbugs")
-
-        // We don't need to lint tests.
-        tasks["spotbugsTest"].enabled = false
-
-        // Configure the bug filter for spotbugs.
-        tasks.withType<com.github.spotbugs.snom.SpotBugsTask>().configureEach {
-            effort.set(com.github.spotbugs.snom.Effort.MAX)
-            excludeFilter.set(file("${project.rootDir}/config/spotbugs/filter.xml"))
-            reports.maybeCreate("xml").isEnabled = false
-            reports.maybeCreate("html").isEnabled = true
-        }
     }
 }

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -236,21 +236,5 @@ subprojects {
             }
         }
 
-        /*
-         * Spotbugs
-         * ====================================================
-         */
-        apply(plugin = "com.github.spotbugs")
-
-        // We don't need to lint tests.
-        tasks["spotbugsTest"].enabled = false
-
-        // Configure the bug filter for spotbugs.
-        tasks.withType<com.github.spotbugs.snom.SpotBugsTask>().configureEach {
-            effort.set(com.github.spotbugs.snom.Effort.MAX)
-            excludeFilter.set(file("${project.rootDir}/config/spotbugs/filter.xml"))
-            reports.maybeCreate("xml").isEnabled = false
-            reports.maybeCreate("html").isEnabled = true
-        }
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/DefaultProtocols.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/DefaultProtocols.java
@@ -16,7 +16,6 @@
 package software.amazon.smithy.go.codegen.integration;
 
 import java.util.List;
-
 import software.amazon.smithy.go.codegen.protocol.aws.AwsJson10ProtocolGenerator;
 import software.amazon.smithy.go.codegen.protocol.rpc2.cbor.Rpc2CborProtocolGenerator;
 import software.amazon.smithy.utils.ListUtils;

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/DefaultProtocols.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/DefaultProtocols.java
@@ -16,12 +16,17 @@
 package software.amazon.smithy.go.codegen.integration;
 
 import java.util.List;
+
+import software.amazon.smithy.go.codegen.protocol.aws.AwsJson10ProtocolGenerator;
 import software.amazon.smithy.go.codegen.protocol.rpc2.cbor.Rpc2CborProtocolGenerator;
 import software.amazon.smithy.utils.ListUtils;
 
 public class DefaultProtocols implements GoIntegration {
     @Override
     public List<ProtocolGenerator> getProtocolGenerators() {
-        return ListUtils.of(new Rpc2CborProtocolGenerator());
+        return ListUtils.of(
+                new Rpc2CborProtocolGenerator(),
+                new AwsJson10ProtocolGenerator()
+        );
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/DefaultProtocols.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/DefaultProtocols.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.go.codegen.integration;
 
 import java.util.List;
+
 import software.amazon.smithy.go.codegen.protocol.aws.AwsJson10ProtocolGenerator;
 import software.amazon.smithy.go.codegen.protocol.rpc2.cbor.Rpc2CborProtocolGenerator;
 import software.amazon.smithy.utils.ListUtils;

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.smithy.go.codegen.protocol.aws;
+
+import static software.amazon.smithy.go.codegen.ApplicationProtocol.createDefaultHttpApplicationProtocol;
+
+import software.amazon.smithy.aws.traits.protocols.AwsJson1_0Trait;
+import software.amazon.smithy.go.codegen.ApplicationProtocol;
+import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public class AwsJson10ProtocolGenerator implements ProtocolGenerator {
+    @Override
+    public ShapeId getProtocol() {
+        return AwsJson1_0Trait.ID;
+    }
+
+    @Override
+    public ApplicationProtocol getApplicationProtocol() {
+        return createDefaultHttpApplicationProtocol();
+    }
+
+    @Override
+    public void generateRequestSerializers(GenerationContext context) {
+        context.getWriter().get().write("// TODO");
+    }
+
+    @Override
+    public void generateResponseDeserializers(GenerationContext context) {
+        context.getWriter().get().write("// TODO");
+    }
+
+    @Override
+    public void generateProtocolDocumentMarshalerMarshalDocument(GenerationContext context) {
+        // TODO
+    }
+
+    @Override
+    public void generateProtocolDocumentMarshalerUnmarshalDocument(GenerationContext context) {
+        // TODO
+    }
+
+    @Override
+    public void generateProtocolDocumentUnmarshalerMarshalDocument(GenerationContext context) {
+        // TODO
+    }
+
+    @Override
+    public void generateProtocolDocumentUnmarshalerUnmarshalDocument(GenerationContext context) {
+        // TODO
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
@@ -19,9 +19,11 @@ import static software.amazon.smithy.go.codegen.ApplicationProtocol.createDefaul
 
 import software.amazon.smithy.aws.traits.protocols.AwsJson1_0Trait;
 import software.amazon.smithy.go.codegen.ApplicationProtocol;
+import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.SmithyGoDependency;
 //import software.amazon.smithy.go.codegen.SmithyGoTypes;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
+import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 //import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -44,39 +46,7 @@ public class AwsJson10ProtocolGenerator implements ProtocolGenerator {
         var model = context.getModel();
         var ops = model.getOperationShapes();
         for (var op : ops) {
-            var opName = op.toShapeId().getName();
-
-            //Struct Definition
-            var structName = "awsAwsjson10_serializeOp" + opName;
-            writer.write("type " + structName + " struct{\n}\n");
-
-            //ID Function
-//            var opID = opName + "Serializer";
-// an id for the operation's serializer, that includes the specific op name
-            var opID = "OperationSerializer";
-            var idFunction = "func (op *$L) ID() string {\n return \"$L\" \n}\n";
-            writer.write(idFunction, structName, opID);
-
-            //Handle Serialize Function
-            var handleFunction = """
-                    func (op *$L) HandleSerialize (
-                    ctx $T, in $T, next $T,
-                    )(out $T, metadata $T, err error) {
-                        return next.HandleSerialize(ctx, in)
-                    }
-                    \n""";
-            writer.write(handleFunction, structName, SmithyGoDependency.CONTEXT.interfaceSymbol("Context"),
-                    SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeInput"),
-                    SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeHandler"),
-                    SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeOutput"),
-                    SmithyGoDependency.SMITHY_MIDDLEWARE.struct("Metadata"));
-
-            //Code for if ID were to be contained in
-//            writer.write("\"ID\": $L", opID); //body of struct
-//            writer.write("}"); //close body of struct
-
-            //Ending Operation
-            writer.write("\n");
+            requestSerializerCode(op, writer);
         }
     }
 
@@ -103,5 +73,41 @@ public class AwsJson10ProtocolGenerator implements ProtocolGenerator {
     @Override
     public void generateProtocolDocumentUnmarshalerUnmarshalDocument(GenerationContext context) {
         // TODO
+    }
+
+    private void requestSerializerCode(OperationShape op, GoWriter writer) {
+        var opName = op.toShapeId().getName();
+
+        //Struct Definition
+        var structName = "awsAwsjson10_serializeOp" + opName;
+        writer.write("type " + structName + " struct{\n}\n");
+
+        //ID Function
+//            var opID = opName + "Serializer";
+// an id for the operation's serializer, that includes the specific op name
+        var opID = "OperationSerializer";
+        var idFunction = "func (op *$L) ID() string {\n return \"$L\" \n}\n";
+        writer.write(idFunction, structName, opID);
+
+        //Handle Serialize Function
+        var handleFunction = """
+                    func (op *$L) HandleSerialize (
+                    ctx $T, in $T, next $T,
+                    )(out $T, metadata $T, err error) {
+                        return next.HandleSerialize(ctx, in)
+                    }
+                    \n""";
+        writer.write(handleFunction, structName, SmithyGoDependency.CONTEXT.interfaceSymbol("Context"),
+                SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeInput"),
+                SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeHandler"),
+                SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeOutput"),
+                SmithyGoDependency.SMITHY_MIDDLEWARE.struct("Metadata"));
+
+        //Code for if ID were to be contained in
+//            writer.write("\"ID\": $L", opID); //body of struct
+//            writer.write("}"); //close body of struct
+
+        //Ending Operation
+        writer.write("\n");
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
@@ -12,6 +12,7 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
 package software.amazon.smithy.go.codegen.protocol.aws;
 
 import static software.amazon.smithy.go.codegen.ApplicationProtocol.createDefaultHttpApplicationProtocol;
@@ -20,6 +21,7 @@ import software.amazon.smithy.aws.traits.protocols.AwsJson1_0Trait;
 import software.amazon.smithy.go.codegen.ApplicationProtocol;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.model.shapes.ShapeId;
+//import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
@@ -36,7 +38,39 @@ public class AwsJson10ProtocolGenerator implements ProtocolGenerator {
 
     @Override
     public void generateRequestSerializers(GenerationContext context) {
-        context.getWriter().get().write("// TODO");
+        var writer = context.getWriter().get();
+        var model = context.getModel();
+        var ops = model.getOperationShapes();
+        for (var op : ops) {
+            var opName = op.toShapeId().getName();
+
+            //Struct Definition
+            var structName = "type " + "awsAwsjson10_serializeOp" + opName + " struct {\n}\n";
+            writer.write(structName);
+
+            //ID Function
+//            var opID = opName + "Serializer"; //an id for the operation's serializer, that includes the specific op name
+            var opID = "OperationSerializer";
+            var idFunction = "func (op *$L) ID() string {\n return \"$L\" \n}\n";
+            writer.write(idFunction, opName, opID);
+
+            //Handle Serialize Function
+            var handleFunction = """
+                    func (op *$L) HandleSerialize
+                    (ctx context.Context, in middleware.SerializeInput, next middleware.SerializeHandler)
+                     (out middleware.SerializeOutput, metadata middleware.Metadata, err error) {
+                        return next.HandleSerialize(ctx, in)
+                    }
+                    \n""";
+            writer.write(handleFunction, opName);
+
+            //Code for if ID were to be contained in
+//            writer.write("\"ID\": $L", opID); //body of struct
+//            writer.write("}"); //close body of struct
+
+            //Ending Operation
+            writer.write("\n");
+        }
     }
 
     @Override

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
@@ -12,7 +12,6 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-
 package software.amazon.smithy.go.codegen.protocol.aws;
 
 import static software.amazon.smithy.go.codegen.ApplicationProtocol.createDefaultHttpApplicationProtocol;
@@ -21,7 +20,6 @@ import software.amazon.smithy.aws.traits.protocols.AwsJson1_0Trait;
 import software.amazon.smithy.go.codegen.ApplicationProtocol;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.model.shapes.ShapeId;
-//import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
@@ -38,39 +36,7 @@ public class AwsJson10ProtocolGenerator implements ProtocolGenerator {
 
     @Override
     public void generateRequestSerializers(GenerationContext context) {
-        var writer = context.getWriter().get();
-        var model = context.getModel();
-        var ops = model.getOperationShapes();
-        for (var op : ops) {
-            var opName = op.toShapeId().getName();
-
-            //Struct Definition
-            var structName = "type " + "awsAwsjson10_serializeOp" + opName + " struct {\n}\n";
-            writer.write(structName);
-
-            //ID Function
-//            var opID = opName + "Serializer"; //an id for the operation's serializer, that includes the specific op name
-            var opID = "OperationSerializer";
-            var idFunction = "func (op *$L) ID() string {\n return \"$L\" \n}\n";
-            writer.write(idFunction, opName, opID);
-
-            //Handle Serialize Function
-            var handleFunction = """
-                    func (op *$L) HandleSerialize
-                    (ctx context.Context, in middleware.SerializeInput, next middleware.SerializeHandler)
-                     (out middleware.SerializeOutput, metadata middleware.Metadata, err error) {
-                        return next.HandleSerialize(ctx, in)
-                    }
-                    \n""";
-            writer.write(handleFunction, opName);
-
-            //Code for if ID were to be contained in
-//            writer.write("\"ID\": $L", opID); //body of struct
-//            writer.write("}"); //close body of struct
-
-            //Ending Operation
-            writer.write("\n");
-        }
+        context.getWriter().get().write("// TODO");
     }
 
     @Override

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
@@ -21,7 +21,7 @@ import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
 import java.util.Map;
 import software.amazon.smithy.aws.traits.protocols.AwsJson1_0Trait;
 import software.amazon.smithy.go.codegen.ApplicationProtocol;
-import software.amazon.smithy.go.cogitdegen.GoWriter;
+import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.SmithyGoDependency;
 //import software.amazon.smithy.go.codegen.SmithyGoTypes;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/DeserializeMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/DeserializeMiddleware.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.protocol.aws;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+import static software.amazon.smithy.go.codegen.SmithyGoDependency.SMITHY_HTTP_TRANSPORT;
+import static software.amazon.smithy.go.codegen.protocol.ProtocolUtil.hasEventStream;
+import static software.amazon.smithy.go.codegen.server.protocol.JsonDeserializerGenerator.getDeserializerName;
+
+import software.amazon.smithy.go.codegen.GoStdlibTypes;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.utils.MapUtils;
+
+public class DeserializeMiddleware {
+
+    public static final String SMITHY_PROTOCOL_NAME = "awsJson10";
+    protected final ProtocolGenerator.GenerationContext ctx;
+    protected final OperationShape operation;
+    protected final GoWriter writer;
+
+    protected final StructureShape input;
+    protected final StructureShape output;
+
+    private String deserialName;
+
+    public DeserializeMiddleware(
+            ProtocolGenerator.GenerationContext ctx, OperationShape operation, GoWriter writer
+    ) {
+        this.ctx = ctx;
+        this.operation = operation;
+        this.writer = writer;
+
+        this.input = ctx.getModel().expectShape(operation.getInputShape(), StructureShape.class);
+        this.output = ctx.getModel().expectShape(operation.getOutputShape(), StructureShape.class);
+    }
+
+    public static String getMiddlewareName(OperationShape operation) {
+        return "awsAwsjson10_deserializeOp" + operation.toShapeId().getName();
+    }
+
+    public GoWriter.Writable generate() {
+        deserialName = getMiddlewareName(operation);
+
+        return goTemplate("""
+
+            type $opName:L struct{
+            }
+
+            func (op *$opName:L) ID() string {
+                return "OperationDeserializer"
+            }
+
+            $handleSerialize:W
+
+            """,
+                MapUtils.of(
+                        "opName", deserialName,
+                        "handleSerialize", generateHandleDeserialize()
+                ));
+    }
+
+    private GoWriter.Writable generateHandleDeserialize() {
+        return goTemplate(
+                """
+
+                        func (op *$opName:L) HandleDeserialize (ctx $context:T, in $input:T, next $handler:T) (
+                        out $output:T, metadata $metadata:T, err error) {
+
+                            $body:W
+
+                            return out, metadata, nil
+                        }
+
+                        """, MapUtils.of(
+                        "context", SmithyGoDependency.CONTEXT.interfaceSymbol("Context"),
+                        "input", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("DeserializeInput"),
+                        "handler", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("DeserializeHandler"),
+                        "output", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("DeserializeOutput"),
+                        "metadata", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("Metadata"),
+                        "opName", deserialName,
+                        "body", generateHandleDeserializeBody())
+        );
+    }
+
+    private GoWriter.Writable generateHandleDeserializeBody() {
+        return goTemplate("""
+                $errors:W
+
+                $response:W
+            """,
+                MapUtils.of(
+                        "errors", handleResponseChecks(),
+                        "response", handleResponse()
+                ));
+    }
+
+
+    private GoWriter.Writable handleResponseChecks() {
+        return goTemplate("""
+
+                out, metadata, err = next.HandleDeserialize(ctx, in)
+                if err != nil {
+                    return out, metadata, err
+                }
+
+                resp, ok := out.RawResponse.($response:P)
+                if !ok {
+                    return out, metadata, $errorf:T("unexpected transport type %T", out.RawResponse)
+                }
+
+                if resp.Header.Get("smithy-protocol") != $protocol:S {
+                    return out, metadata, &$deserError:T{
+                        Err: $errorf:T(
+                            "unexpected smithy-protocol response header '%s' (HTTP status: %s)",
+                            resp.Header.Get("smithy-protocol"),
+                            resp.Status,
+                        ),
+                    }
+                }
+
+                if resp.StatusCode != 200 {
+                    return out, metadata, &$deserError:T{}
+                }
+
+            """,
+                MapUtils.of(
+                        "response", SMITHY_HTTP_TRANSPORT.pointableSymbol("Response"),
+                        "errorf", GoStdlibTypes.Fmt.Errorf,
+                        "deserError", SmithyGoDependency.SMITHY.struct("DeserializationError"),
+                        "protocol", SMITHY_PROTOCOL_NAME
+                ));
+    }
+
+    private GoWriter.Writable handleResponse() {
+        if (output.members().isEmpty()) {
+            return discardDeserialize();
+        } else if (hasEventStream(ctx.getModel(), output)) {
+            return deserializeEventStream();
+        }
+        return handlePayload();
+    }
+
+    private GoWriter.Writable handlePayload() {
+        return goTemplate("""
+                payload, err := $readAll:T(resp.Body)
+                if err != nil {
+                    return out, metadata, err
+                }
+
+                if len(payload) == 0 {
+                    out.Result = &$output:T{}
+                    return out, metadata, nil
+                }
+
+                decoder := $decoder:T(resp.Body)
+                var cv map[string]interface{}
+                err = decoder.Decode(&cv)
+                if err!= nil {
+                    return out, metadata, err
+                }
+
+                output, err := $deserialize:L(cv)
+                    if err != nil {
+                        return out, metadata, err
+                    }
+
+                    out.Result = output
+                """,
+                MapUtils.of(
+                        "readAll", GoStdlibTypes.Io.ReadAll,
+                        "output", ctx.getSymbolProvider()
+                                .toSymbol(ctx.getModel().expectShape(operation.getOutputShape())),
+                        "decoder", GoStdlibTypes.Encoding.Json.NewDecoder,
+                        "deserialize", getDeserializerName(output)
+                ));
+    }
+
+    private GoWriter.Writable discardDeserialize() {
+        return goTemplate("""
+                if _, err = $copy:T($discard:T, resp.Body); err != nil {
+                    return out, metadata, $errorf:T("discard response body: %w", err)
+                }
+
+                out.Result = &$result:T{}
+                """,
+                MapUtils.of(
+                        "copy", GoStdlibTypes.Io.Copy,
+                        "discard", GoStdlibTypes.Io.IoUtil.Discard,
+                        "errorf", GoStdlibTypes.Fmt.Errorf,
+                        "result", ctx.getSymbolProvider().toSymbol(output)
+                ));
+    }
+
+    // Basically a no-op. Event stream deserializer middleware, implemented elsewhere, will handle the wire-up here,
+    // including handling the initial-response message to deserialize any non-stream members to output.
+    // Taken straight from CBOR implementation
+    private GoWriter.Writable deserializeEventStream() {
+        return goTemplate("out.Result = &$T{}", ctx.getSymbolProvider().toSymbol(output));
+    }
+}
+
+

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/SerializeMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/SerializeMiddleware.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.protocol.aws;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+import static software.amazon.smithy.go.codegen.SmithyGoDependency.SMITHY_HTTP_TRANSPORT;
+import static software.amazon.smithy.go.codegen.server.protocol.JsonSerializerGenerator.getSerializerName;
+
+import software.amazon.smithy.go.codegen.GoStdlibTypes;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.SmithyGoTypes;
+import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.utils.MapUtils;
+
+public class SerializeMiddleware {
+    public static final String CONTENT_TYPE = "application/x-amz-json-1.0";
+
+    protected final ProtocolGenerator.GenerationContext ctx;
+    protected final OperationShape operation;
+    protected final GoWriter writer;
+
+    protected final StructureShape input;
+    protected final StructureShape output;
+
+    private String serialName;
+
+    public SerializeMiddleware(
+            ProtocolGenerator.GenerationContext ctx, OperationShape operation, GoWriter writer
+    ) {
+        this.ctx = ctx;
+        this.operation = operation;
+        this.writer = writer;
+
+        this.input = ctx.getModel().expectShape(operation.getInputShape(), StructureShape.class);
+        this.output = ctx.getModel().expectShape(operation.getOutputShape(), StructureShape.class);
+    }
+
+    public static String getMiddlewareName(OperationShape operation) {
+        return "awsAwsjson10_serializeOp" + operation.toShapeId().getName();
+    }
+
+    public GoWriter.Writable generate() {
+        serialName = getMiddlewareName(operation);
+
+        return goTemplate("""
+
+            type $opName:L struct{
+            }
+
+            func (op *$opName:L) ID() string {
+                return "OperationSerializer"
+            }
+
+            $handleSerialize:W
+
+            """,
+            MapUtils.of(
+                "opName", serialName,
+                "handleSerialize", generateHandleSerialize()
+        ));
+    }
+
+    private GoWriter.Writable generateHandleSerialize() {
+        return goTemplate(
+                """
+
+                        func (op *$opName:L) HandleSerialize (ctx $context:T, in $input:T, next $handler:T) (
+                        out $output:T, metadata $metadata:T, err error) {
+
+                            $body:W
+
+                            return next.HandleSerialize(ctx, in)
+                        }
+
+                        """, MapUtils.of(
+                        "context", SmithyGoDependency.CONTEXT.interfaceSymbol("Context"),
+                        "input", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeInput"),
+                        "handler", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeHandler"),
+                        "output", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeOutput"),
+                        "metadata", SmithyGoDependency.SMITHY_MIDDLEWARE.struct("Metadata"),
+                        "opName", serialName,
+                        "body", generateHandleSerializeBody())
+        );
+    }
+
+    private GoWriter.Writable generateHandleSerializeBody() {
+        return goTemplate("""
+                $route:W
+
+                $serialize:W
+
+            """,
+            MapUtils.of(
+                    "route", handleProtocolSetup(),
+                    "serialize", handlePayload()
+            ));
+    }
+
+    private GoWriter.Writable handleProtocolSetup() {
+
+        return goTemplate("""
+                input, ok := in.Parameters.($input:P)
+                if !ok {
+                    return out, metadata, $errorf:T("unexpected input type %T", in.Parameters)
+                }
+                _ = input
+
+                req, ok := in.Request.($request:P)
+                if !ok {
+                    return out, metadata, $errorf:T("unexpected transport type %T", in.Request)
+                }
+
+                req.Method = $methodPost:T
+                req.URL.Path = "/"
+                req.Header.Set("Content-Type", $contentType:S)
+                req.Header.Set("X-Amz-Target", $target:S)
+
+            """,
+            MapUtils.of(
+                "input", ctx.getSymbolProvider().toSymbol(input),
+                "request", SMITHY_HTTP_TRANSPORT.pointableSymbol("Request"),
+                "methodPost", GoStdlibTypes.Net.Http.MethodPost,
+                "contentType", CONTENT_TYPE,
+                "target", ctx.getService().getId().getName() + '.' + operation.getId().getName(),
+                "errorf", GoStdlibTypes.Fmt.Errorf
+                ));
+    }
+
+    private GoWriter.Writable handlePayload() {
+        return goTemplate("""
+
+                jsonEncoder := $encoder:T()
+
+                err = $serialize:L(input, jsonEncoder.Value)
+                if err != nil {
+                    return out, metadata, &$error:T{Err: err}
+                }
+
+                payload := $reader:T(jsonEncoder.Bytes())
+                req, err = req.SetStream(payload)
+                if err != nil {
+                    return out, metadata, &$error:T{Err: err}
+                }
+
+                in.Request = req
+            """,
+            MapUtils.of(
+                "serialize", getSerializerName(input),
+                "encoder", SmithyGoTypes.Encoding.Json.NewEncoder,
+                "reader", GoStdlibTypes.Bytes.NewReader,
+                "error", SmithyGoTypes.Smithy.SerializationError
+        ));
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.go.codegen.integration.GoIntegration
+++ b/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.go.codegen.integration.GoIntegration
@@ -7,6 +7,8 @@ software.amazon.smithy.go.codegen.integration.OperationInterfaceGenerator
 software.amazon.smithy.go.codegen.integration.ClientLogger
 software.amazon.smithy.go.codegen.endpoints.EndpointClientPluginsGenerator
 
+software.amazon.smithy.go.codegen.integration.DefaultProtocols
+
 # modeled auth schemes
 software.amazon.smithy.go.codegen.integration.auth.SigV4AuthScheme
 software.amazon.smithy.go.codegen.integration.auth.AnonymousAuthScheme


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Update the Protocol Generator with a complete Deserializer Implementation that generates the response deserializer and the shared deserializers.
- Create a new DeserializeMiddleware class to handle all generation for the overall response deserializer, with specific functions to specifically handle event streams and empty responses.
- Add support for shared deserializer generation in the protocol generator.
- Amend the JsonDeserializerGenerator as needed, mainly adding support for float and intEnum values

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
