### PR TITLE
add tracing APIs and instrumentation

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
@@ -59,7 +59,7 @@ public final class GoWriter extends SymbolWriter<GoWriter, ImportDeclarations> {
 
     private static final Logger LOGGER = Logger.getLogger(GoWriter.class.getName());
     private static final int DEFAULT_DOC_WRAP_LENGTH = 80;
-    private static final Pattern ARGUMENT_NAME_PATTERN = Pattern.compile("\\$([a-z][a-zA-Z_0-9]+)(:\\w)?");
+    private static final Pattern ARGUMENT_NAME_PATTERN = Pattern.compile("\\$([a-z][a-zA-Z_0-9]\\.+)(:\\w)?");
     private final String fullPackageName;
     private final boolean innerWriter;
     private final List<String> buildTags = new ArrayList<>();
@@ -96,6 +96,11 @@ public final class GoWriter extends SymbolWriter<GoWriter, ImportDeclarations> {
         putFormatter('P', new PointableGoSymbolFormatter());
         putFormatter('W', new GoWritableInjector());
         putFormatter('D', new GoDependencyFormatter());
+
+        putContext("fmt.Sprintf", SmithyGoDependency.FMT.func("Sprintf"));
+        putContext("fmt.Errorf", SmithyGoDependency.FMT.func("Errorf"));
+        putContext("errors.As", SmithyGoDependency.ERRORS.func("As"));
+        putContext("context.Context", SmithyGoDependency.CONTEXT.func("Context"));
 
         if (!innerWriter) {
             packageDocs = new GoWriter(this.fullPackageName, true);

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -76,6 +76,7 @@ public final class SmithyGoDependency {
     public static final GoDependency SMITHY_AUTH_BEARER = smithy("auth/bearer");
     public static final GoDependency SMITHY_ENDPOINTS = smithy("endpoints", "smithyendpoints");
     public static final GoDependency SMITHY_ENDPOINT_RULESFN = smithy("endpoints/private/rulesfn");
+    public static final GoDependency SMITHY_TRACING = smithy("tracing");
 
     public static final GoDependency GO_JMESPATH = goJmespath(null);
     public static final GoDependency MATH = stdlib("math");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/ResolveAuthSchemeMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/ResolveAuthSchemeMiddlewareGenerator.java
@@ -22,6 +22,7 @@ import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.go.codegen.GoStdlibTypes;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.MiddlewareIdentifier;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.go.codegen.SmithyGoTypes;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.utils.MapUtils;
@@ -66,6 +67,9 @@ public class ResolveAuthSchemeMiddlewareGenerator {
 
     private GoWriter.Writable generateBody() {
         return goTemplate("""
+                _, span := $3T(ctx, "ResolveAuthScheme")
+                defer span.End()
+
                 params := $1L(ctx, m.operation, getOperationInput(ctx), m.options)
                 options, err := m.options.AuthSchemeResolver.ResolveAuthSchemes(ctx, params)
                 if err != nil {
@@ -78,10 +82,14 @@ public class ResolveAuthSchemeMiddlewareGenerator {
                 }
 
                 ctx = setResolvedAuthScheme(ctx, scheme)
+
+                span.SetProperty("operation.auth.resolved_scheme_id", scheme.Scheme.SchemeID())
+                span.End()
                 return next.HandleFinalize(ctx, in)
                 """,
                 AuthParametersResolverGenerator.FUNC_NAME,
-                GoStdlibTypes.Fmt.Errorf
+                GoStdlibTypes.Fmt.Errorf,
+                SmithyGoDependency.SMITHY_TRACING.func("StartSpan")
         );
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.go.codegen.integration;
 
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+import static software.amazon.smithy.go.codegen.SmithyGoDependency.SMITHY_TRACING;
 import static software.amazon.smithy.go.codegen.integration.ProtocolUtils.requiresDocumentSerdeFunction;
 
 import java.util.Collection;
@@ -250,6 +252,11 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.addUseImports(SmithyGoDependency.SMITHY);
             writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_BINDING);
 
+            writer.write(goTemplate("""
+                    _, span := $T(ctx, "OperationSerializer")
+                    defer span.End()
+                    """, SMITHY_TRACING.func("StartSpan")));
+
             // cast input request to smithy transport type, check for failures
             writer.write("request, ok := in.Request.($P)", requestType);
             writer.openBlock("if !ok {", "}", () -> {
@@ -351,6 +358,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.write("in.Request = request");
             writer.write("");
 
+            writer.write("span.End()");
             writer.write("return next.$L(ctx, in)", generator.getHandleMethodName());
         });
     }
@@ -384,6 +392,11 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.write("out, metadata, err = next.$L(ctx, in)", generator.getHandleMethodName());
             writer.write("if err != nil { return out, metadata, err }");
             writer.write("");
+
+            writer.write(goTemplate("""
+                    _, span := $T(ctx, "OperationDeserializer")
+                    defer span.End()
+                    """, SMITHY_TRACING.func("StartSpan")));
 
             writer.write("response, ok := out.RawResponse.($P)", responseType);
             writer.openBlock("if !ok {", "}", () -> {
@@ -451,6 +464,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             }
             writer.write("");
 
+            writer.write("span.End()");
             writer.write("return out, metadata, err");
         });
         goWriter.write("");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
@@ -15,6 +15,9 @@
 
 package software.amazon.smithy.go.codegen.integration;
 
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+import static software.amazon.smithy.go.codegen.SmithyGoDependency.SMITHY_TRACING;
+
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -144,6 +147,11 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
             writer.addUseImports(SmithyGoDependency.FMT);
             writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_BINDING);
 
+            writer.write(goTemplate("""
+                    _, span := $T(ctx, "OperationSerializer")
+                    defer span.End()
+                    """, SMITHY_TRACING.func("StartSpan")));
+
             // TODO: refactor the http binding encoder to be split up into its component parts
             // This would allow most of this shared code to be split off into its own function
             // to reduce duplication, and potentially allowing it to be a static function.
@@ -212,6 +220,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
             writer.write("in.Request = request");
 
             writer.write("");
+            writer.write("span.End()");
             writer.write("return next.$L(ctx, in)", generator.getHandleMethodName());
         });
 
@@ -330,6 +339,11 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
             writer.write("if err != nil { return out, metadata, err }");
             writer.write("");
 
+            writer.write(goTemplate("""
+                    _, span := $T(ctx, "OperationDeserializer")
+                    defer span.End()
+                    """, SMITHY_TRACING.func("StartSpan")));
+
             writer.write("response, ok := out.RawResponse.($P)", responseType);
             writer.openBlock("if !ok {", "}", () -> {
                 writer.write(String.format("return out, metadata, &smithy.DeserializationError{Err: %s}",
@@ -364,6 +378,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
             }
             writer.write("");
 
+            writer.write("span.End()");
             writer.write("return out, metadata, err");
         });
         writer.write("");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ObservabilityOptions.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ObservabilityOptions.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.integration;
+
+import java.util.List;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+
+/**
+ * Adds observability providers to client options.
+ */
+public class ObservabilityOptions implements GoIntegration {
+    private static final ConfigField TRACER_PROVIDER = ConfigField.builder()
+            .name("TracerProvider")
+            .type(SmithyGoDependency.SMITHY_TRACING.interfaceSymbol("TracerProvider"))
+            .documentation("The client tracer provider.")
+            .build();
+
+    // TODO
+    //  private static final ConfigField METER_PROVIDER = ConfigField.builder()
+    //          .name("MeterProvider")
+    //          .type(SmithyGoDependency.SMITHY_METRICS.interfaceSymbol("MeterProvider"))
+    //          .documentation("The client meter provider.")
+    //          .build();
+
+    @Override
+    public List<RuntimeClientPlugin> getClientPlugins() {
+        return List.of(
+                RuntimeClientPlugin.builder()
+                        .addConfigField(TRACER_PROVIDER)
+                        .build()
+        );
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/TracingSpans.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/TracingSpans.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ *
+ */
+
+package software.amazon.smithy.go.codegen.integration;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+import static software.amazon.smithy.go.codegen.SmithyGoDependency.SMITHY_MIDDLEWARE;
+import static software.amazon.smithy.go.codegen.SmithyGoDependency.SMITHY_TRACING;
+import static software.amazon.smithy.go.codegen.SymbolUtils.buildPackageSymbol;
+
+import java.util.List;
+import java.util.Map;
+import software.amazon.smithy.go.codegen.GoCodegenContext;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.middleware.BuildStepMiddleware;
+import software.amazon.smithy.go.codegen.middleware.InitializeStepMiddleware;
+import software.amazon.smithy.go.codegen.middleware.SerializeStepMiddleware;
+
+/**
+ * Instruments the client with various base trace spans.
+ */
+public class TracingSpans implements GoIntegration {
+    public static final MiddlewareRegistrar SPAN_INITIALIZE_START = MiddlewareRegistrar.builder()
+            .resolvedFunction(buildPackageSymbol("addSpanInitializeStart"))
+            .build();
+    public static final MiddlewareRegistrar SPAN_INITIALIZE_END = MiddlewareRegistrar.builder()
+            .resolvedFunction(buildPackageSymbol("addSpanInitializeEnd"))
+            .build();
+    public static final MiddlewareRegistrar SPAN_BUILD_REQUEST_START = MiddlewareRegistrar.builder()
+            .resolvedFunction(buildPackageSymbol("addSpanBuildRequestStart"))
+            .build();
+    public static final MiddlewareRegistrar SPAN_BUILD_REQUEST_END = MiddlewareRegistrar.builder()
+            .resolvedFunction(buildPackageSymbol("addSpanBuildRequestEnd"))
+            .build();
+
+    @Override
+    public byte getOrder() {
+        return 127;
+    }
+
+    @Override
+    public List<RuntimeClientPlugin> getClientPlugins() {
+        return List.of(
+                RuntimeClientPlugin.builder().registerMiddleware(SPAN_INITIALIZE_START).build(),
+                RuntimeClientPlugin.builder().registerMiddleware(SPAN_INITIALIZE_END).build(),
+                RuntimeClientPlugin.builder().registerMiddleware(SPAN_BUILD_REQUEST_START).build(),
+                RuntimeClientPlugin.builder().registerMiddleware(SPAN_BUILD_REQUEST_END).build()
+        );
+    }
+
+    @Override
+    public void writeAdditionalFiles(GoCodegenContext ctx) {
+        ctx.writerDelegator().useFileWriter("api_client.go", ctx.settings().getModuleName(), goTemplate("""
+                $initializeStart:W
+                $initializeEnd:W
+
+                $buildRequestStart:W
+                $buildRequestEnd:W
+
+                func addSpanInitializeStart(stack $stack:P) error {
+                    return stack.Initialize.Add(&spanInitializeStart{}, $before:T)
+                }
+
+                func addSpanInitializeEnd(stack $stack:P) error {
+                    return stack.Initialize.Add(&spanInitializeEnd{}, $after:T)
+                }
+
+                func addSpanBuildRequestStart(stack $stack:P) error {
+                    return stack.Serialize.Add(&spanBuildRequestStart{}, $before:T)
+                }
+
+                func addSpanBuildRequestEnd(stack $stack:P) error {
+                    return stack.Build.Add(&spanBuildRequestEnd{}, $after:T)
+                }
+                """,
+                Map.of(
+                        "initializeStart", new SpanInitializeStart(),
+                        "initializeEnd", new SpanInitializeEnd(),
+                        "buildRequestStart", new SpanBuildRequestStart(),
+                        "buildRequestEnd", new SpanBuildRequestEnd(),
+                        "stack", SMITHY_MIDDLEWARE.struct("Stack"),
+                        "before", SMITHY_MIDDLEWARE.constSymbol("Before"),
+                        "after", SMITHY_MIDDLEWARE.constSymbol("After")
+                )));
+    }
+
+    private static final class SpanInitializeStart extends InitializeStepMiddleware {
+        @Override
+        public String getStructName() {
+            return "spanInitializeStart";
+        }
+
+        @Override
+        public GoWriter.Writable getFuncBody() {
+            return goTemplate("""
+                    ctx, _ = $T(ctx, "Initialize")
+
+                    return next.HandleInitialize(ctx, in)
+                    """, SMITHY_TRACING.func("StartSpan"));
+        }
+    }
+
+    private static final class SpanInitializeEnd extends InitializeStepMiddleware {
+        @Override
+        public String getStructName() {
+            return "spanInitializeEnd";
+        }
+
+        @Override
+        public GoWriter.Writable getFuncBody() {
+            return goTemplate("""
+                    ctx, span := $T(ctx)
+                    span.End()
+
+                    return next.HandleInitialize(ctx, in)
+                    """, SMITHY_TRACING.func("PopSpan"));
+        }
+    }
+
+    private static final class SpanBuildRequestStart extends SerializeStepMiddleware {
+        @Override
+        public String getStructName() {
+            return "spanBuildRequestStart";
+        }
+
+        @Override
+        public GoWriter.Writable getFuncBody() {
+            return goTemplate("""
+                    ctx, _ = $T(ctx, "BuildRequest")
+
+                    return next.HandleSerialize(ctx, in)
+                    """, SMITHY_TRACING.func("StartSpan"));
+        }
+    }
+
+    private static final class SpanBuildRequestEnd extends BuildStepMiddleware {
+        @Override
+        public String getStructName() {
+            return "spanBuildRequestEnd";
+        }
+
+        @Override
+        public GoWriter.Writable getFuncBody() {
+            return goTemplate("""
+                    ctx, span := $T(ctx)
+                    span.End()
+
+                    return next.HandleBuild(ctx, in)
+                    """, SMITHY_TRACING.func("PopSpan"));
+        }
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/middleware/BuildStepMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/middleware/BuildStepMiddleware.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.middleware;
+
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+
+/**
+ * Abstract class for BuildStep middleware generation.
+ */
+public abstract class BuildStepMiddleware extends OperationMiddleware {
+    @Override
+    public String getFuncName() {
+        return "HandleBuild";
+    }
+
+    @Override
+    public Symbol getInput() {
+        return SmithyGoDependency.SMITHY_MIDDLEWARE.struct("BuildInput");
+    }
+
+    @Override
+    public Symbol getHandler() {
+        return SmithyGoDependency.SMITHY_MIDDLEWARE.struct("BuildHandler");
+    }
+
+    @Override
+    public Symbol getOutput() {
+        return SmithyGoDependency.SMITHY_MIDDLEWARE.struct("BuildOutput");
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/middleware/DeserializeStepMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/middleware/DeserializeStepMiddleware.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.middleware;
+
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+
+/**
+ * Abstract class for DeserializeStep middleware generation.
+ */
+public abstract class DeserializeStepMiddleware extends OperationMiddleware {
+    @Override
+    public String getFuncName() {
+        return "HandleDeserialize";
+    }
+
+    @Override
+    public Symbol getInput() {
+        return SmithyGoDependency.SMITHY_MIDDLEWARE.struct("DeserializeInput");
+    }
+
+    @Override
+    public Symbol getHandler() {
+        return SmithyGoDependency.SMITHY_MIDDLEWARE.struct("DeserializeHandler");
+    }
+
+    @Override
+    public Symbol getOutput() {
+        return SmithyGoDependency.SMITHY_MIDDLEWARE.struct("DeserializeOutput");
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/middleware/FinalizeStepMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/middleware/FinalizeStepMiddleware.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.middleware;
+
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+
+/**
+ * Abstract class for FinalizeStep middleware generation.
+ */
+public abstract class FinalizeStepMiddleware extends OperationMiddleware {
+    @Override
+    public String getFuncName() {
+        return "HandleFinalize";
+    }
+
+    @Override
+    public Symbol getInput() {
+        return SmithyGoDependency.SMITHY_MIDDLEWARE.struct("FinalizeInput");
+    }
+
+    @Override
+    public Symbol getHandler() {
+        return SmithyGoDependency.SMITHY_MIDDLEWARE.struct("FinalizeHandler");
+    }
+
+    @Override
+    public Symbol getOutput() {
+        return SmithyGoDependency.SMITHY_MIDDLEWARE.struct("FinalizeOutput");
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/middleware/InitializeStepMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/middleware/InitializeStepMiddleware.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.middleware;
+
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+
+/**
+ * Abstract class for InitializeStep middleware generation.
+ */
+public abstract class InitializeStepMiddleware extends OperationMiddleware {
+    @Override
+    public String getFuncName() {
+        return "HandleInitialize";
+    }
+
+    @Override
+    public Symbol getInput() {
+        return SmithyGoDependency.SMITHY_MIDDLEWARE.struct("InitializeInput");
+    }
+
+    @Override
+    public Symbol getHandler() {
+        return SmithyGoDependency.SMITHY_MIDDLEWARE.struct("InitializeHandler");
+    }
+
+    @Override
+    public Symbol getOutput() {
+        return SmithyGoDependency.SMITHY_MIDDLEWARE.struct("InitializeOutput");
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/middleware/OperationMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/middleware/OperationMiddleware.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.middleware;
+
+import static java.util.Collections.emptyMap;
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+
+import java.util.Map;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.GoStdlibTypes;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SmithyGoTypes;
+
+/**
+ * Abstract base class for code generation of operation middleware.
+ */
+public abstract class OperationMiddleware implements GoWriter.Writable {
+    public abstract String getStructName();
+
+    public Map<String, Symbol> getFields() {
+        return emptyMap();
+    }
+
+    public String getId() {
+        return getStructName();
+    }
+
+    public abstract String getFuncName();
+
+    public abstract Symbol getInput();
+
+    public abstract Symbol getHandler();
+
+    public abstract Symbol getOutput();
+
+    public abstract GoWriter.Writable getFuncBody();
+
+    @Override
+    public final void accept(GoWriter goWriter) {
+        goWriter.write(goTemplate("""
+                type $name:L struct {
+                    $fields:W
+                }
+
+                func (*$name:L) ID() string {
+                    return $id:S
+                }
+
+                func (m *$name:L) $func:L (
+                    ctx $context:T, in $in:T, next $next:T,
+                ) (
+                    $out:T, $md:T, error,
+                ) {
+                    $body:W
+                }
+                """,
+                Map.of(
+                        "name", getStructName(),
+                        "fields", renderFields(),
+                        "id", getId(),
+                        "func", getFuncName(),
+                        "context", GoStdlibTypes.Context.Context,
+                        "in", getInput(),
+                        "next", getHandler(),
+                        "out", getOutput(),
+                        "md", SmithyGoTypes.Middleware.Metadata,
+                        "body", getFuncBody()
+                )));
+    }
+
+    private GoWriter.Writable renderFields() {
+        return GoWriter.ChainWritable.of(
+                getFields().entrySet().stream()
+                        .map(it -> goTemplate("$L $P", it.getKey(), it.getValue()))
+                        .toList()
+        ).compose(false);
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/middleware/SerializeStepMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/middleware/SerializeStepMiddleware.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.middleware;
+
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+
+/**
+ * Abstract class for SerializeStep middleware generation.
+ */
+public abstract class SerializeStepMiddleware extends OperationMiddleware {
+    @Override
+    public String getFuncName() {
+        return "HandleSerialize";
+    }
+
+    @Override
+    public Symbol getInput() {
+        return SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeInput");
+    }
+
+    @Override
+    public Symbol getHandler() {
+        return SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeHandler");
+    }
+
+    @Override
+    public Symbol getOutput() {
+        return SmithyGoDependency.SMITHY_MIDDLEWARE.struct("SerializeOutput");
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.go.codegen.integration.GoIntegration
+++ b/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.go.codegen.integration.GoIntegration
@@ -13,5 +13,8 @@ software.amazon.smithy.go.codegen.integration.auth.AnonymousAuthScheme
 
 software.amazon.smithy.go.codegen.requestcompression.RequestCompression
 
+software.amazon.smithy.go.codegen.integration.ObservabilityOptions
+software.amazon.smithy.go.codegen.integration.TracingSpans
+
 # server
 software.amazon.smithy.go.codegen.server.integration.DefaultProtocols

--- a/properties.go
+++ b/properties.go
@@ -1,9 +1,11 @@
 package smithy
 
+import "maps"
+
 // PropertiesReader provides an interface for reading metadata from the
 // underlying metadata container.
 type PropertiesReader interface {
-	Get(key interface{}) interface{}
+	Get(key any) any
 }
 
 // Properties provides storing and reading metadata values. Keys may be any
@@ -12,14 +14,14 @@ type PropertiesReader interface {
 // The zero value for a Properties instance is ready for reads/writes without
 // any additional initialization.
 type Properties struct {
-	values map[interface{}]interface{}
+	values map[any]any
 }
 
 // Get attempts to retrieve the value the key points to. Returns nil if the
 // key was not found.
 //
 // Panics if key type is not comparable.
-func (m *Properties) Get(key interface{}) interface{} {
+func (m *Properties) Get(key any) any {
 	m.lazyInit()
 	return m.values[key]
 }
@@ -28,7 +30,7 @@ func (m *Properties) Get(key interface{}) interface{} {
 // that key it will be replaced with the new value.
 //
 // Panics if the key type is not comparable.
-func (m *Properties) Set(key, value interface{}) {
+func (m *Properties) Set(key, value any) {
 	m.lazyInit()
 	m.values[key] = value
 }
@@ -36,7 +38,7 @@ func (m *Properties) Set(key, value interface{}) {
 // Has returns whether the key exists in the metadata.
 //
 // Panics if the key type is not comparable.
-func (m *Properties) Has(key interface{}) bool {
+func (m *Properties) Has(key any) bool {
 	m.lazyInit()
 	_, ok := m.values[key]
 	return ok
@@ -55,8 +57,13 @@ func (m *Properties) SetAll(other *Properties) {
 	}
 }
 
+// Values returns a shallow clone of the property set's values.
+func (m *Properties) Values() map[any]any {
+	return maps.Clone(m.values)
+}
+
 func (m *Properties) lazyInit() {
 	if m.values == nil {
-		m.values = map[interface{}]interface{}{}
+		m.values = map[any]any{}
 	}
 }

--- a/tracing/context.go
+++ b/tracing/context.go
@@ -1,0 +1,96 @@
+package tracing
+
+import "context"
+
+type (
+	operationTracerKey struct{}
+	spanLineageKey     struct{}
+)
+
+// GetSpan returns the active trace Span on the context.
+//
+// The boolean in the return indicates whether a Span was actually in the
+// context, but a no-op implementation will be returned if not, so callers
+// can generally disregard the boolean unless they wish to explicitly confirm
+// presence/absence of a Span.
+func GetSpan(ctx context.Context) (Span, bool) {
+	lineage := getLineage(ctx)
+	if len(lineage) == 0 {
+		return nopSpan{}, false
+	}
+
+	return lineage[len(lineage)-1], true
+}
+
+// WithSpan sets the active trace Span on the context.
+func WithSpan(parent context.Context, span Span) context.Context {
+	lineage := getLineage(parent)
+	if len(lineage) == 0 {
+		return context.WithValue(parent, spanLineageKey{}, []Span{span})
+	}
+
+	lineage = append(lineage, span)
+	return context.WithValue(parent, spanLineageKey{}, lineage)
+}
+
+// PopSpan pops the current Span off the context, setting the active Span on
+// the returned Context back to its parent and returning the REMOVED one.
+//
+// PopSpan on a context with no active Span will return a no-op instance.
+//
+// This is mostly necessary for the runtime to manage base trace spans due to
+// the wrapped-function nature of the middleware stack. End-users of Smithy
+// clients SHOULD NOT generally be using this API.
+func PopSpan(parent context.Context) (context.Context, Span) {
+	lineage := getLineage(parent)
+	if len(lineage) == 0 {
+		return parent, nopSpan{}
+	}
+
+	span := lineage[len(lineage)-1]
+	lineage = lineage[:len(lineage)-1]
+	return context.WithValue(parent, spanLineageKey{}, lineage), span
+}
+
+func getLineage(ctx context.Context) []Span {
+	v := ctx.Value(spanLineageKey{})
+	if v == nil {
+		return nil
+	}
+
+	return v.([]Span)
+}
+
+// GetOperationTracer returns the embedded operation-scoped Tracer on a
+// Context.
+//
+// The boolean in the return indicates whether a Tracer was actually in the
+// context, but a no-op implementation will be returned if not, so callers
+// can generally disregard the boolean unless they wish to explicitly confirm
+// presence/absence of a Tracer.
+func GetOperationTracer(ctx context.Context) (Tracer, bool) {
+	v := ctx.Value(operationTracerKey{})
+	if v == nil {
+		return nopTracer{}, false
+	}
+
+	return v.(Tracer), true
+}
+
+// WithOperationTracer returns a child Context embedding the given Tracer.
+//
+// The runtime will use this embed a scoped tracer for client operations,
+// Smithy/SDK client callers DO NOT need to do this explicitly.
+func WithOperationTracer(parent context.Context, tracer Tracer) context.Context {
+	return context.WithValue(parent, operationTracerKey{}, tracer)
+}
+
+// StartSpan is a convenience API for creating tracing Spans from a Context.
+//
+// StartSpan uses the operation-scoped Tracer, previously stored using
+// [WithOperationTracer], to start the Span. If a Tracer has not been embedded
+// the returned Span will be a no-op implementation.
+func StartSpan(ctx context.Context, name string, opts ...SpanOption) (context.Context, Span) {
+	tracer, _ := GetOperationTracer(ctx)
+	return tracer.StartSpan(ctx, name, opts...)
+}

--- a/tracing/context_test.go
+++ b/tracing/context_test.go
@@ -1,0 +1,64 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+)
+
+// nopSpan has no fields so all values are equal, adding an int allows us to
+// differentiate
+type mockSpan struct {
+	nopSpan
+	id int
+}
+
+func TestSpanContextAPIs(t *testing.T) {
+	parent := mockSpan{id: 1}
+	child := mockSpan{id: 2}
+
+	ctx := context.Background()
+	span, ok := GetSpan(ctx)
+	if ok {
+		t.Error("should have no span at the start but it did")
+	}
+
+	// set & expect parent
+	ctx = WithSpan(ctx, parent)
+	span, _ = GetSpan(ctx)
+	if actual, ok := span.(mockSpan); !ok || parent != actual {
+		t.Errorf("span %d != %d", parent.id, actual.id)
+	}
+
+	// set & expect child
+	ctx = WithSpan(ctx, child)
+	span, _ = GetSpan(ctx)
+	if actual, ok := span.(mockSpan); !ok || child != actual {
+		t.Errorf("span %d != %d", child.id, actual.id)
+	}
+
+	// pop, expect popped child, with parent remaining
+	ctx, span = PopSpan(ctx)
+	if actual, ok := span.(mockSpan); !ok || child != actual {
+		t.Errorf("span %d != %d", child.id, actual.id)
+	}
+	span, _ = GetSpan(ctx)
+	if actual, ok := span.(mockSpan); !ok || parent != actual {
+		t.Errorf("span %d != %d", parent.id, actual.id)
+	}
+
+	// pop, expect popped parent, with no span remaining
+	ctx, span = PopSpan(ctx)
+	if actual, ok := span.(mockSpan); !ok || parent != actual {
+		t.Errorf("span %d != %d", parent.id, actual.id)
+	}
+	span, ok = GetSpan(ctx)
+	if ok {
+		t.Error("should have no span at the end but it did")
+	}
+
+	// pop, expect it to be a nop since nothing is left
+	ctx, span = PopSpan(ctx)
+	if _, ok := span.(nopSpan); !ok {
+		t.Errorf("should have been nop span on last pop but was %T", span)
+	}
+}

--- a/tracing/nop.go
+++ b/tracing/nop.go
@@ -1,0 +1,32 @@
+package tracing
+
+import "context"
+
+// NopTracerProvider is a no-op tracing implementation.
+type NopTracerProvider struct{}
+
+var _ TracerProvider = (*NopTracerProvider)(nil)
+
+// Tracer returns a tracer which creates no-op spans.
+func (NopTracerProvider) Tracer(string, ...TracerOption) Tracer {
+	return nopTracer{}
+}
+
+type nopTracer struct{}
+
+var _ Tracer = (*nopTracer)(nil)
+
+func (nopTracer) StartSpan(ctx context.Context, name string, opts ...SpanOption) (context.Context, Span) {
+	return ctx, nopSpan{}
+}
+
+type nopSpan struct{}
+
+var _ Span = (*nopSpan)(nil)
+
+func (nopSpan) Name() string                    { return "" }
+func (nopSpan) Context() SpanContext            { return SpanContext{} }
+func (nopSpan) AddEvent(string, ...EventOption) {}
+func (nopSpan) SetProperty(any, any)            {}
+func (nopSpan) SetStatus(SpanStatus)            {}
+func (nopSpan) End()                            {}

--- a/tracing/smithy-otel-tracing/adapt.go
+++ b/tracing/smithy-otel-tracing/adapt.go
@@ -1,0 +1,186 @@
+package smithyoteltracing
+
+import (
+	"context"
+
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/tracing"
+	otelattribute "go.opentelemetry.io/otel/attribute"
+	otelcodes "go.opentelemetry.io/otel/codes"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+// Adapt wraps a concrete OpenTelemetry SDK TraceProvider for use with Smithy
+// SDK clients.
+//
+// Adapt can be called multiple times on a single TracerProvider.
+func Adapt(tp oteltrace.TracerProvider) tracing.TracerProvider {
+	return &tracerProvider{tp}
+}
+
+type tracerProvider struct {
+	otel oteltrace.TracerProvider
+}
+
+var _ tracing.TracerProvider = (*tracerProvider)(nil)
+
+func (p *tracerProvider) Tracer(scope string, opts ...tracing.TracerOption) tracing.Tracer {
+	var options tracing.TracerOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	t := p.otel.Tracer(scope, oteltrace.WithInstrumentationAttributes(
+		toOTELKeyValues(options.Properties)...,
+	))
+	return &tracer{t}
+}
+
+type tracer struct {
+	otel oteltrace.Tracer
+}
+
+var _ tracing.Tracer = (*tracer)(nil)
+
+func (t *tracer) StartSpan(ctx context.Context, name string, opts ...tracing.SpanOption) (context.Context, tracing.Span) {
+	// We do some context value juggling with our adapted Span to ensure the
+	// following:
+	//   (1) Our adapted Span is what actually persists on the context and
+	//       is what callers are getting and recording to.
+	//   (2) OTEL itself sees any pre-existing Span such that the parent-child
+	//       relationship of concrete OTEL spans is maintained.
+	ours, ok := tracing.GetSpan(ctx)
+	if ok {
+		ctx = oteltrace.ContextWithSpan(ctx, ours.(*span).otel) // (2)
+	}
+
+	var options tracing.SpanOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	kind := toOTELSpanKind(options.Kind)
+	ctx, theirs := t.otel.Start(ctx, name, oteltrace.WithSpanKind(kind))
+
+	ours = &span{
+		otel: theirs,
+		name: name,
+	}
+	for k, v := range options.Properties.Values() {
+		ours.SetProperty(k, v)
+	}
+	return tracing.WithSpan(ctx, ours) /* (1) */, ours
+}
+
+type span struct {
+	otel oteltrace.Span
+	name string
+}
+
+var _ tracing.Span = (*span)(nil)
+
+func (s *span) Name() string {
+	return s.name
+}
+
+func (s *span) Context() tracing.SpanContext {
+	ctx := s.otel.SpanContext()
+	return tracing.SpanContext{
+		TraceID:  ctx.TraceID().String(),
+		SpanID:   ctx.SpanID().String(),
+		IsRemote: ctx.IsRemote(),
+	}
+}
+
+func (s *span) AddEvent(name string, opts ...tracing.EventOption) {
+	var options tracing.EventOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	s.otel.AddEvent(name, oteltrace.WithAttributes(
+		toOTELKeyValues(options.Properties)...,
+	))
+}
+
+func (s *span) SetProperty(k, v any) {
+	if kv, ok := toOTELKeyValue(k, v); ok {
+		s.otel.SetAttributes(kv)
+	}
+}
+
+func (s *span) SetStatus(status tracing.SpanStatus) {
+	s.otel.SetStatus(toOTELSpanStatus(status), "")
+}
+
+func (s *span) End() {
+	s.otel.End()
+}
+
+func toOTELSpanKind(v tracing.SpanKind) oteltrace.SpanKind {
+	switch v {
+	case tracing.SpanKindClient:
+		return oteltrace.SpanKindClient
+	case tracing.SpanKindServer:
+		return oteltrace.SpanKindServer
+	case tracing.SpanKindProducer:
+		return oteltrace.SpanKindProducer
+	case tracing.SpanKindConsumer:
+		return oteltrace.SpanKindConsumer
+	default:
+		return oteltrace.SpanKindInternal
+	}
+}
+
+func toOTELSpanStatus(v tracing.SpanStatus) otelcodes.Code {
+	switch v {
+	case tracing.SpanStatusOK:
+		return otelcodes.Ok
+	case tracing.SpanStatusError:
+		return otelcodes.Error
+	default:
+		return otelcodes.Unset
+	}
+}
+
+func toOTELKeyValue(k, v any) (otelattribute.KeyValue, bool) {
+	kk, ok := k.(string)
+	if !ok {
+		return otelattribute.KeyValue{}, false
+	}
+
+	switch vv := v.(type) {
+	case bool:
+		return otelattribute.Bool(kk, vv), true
+	case []bool:
+		return otelattribute.BoolSlice(kk, vv), true
+	case int:
+		return otelattribute.Int(kk, vv), true
+	case []int:
+		return otelattribute.IntSlice(kk, vv), true
+	case int64:
+		return otelattribute.Int64(kk, vv), true
+	case []int64:
+		return otelattribute.Int64Slice(kk, vv), true
+	case float64:
+		return otelattribute.Float64(kk, vv), true
+	case []float64:
+		return otelattribute.Float64Slice(kk, vv), true
+	case string:
+		return otelattribute.String(kk, vv), true
+	case []string:
+		return otelattribute.StringSlice(kk, vv), true
+	default:
+		return otelattribute.KeyValue{}, false
+	}
+}
+
+func toOTELKeyValues(props smithy.Properties) []otelattribute.KeyValue {
+	var kvs []otelattribute.KeyValue
+	for k, v := range props.Values() {
+		if kv, ok := toOTELKeyValue(k, v); ok {
+			kvs = append(kvs, kv)
+		}
+	}
+	return kvs
+}

--- a/tracing/smithy-otel-tracing/adapt_test.go
+++ b/tracing/smithy-otel-tracing/adapt_test.go
@@ -1,0 +1,81 @@
+package smithyoteltracing
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/smithy-go/tracing"
+	otelattribute "go.opentelemetry.io/otel/attribute"
+	otelcodes "go.opentelemetry.io/otel/codes"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+func TestToOTELSpanKind(t *testing.T) {
+	for _, tt := range []struct {
+		In     tracing.SpanKind
+		Expect oteltrace.SpanKind
+	}{
+		{tracing.SpanKindClient, oteltrace.SpanKindClient},
+		{tracing.SpanKindServer, oteltrace.SpanKindServer},
+		{tracing.SpanKindProducer, oteltrace.SpanKindProducer},
+		{tracing.SpanKindConsumer, oteltrace.SpanKindConsumer},
+		{tracing.SpanKindInternal, oteltrace.SpanKindInternal},
+		{tracing.SpanKind(-1), oteltrace.SpanKindInternal},
+	} {
+		name := fmt.Sprintf("%v -> %v", tt.In, tt.Expect)
+		t.Run(name, func(t *testing.T) {
+			actual := toOTELSpanKind(tt.In)
+			if tt.Expect != actual {
+				t.Errorf("%v != %v", tt.Expect, actual)
+			}
+		})
+	}
+}
+
+func TestToOTELSpanStatus(t *testing.T) {
+	for _, tt := range []struct {
+		In     tracing.SpanStatus
+		Expect otelcodes.Code
+	}{
+		{tracing.SpanStatusOK, otelcodes.Ok},
+		{tracing.SpanStatusError, otelcodes.Error},
+		{tracing.SpanStatusUnset, otelcodes.Unset},
+		{tracing.SpanStatus(-1), otelcodes.Unset},
+	} {
+		name := fmt.Sprintf("%v -> %v", tt.In, tt.Expect)
+		t.Run(name, func(t *testing.T) {
+			actual := toOTELSpanStatus(tt.In)
+			if tt.Expect != actual {
+				t.Errorf("%v != %v", tt.Expect, actual)
+			}
+		})
+	}
+}
+
+func TestToOTELKeyValue(t *testing.T) {
+	for _, tt := range []struct {
+		K, V   any
+		Expect otelattribute.KeyValue
+	}{
+		{1, "asdf", otelattribute.KeyValue{}},      // non-string key
+		{"key", uint(0), otelattribute.KeyValue{}}, // unsupported value type
+		{"key", true, otelattribute.Bool("key", true)},
+		{"key", []bool{true, false}, otelattribute.BoolSlice("key", []bool{true, false})},
+		{"key", int(1), otelattribute.Int("key", 1)},
+		{"key", []int{1, 2}, otelattribute.IntSlice("key", []int{1, 2})},
+		{"key", int64(1), otelattribute.Int64("key", 1)},
+		{"key", []int64{1, 2}, otelattribute.Int64Slice("key", []int64{1, 2})},
+		{"key", float64(1), otelattribute.Float64("key", 1)},
+		{"key", []float64{1, 2}, otelattribute.Float64Slice("key", []float64{1, 2})},
+		{"key", "value", otelattribute.String("key", "value")},
+		{"key", []string{"v1", "v2"}, otelattribute.StringSlice("key", []string{"v1", "v2"})},
+	} {
+		name := fmt.Sprintf("(%v, %v) -> %v", tt.K, tt.V, tt.Expect)
+		t.Run(name, func(t *testing.T) {
+			actual, _ := toOTELKeyValue(tt.K, tt.V)
+			if tt.Expect != actual {
+				t.Errorf("%v != %v", tt.Expect, actual)
+			}
+		})
+	}
+}

--- a/tracing/smithy-otel-tracing/doc.go
+++ b/tracing/smithy-otel-tracing/doc.go
@@ -1,0 +1,58 @@
+// Package smithyoteltracing implements a Smithy client tracing adapter for the
+// OTEL Go SDK.
+//
+// # Usage
+//
+// Callers use the [Adapt] API in this package to wrap a concrete OTEL SDK
+// TracerProvider.
+//
+// The following example uses the AWS SDK for S3:
+//
+//	import (
+//		"github.com/aws/aws-sdk-go-v2/config"
+//		"github.com/aws/aws-sdk-go-v2/service/s3"
+//		smithyoteltracing "github.com/aws/smithy-go/tracing/smithy-otel-tracing"
+//		"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+//		"go.opentelemetry.io/otel/sdk/trace"
+//	)
+//
+//	func main() {
+//		exporter, err := stdouttrace.New()
+//		if err != nil {
+//			panic(err)
+//		}
+//
+//		cfg, err := config.LoadDefaultConfig(context.Background())
+//		if err != nil {
+//			panic(err)
+//		}
+//
+//		provider := trace.NewTracerProvider(trace.WithBatcher(exporter))
+//		svc := s3.NewFromConfig(cfg, func(o *s3.Options) {
+//			o.TracerProvider = smithyoteltracing.Adapt(provider)
+//		})
+//		// ...
+//	}
+//
+// # OTEL Attributes
+//
+// This adapter supports all attribute types used in the OTEL SDK (including
+// their slice-of variants):
+//   - bool
+//   - int
+//   - int64
+//   - float64
+//   - string
+//
+// A key-value pair set on a [smithy.Properties] container in any of the
+// tracing APIs will automatically propagate to the underlying OTEL SDK if its
+// key is of type string, and its value is of one of the supported types. All
+// other values are silently ignored.
+//
+// e.g.
+//
+//	ctx, span := tracing.StartSpan(ctx, "Foo", func(o *tracing.SpanOptions) {
+//		o.Properties.Set("app.version", "bar")       // propagates to OTEL
+//		o.Properties.Set(customPropertyKey{}, "baz") // does not
+//	})
+package smithyoteltracing

--- a/tracing/smithy-otel-tracing/go.mod
+++ b/tracing/smithy-otel-tracing/go.mod
@@ -1,0 +1,11 @@
+module github.com/aws/smithy-go/tracing/smithy-otel-tracing
+
+go 1.22
+
+require (
+	github.com/aws/smithy-go v1.20.4
+	go.opentelemetry.io/otel v1.28.0
+	go.opentelemetry.io/otel/trace v1.28.0
+)
+
+replace github.com/aws/smithy-go => ../../

--- a/tracing/smithy-otel-tracing/go.sum
+++ b/tracing/smithy-otel-tracing/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.opentelemetry.io/otel v1.28.0 h1:/SqNcYk+idO0CxKEUOtKQClMK/MimZihKYMruSMViUo=
+go.opentelemetry.io/otel v1.28.0/go.mod h1:q68ijF8Fc8CnMHKyzqL6akLO46ePnjkgfIMIjUIX9z4=
+go.opentelemetry.io/otel/trace v1.28.0 h1:GhQ9cUuQGmNDd5BTCP2dAvv75RdMxEfTmYejp+lkx9g=
+go.opentelemetry.io/otel/trace v1.28.0/go.mod h1:jPyXzNPg6da9+38HEwElrQiHlVMTnVfM3/yv2OlIHaI=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -1,0 +1,95 @@
+// Package tracing defines tracing APIs to be used by Smithy clients.
+package tracing
+
+import (
+	"context"
+
+	"github.com/aws/smithy-go"
+)
+
+// SpanStatus records the "success" state of an observed span.
+type SpanStatus int
+
+// Enumeration of SpanStatus.
+const (
+	SpanStatusUnset SpanStatus = iota
+	SpanStatusOK
+	SpanStatusError
+)
+
+// SpanKind indicates the nature of the work being performed.
+type SpanKind int
+
+// Enumeration of SpanKind.
+const (
+	SpanKindInternal SpanKind = iota
+	SpanKindClient
+	SpanKindServer
+	SpanKindProducer
+	SpanKindConsumer
+)
+
+// TracerProvider is the entry point for creating client traces.
+type TracerProvider interface {
+	Tracer(scope string, opts ...TracerOption) Tracer
+}
+
+// TracerOption applies configuration to a tracer.
+type TracerOption func(o *TracerOptions)
+
+// TracerOptions represent configuration for tracers.
+type TracerOptions struct {
+	Properties smithy.Properties
+}
+
+// Tracer is the entry point for creating observed client Spans.
+//
+// Spans created by tracers propagate by existing on the Context. Consumers of
+// the API can use [GetSpan] to pull the active Span from a Context.
+//
+// Creation of child Spans is implicit through Context persistence. If
+// CreateSpan is called with a Context that holds a Span, the result will be a
+// child of that Span.
+type Tracer interface {
+	StartSpan(ctx context.Context, name string, opts ...SpanOption) (context.Context, Span)
+}
+
+// SpanOption applies configuration to a span.
+type SpanOption func(o *SpanOptions)
+
+// SpanOptions represent configuration for span events.
+type SpanOptions struct {
+	Kind       SpanKind
+	Properties smithy.Properties
+}
+
+// Span records a conceptually individual unit of work that takes place in a
+// Smithy client operation.
+type Span interface {
+	Name() string
+	Context() SpanContext
+	AddEvent(name string, opts ...EventOption)
+	SetStatus(status SpanStatus)
+	SetProperty(k, v any)
+	End()
+}
+
+// EventOption applies configuration to a span event.
+type EventOption func(o *EventOptions)
+
+// EventOptions represent configuration for span events.
+type EventOptions struct {
+	Properties smithy.Properties
+}
+
+// SpanContext uniquely identifies a Span.
+type SpanContext struct {
+	TraceID  string
+	SpanID   string
+	IsRemote bool
+}
+
+// IsValid is true when a span has nonzero trace and span IDs.
+func (ctx *SpanContext) IsValid() bool {
+	return len(ctx.TraceID) != 0 && len(ctx.SpanID) != 0
+}

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -7,6 +7,7 @@ import (
 
 	smithy "github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/middleware"
+	"github.com/aws/smithy-go/tracing"
 )
 
 // ClientDo provides the interface for custom HTTP client implementations.
@@ -42,6 +43,9 @@ func NewClientHandler(client ClientDo) ClientHandler {
 func (c ClientHandler) Handle(ctx context.Context, input interface{}) (
 	out interface{}, metadata middleware.Metadata, err error,
 ) {
+	ctx, span := tracing.StartSpan(ctx, "DoHTTPRequest")
+	defer span.End()
+
 	req, ok := input.(*Request)
 	if !ok {
 		return nil, metadata, fmt.Errorf("expect Smithy http.Request value as input, got unsupported type %T", input)
@@ -50,6 +54,16 @@ func (c ClientHandler) Handle(ctx context.Context, input interface{}) (
 	builtRequest := req.Build(ctx)
 	if err := ValidateEndpointHost(builtRequest.Host); err != nil {
 		return nil, metadata, err
+	}
+
+	span.SetProperty("http.request.method", req.Method)
+	span.SetProperty("http.request.content_length", -1) // at least indicate unknown
+	length, ok, err := req.StreamLength()
+	if err != nil {
+		return nil, metadata, err
+	}
+	if ok {
+		span.SetProperty("http.request.content_length", length)
 	}
 
 	resp, err := c.client.Do(builtRequest)
@@ -78,6 +92,10 @@ func (c ClientHandler) Handle(ctx context.Context, input interface{}) (
 	if builtRequest.Body != nil {
 		_ = builtRequest.Body.Close()
 	}
+
+	span.SetProperty("http.proto", fmt.Sprintf("%d.%d", resp.ProtoMajor, resp.ProtoMinor))
+	span.SetProperty("http.response.status_code", resp.StatusCode)
+	span.SetProperty("http.response.content_length", resp.ContentLength)
 
 	return &Response{Response: resp}, metadata, err
 }


### PR DESCRIPTION
Tracing component of #470

* misc
  * adds Java-esque abstract Middleware codegen classes
  * adds the most common stdlib functions we use directly into Writer's context so they can be referenced without having to inject a symbol (e.g. `fmt.Sprintf`)
* Adds `smithy-go/tracing` APIs
* New module: `github.com/aws/smithy-go/tracing/smithy-otel-tracing` adapts an OTEL SDK TracerProvider for use with Smithy clients
* Instrument clients operations with the following span hierarchy:
  * <Service.Operation>
    * Initialize
    * BuildRequest
      * OperationSerializer
    * ResolveAuthScheme
    * GetIdentity
    * ResolveEndpoint
    * ComputePayloadSHA256
    * (note - everything from here down is part of the retry loop, but it is not instrumented that way here because all of the retry logic is SDK-side right now)
      * SignRequest
      * DoHTTPRequest
      * OperationDeserializer
* Adds the following Span attributes
  * `rpc.method` - name of the operation
  * `rpc.service` - sdkID of the service (or shape name if not present)
  * `rpc.system` - hardcoded to `aws-api`
    * Theoretically this would vary by client scope (e.g. non-AWS SDKs would set something different here). I've elected to defer allowing configuration of it for now since it's really just a string, if you disagree let's discuss
  * `error.go.type` - literal go type of an operation's error e.g. `&smithy.GenericAPIError`
  * `error.go.error` - results of `Error()` on an operation's error
  * `error.api.fault` - if error is a smithy API error, the fault type (client/server/unknown)
  * `error.api.code` - if error ", the error code
  * `error.api.message` - if error ", the error message
  * `error` - `true` if operation returned an error
  * `http.proto` - HTTP protocol version (as read from the response)
  * `http.request.content_length` - content length of serialized request body
  * `http.request.method` - HTTP method of serialized request
  * `http.response.status_code` - HTTP status code of raw response
  * `http.response.content_length` - content length of raw response body
  * `operation.resolved_endpoint` - the exact URL returned from endpoint resolution (including the scheme and any base path)
  * `operation.auth.resolved_scheme_id` - the auth scheme ID selected during resolution e.g. aws.auth#sigv4