### PR TITLE
Add awsJson10 Error Deserialization support.

### DIFF
--- a/.github/workflows/api_diff_check.yml
+++ b/.github/workflows/api_diff_check.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: "1.20"
+        go-version: "1.22"
       id: go
 
     - name: Check out code into the Go module directory

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
@@ -235,7 +235,21 @@ public class AwsJson10ProtocolGenerator implements ProtocolGenerator {
 
                 if jtyp, ok := jv["__type"]; ok {
                     typ = jtyp.(string)
+                } else if jtyp, ok := jv["code"]; ok {
+                    typ = jtyp.(string)
                 }
+                // TODO: Add in Header Check for "x-amzn-errortype"
+
+                hashIndex, colonIndex := 0, len(typ)-1
+                for idx := 0; idx < len(typ); idx++ {
+                    if typ[idx] == '#' && hashIndex == 0 {
+                        hashIndex = idx
+                    }
+                    if typ[idx] == ':' && colonIndex == len(typ)-1 {
+                        colonIndex = idx
+                    }
+                }
+                typ = typ[hashIndex:colonIndex+1]
 
                 if jmsg, ok := jv["message"]; ok {
                     msg = jmsg.(string)

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
@@ -240,22 +240,27 @@ public class AwsJson10ProtocolGenerator implements ProtocolGenerator {
                 }
                 // TODO: Add in Header Check for "x-amzn-errortype"
 
-                hashIndex, colonIndex := 0, len(typ)-1
-                for idx := 0; idx < len(typ); idx++ {
-                    if typ[idx] == '#' && hashIndex == 0 {
-                        hashIndex = idx
-                    }
-                    if typ[idx] == ':' && colonIndex == len(typ)-1 {
-                        colonIndex = idx
-                    }
-                }
-                typ = typ[hashIndex:colonIndex+1]
+                typ = sanitizeProtocolErrorTyp(typ)
 
                 if jmsg, ok := jv["message"]; ok {
                     msg = jmsg.(string)
                 }
 
                 return typ, msg, val.($value:T), nil
+            }
+
+            func sanitizeProtocolErrorTyp(typ string) (val string){
+                val = typ
+                hashIndex, colonIndex := 0, len(val)-1
+                for idx := 0; idx < len(val); idx++ {
+                    if val[idx] == '#' && hashIndex == 0 {
+                        hashIndex = idx
+                    }
+                    if val[idx] == ':' && colonIndex == len(val)-1 {
+                        colonIndex = idx
+                    }
+                }
+                return val[hashIndex:colonIndex+1]
             }
             """,
             MapUtils.of(

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/AwsJson10ProtocolGenerator.java
@@ -235,7 +235,7 @@ public class AwsJson10ProtocolGenerator implements ProtocolGenerator {
 
                 if jtyp, ok := jv["__type"]; ok {
                     typ = jtyp.(string)
-                } else if jtyp, ok := jv["code"]; ok {
+                } else if jtyp, ok = jv["code"]; ok {
                     typ = jtyp.(string)
                 }
                 // TODO: Add in Header Check for "x-amzn-errortype"

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/DeserializeMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/DeserializeMiddleware.java
@@ -28,7 +28,6 @@ import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.utils.MapUtils;
-import software.amazon.smithy.utils.StringUtils;
 
 public class DeserializeMiddleware {
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/DeserializeMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/aws/DeserializeMiddleware.java
@@ -58,11 +58,6 @@ public class DeserializeMiddleware {
         return "awsAwsjson10_deserializeOp" + operation.toShapeId().getName();
     }
 
-    public static String getOperationErrorDeserializerName(OperationShape operation,
-                                                           ProtocolGenerator.GenerationContext ctx) {
-         return "awsAwsjson10_deserializeOpError" + StringUtils.capitalize(operation.getId().getName(ctx.getService()));
-    }
-
     public GoWriter.Writable generate() {
         return goTemplate("""
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Protocol Generator: 

- generateSharedDeserializers contains revisions that attain all error shapes and generate shared deserializers with regular member shapes 
- generateSharedDeserializes generates deserializers specific to each operation and additional error info functions
- generateOperationErrorDeserializers handles all parts of error generation, including cycling through the different operations. There are 4 additional helper functions in protocol generator utilized here. 

Deserialize Middleware:
- Response Checks function calls the error deserializers if a non 200 error is reported

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
