### PR TITLE
add metrics APIs and corresponding otel adapter

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
@@ -101,6 +101,7 @@ public final class GoWriter extends SymbolWriter<GoWriter, ImportDeclarations> {
         putContext("fmt.Errorf", SmithyGoDependency.FMT.func("Errorf"));
         putContext("errors.As", SmithyGoDependency.ERRORS.func("As"));
         putContext("context.Context", SmithyGoDependency.CONTEXT.func("Context"));
+        putContext("time.Now", SmithyGoDependency.TIME.func("Now"));
 
         if (!innerWriter) {
             packageDocs = new GoWriter(this.fullPackageName, true);

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -390,7 +390,8 @@ final class ServiceGenerator implements Runnable {
                         o.Properties.Set("rpc.method", opID)
                         o.Properties.Set("rpc.service", ServiceID)
                     })
-                    defer startMetricTimer(ctx, "client.call.duration")()
+                    endTimer := startMetricTimer(ctx, "client.call.duration")
+                    defer endTimer()
                     defer span.End()
 
                     handler := $newClientHandler:T(options.HTTPClient)

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -77,6 +77,7 @@ public final class SmithyGoDependency {
     public static final GoDependency SMITHY_ENDPOINTS = smithy("endpoints", "smithyendpoints");
     public static final GoDependency SMITHY_ENDPOINT_RULESFN = smithy("endpoints/private/rulesfn");
     public static final GoDependency SMITHY_TRACING = smithy("tracing");
+    public static final GoDependency SMITHY_METRICS = smithy("metrics");
 
     public static final GoDependency GO_JMESPATH = goJmespath(null);
     public static final GoDependency MATH = stdlib("math");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -398,7 +398,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
             writer.write(goTemplate("""
                     _, span := $T(ctx, "OperationDeserializer")
-                    defer startMetricTimer(ctx, "client.call.deserialization_duration")()
+                    endTimer := startMetricTimer(ctx, "client.call.deserialization_duration")
+                    defer endTimer()
                     defer span.End()
                     """, SMITHY_TRACING.func("StartSpan")));
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -254,6 +254,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
             writer.write(goTemplate("""
                     _, span := $T(ctx, "OperationSerializer")
+                    endTimer := startMetricTimer(ctx, "client.call.serialization_duration")
+                    defer endTimer()
                     defer span.End()
                     """, SMITHY_TRACING.func("StartSpan")));
 
@@ -358,6 +360,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.write("in.Request = request");
             writer.write("");
 
+            writer.write("endTimer()");
             writer.write("span.End()");
             writer.write("return next.$L(ctx, in)", generator.getHandleMethodName());
         });
@@ -395,6 +398,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
             writer.write(goTemplate("""
                     _, span := $T(ctx, "OperationDeserializer")
+                    defer startMetricTimer(ctx, "client.call.deserialization_duration")()
                     defer span.End()
                     """, SMITHY_TRACING.func("StartSpan")));
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
@@ -149,6 +149,8 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
 
             writer.write(goTemplate("""
                     _, span := $T(ctx, "OperationSerializer")
+                    endTimer := startMetricTimer(ctx, "client.call.serialization_duration")
+                    defer endTimer()
                     defer span.End()
                     """, SMITHY_TRACING.func("StartSpan")));
 
@@ -220,6 +222,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
             writer.write("in.Request = request");
 
             writer.write("");
+            writer.write("endTimer()");
             writer.write("span.End()");
             writer.write("return next.$L(ctx, in)", generator.getHandleMethodName());
         });
@@ -341,6 +344,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
 
             writer.write(goTemplate("""
                     _, span := $T(ctx, "OperationDeserializer")
+                    defer startMetricTimer(ctx, "client.call.deserialization_duration")()
                     defer span.End()
                     """, SMITHY_TRACING.func("StartSpan")));
 
@@ -378,7 +382,6 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
             }
             writer.write("");
 
-            writer.write("span.End()");
             writer.write("return out, metadata, err");
         });
         writer.write("");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
@@ -344,7 +344,8 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
 
             writer.write(goTemplate("""
                     _, span := $T(ctx, "OperationDeserializer")
-                    defer startMetricTimer(ctx, "client.call.deserialization_duration")()
+                    endTimer := startMetricTimer(ctx, "client.call.deserialization_duration")
+                    defer endTimer()
                     defer span.End()
                     """, SMITHY_TRACING.func("StartSpan")));
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/OperationMetricsStruct.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/OperationMetricsStruct.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package software.amazon.smithy.go.codegen.integration;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+import static software.amazon.smithy.go.codegen.SmithyGoDependency.CONTEXT;
+import static software.amazon.smithy.go.codegen.SmithyGoDependency.SMITHY_METRICS;
+import static software.amazon.smithy.go.codegen.SmithyGoDependency.SMITHY_MIDDLEWARE;
+import static software.amazon.smithy.go.codegen.SmithyGoDependency.TIME;
+
+import software.amazon.smithy.go.codegen.GoWriter;
+
+/**
+ * Writable operationMetrics structure that records operation-specific metrics.
+ */
+public class OperationMetricsStruct implements GoWriter.Writable {
+    private final String scope;
+
+    public OperationMetricsStruct(String scope) {
+        this.scope = scope;
+    }
+
+    @Override
+    public void accept(GoWriter writer) {
+        writer.write(GoWriter.ChainWritable.of(
+                useDependencies(), generateStruct(), generateHelpers(), generateContextApis()
+        ).compose());
+    }
+
+    private GoWriter.Writable useDependencies() {
+        return writer -> writer
+                .addUseImports(CONTEXT)
+                .addUseImports(TIME)
+                .addUseImports(SMITHY_METRICS)
+                .addUseImports(SMITHY_MIDDLEWARE);
+    }
+
+    private GoWriter.Writable generateStruct() {
+        return goTemplate("""
+                type operationMetrics struct {
+                    Duration                metrics.Float64Histogram
+                    SerializeDuration       metrics.Float64Histogram
+                    GetIdentityDuration     metrics.Float64Histogram
+                    ResolveEndpointDuration metrics.Float64Histogram
+                    SignRequestDuration     metrics.Float64Histogram
+                    DeserializeDuration     metrics.Float64Histogram
+                }
+                """);
+    }
+
+    @SuppressWarnings({"checkstyle:LineLength"})
+    private GoWriter.Writable generateContextApis() {
+        return goTemplate("""
+                type operationMetricsKey struct{}
+
+                func withOperationMetrics(parent context.Context, mp metrics.MeterProvider) (context.Context, error) {
+                    meter := mp.Meter($S)
+                    om := &operationMetrics{}
+
+                    var err error
+
+                    om.Duration, err = operationMetricTimer(meter, "client.call.duration",
+                        "Overall call duration (including retries and time to send or receive request and response body)")
+                    if err != nil {
+                        return nil, err
+                    }
+                    om.SerializeDuration, err = operationMetricTimer(meter, "client.call.serialization_duration",
+                        "The time it takes to serialize a message body")
+                    if err != nil {
+                        return nil, err
+                    }
+                    om.GetIdentityDuration, err = operationMetricTimer(meter, "client.call.auth.resolve_identity_duration",
+                        "The time taken to acquire an identity (AWS credentials, bearer token, etc) from an Identity Provider")
+                    if err != nil {
+                        return nil, err
+                    }
+                    om.ResolveEndpointDuration, err = operationMetricTimer(meter, "client.call.resolve_endpoint_duration",
+                        "The time it takes to resolve an endpoint (endpoint resolver, not DNS) for the request")
+                    if err != nil {
+                        return nil, err
+                    }
+                    om.SignRequestDuration, err = operationMetricTimer(meter, "client.call.auth.signing_duration",
+                        "The time it takes to sign a request")
+                    if err != nil {
+                        return nil, err
+                    }
+                    om.DeserializeDuration, err = operationMetricTimer(meter, "client.call.deserialization_duration",
+                        "The time it takes to deserialize a message body")
+                    if err != nil {
+                        return nil, err
+                    }
+
+                    return context.WithValue(parent, operationMetricsKey{}, om), nil
+                }
+
+                func operationMetricTimer(m metrics.Meter, name, desc string) (metrics.Float64Histogram, error) {
+                    return m.Float64Histogram(name, func(o *metrics.InstrumentOptions) {
+                        o.UnitLabel = "s"
+                        o.Description = desc
+                    })
+                }
+
+                func getOperationMetrics(ctx context.Context) *operationMetrics {
+                    return ctx.Value(operationMetricsKey{}).(*operationMetrics)
+                }
+                """, scope);
+    }
+
+    private GoWriter.Writable generateHelpers() {
+        return goTemplate("""
+                func (m *operationMetrics) histogramFor(name string) metrics.Float64Histogram {
+                    switch name {
+                    case "client.call.duration":
+                        return m.Duration
+                    case "client.call.serialization_duration":
+                        return m.SerializeDuration
+                    case "client.call.resolve_identity_duration":
+                        return m.GetIdentityDuration
+                    case "client.call.resolve_endpoint_duration":
+                        return m.ResolveEndpointDuration
+                    case "client.call.signing_duration":
+                        return m.SignRequestDuration
+                    case "client.call.deserialization_duration":
+                        return m.DeserializeDuration
+                    default:
+                        panic("unrecognized operation metric")
+                    }
+                }
+
+                func timeOperationMetric[T any](
+                    ctx context.Context, metric string, fn func() (T, error),
+                    opts ...metrics.RecordMetricOption,
+                ) (T, error) {
+                    instr := getOperationMetrics(ctx).histogramFor(metric)
+                    opts = append([]metrics.RecordMetricOption{withOperationMetadata(ctx)}, opts...)
+
+                    start := time.Now()
+                    v, err := fn()
+                    end := time.Now()
+
+                    elapsed := end.Sub(start)
+                    instr.Record(ctx, float64(elapsed)/1e9, opts...)
+                    return v, err
+                }
+
+                func startMetricTimer(ctx context.Context, metric string, opts ...metrics.RecordMetricOption) func() {
+                    instr := getOperationMetrics(ctx).histogramFor(metric)
+                    opts = append([]metrics.RecordMetricOption{withOperationMetadata(ctx)}, opts...)
+
+                    var ended bool
+                    start := time.Now()
+                    return func() {
+                        if ended {
+                            return
+                        }
+                        ended = true
+
+                        end := time.Now()
+
+                        elapsed := end.Sub(start)
+                        instr.Record(ctx, float64(elapsed)/1e9, opts...)
+                    }
+                }
+
+                func withOperationMetadata(ctx context.Context) metrics.RecordMetricOption {
+                    return func(o *metrics.RecordMetricOptions) {
+                        o.Properties.Set("rpc.service", middleware.GetServiceID(ctx))
+                        o.Properties.Set("rpc.method", middleware.GetOperationName(ctx))
+                    }
+                }
+                """);
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/OperationMetricsStruct.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/OperationMetricsStruct.java
@@ -54,7 +54,7 @@ public class OperationMetricsStruct implements GoWriter.Writable {
                 type operationMetrics struct {
                     Duration                metrics.Float64Histogram
                     SerializeDuration       metrics.Float64Histogram
-                    GetIdentityDuration     metrics.Float64Histogram
+                    ResolveIdentityDuration metrics.Float64Histogram
                     ResolveEndpointDuration metrics.Float64Histogram
                     SignRequestDuration     metrics.Float64Histogram
                     DeserializeDuration     metrics.Float64Histogram
@@ -83,7 +83,7 @@ public class OperationMetricsStruct implements GoWriter.Writable {
                     if err != nil {
                         return nil, err
                     }
-                    om.GetIdentityDuration, err = operationMetricTimer(meter, "client.call.auth.resolve_identity_duration",
+                    om.ResolveIdentityDuration, err = operationMetricTimer(meter, "client.call.auth.resolve_identity_duration",
                         "The time taken to acquire an identity (AWS credentials, bearer token, etc) from an Identity Provider")
                     if err != nil {
                         return nil, err
@@ -129,7 +129,7 @@ public class OperationMetricsStruct implements GoWriter.Writable {
                     case "client.call.serialization_duration":
                         return m.SerializeDuration
                     case "client.call.resolve_identity_duration":
-                        return m.GetIdentityDuration
+                        return m.ResolveIdentityDuration
                     case "client.call.resolve_endpoint_duration":
                         return m.ResolveEndpointDuration
                     case "client.call.signing_duration":

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,136 @@
+// Package metrics defines the metrics APIs used by Smithy clients.
+package metrics
+
+import (
+	"context"
+
+	"github.com/aws/smithy-go"
+)
+
+// MeterProvider is the entry point for creating a Meter.
+type MeterProvider interface {
+	Meter(scope string, opts ...MeterOption) Meter
+}
+
+// MeterOption applies configuration to a Meter.
+type MeterOption func(o *MeterOptions)
+
+// MeterOptions represents configuration for a Meter.
+type MeterOptions struct {
+	Properties smithy.Properties
+}
+
+// Meter is the entry point for creation of measurement instruments.
+type Meter interface {
+	// integer/synchronous
+	Int64Counter(name string, opts ...InstrumentOption) (Int64Counter, error)
+	Int64UpDownCounter(name string, opts ...InstrumentOption) (Int64UpDownCounter, error)
+	Int64Gauge(name string, opts ...InstrumentOption) (Int64Gauge, error)
+	Int64Histogram(name string, opts ...InstrumentOption) (Int64Histogram, error)
+
+	// integer/asynchronous
+	Int64AsyncCounter(name string, callback Int64Callback, opts ...InstrumentOption) (AsyncInstrument, error)
+	Int64AsyncUpDownCounter(name string, callback Int64Callback, opts ...InstrumentOption) (AsyncInstrument, error)
+	Int64AsyncGauge(name string, callback Int64Callback, opts ...InstrumentOption) (AsyncInstrument, error)
+
+	// floating-point/synchronous
+	Float64Counter(name string, opts ...InstrumentOption) (Float64Counter, error)
+	Float64UpDownCounter(name string, opts ...InstrumentOption) (Float64UpDownCounter, error)
+	Float64Gauge(name string, opts ...InstrumentOption) (Float64Gauge, error)
+	Float64Histogram(name string, opts ...InstrumentOption) (Float64Histogram, error)
+
+	// floating-point/asynchronous
+	Float64AsyncCounter(name string, callback Float64Callback, opts ...InstrumentOption) (AsyncInstrument, error)
+	Float64AsyncUpDownCounter(name string, callback Float64Callback, opts ...InstrumentOption) (AsyncInstrument, error)
+	Float64AsyncGauge(name string, callback Float64Callback, opts ...InstrumentOption) (AsyncInstrument, error)
+}
+
+// InstrumentOption applies configuration to an instrument.
+type InstrumentOption func(o *InstrumentOptions)
+
+// InstrumentOptions represents configuration for an instrument.
+type InstrumentOptions struct {
+	UnitLabel   string
+	Description string
+}
+
+// Int64Counter measures a monotonically increasing int64 value.
+type Int64Counter interface {
+	Add(context.Context, int64, ...RecordMetricOption)
+}
+
+// Int64UpDownCounter measures a fluctuating int64 value.
+type Int64UpDownCounter interface {
+	Add(context.Context, int64, ...RecordMetricOption)
+}
+
+// Int64Gauge samples a discrete int64 value.
+type Int64Gauge interface {
+	Sample(context.Context, int64, ...RecordMetricOption)
+}
+
+// Int64Histogram records multiple data points for an int64 value.
+type Int64Histogram interface {
+	Record(context.Context, int64, ...RecordMetricOption)
+}
+
+// Float64Counter measures a monotonically increasing float64 value.
+type Float64Counter interface {
+	Add(context.Context, float64, ...RecordMetricOption)
+}
+
+// Float64UpDownCounter measures a fluctuating float64 value.
+type Float64UpDownCounter interface {
+	Add(context.Context, float64, ...RecordMetricOption)
+}
+
+// Float64Gauge samples a discrete float64 value.
+type Float64Gauge interface {
+	Sample(context.Context, float64, ...RecordMetricOption)
+}
+
+// Float64Histogram records multiple data points for an float64 value.
+type Float64Histogram interface {
+	Record(context.Context, float64, ...RecordMetricOption)
+}
+
+// AsyncInstrument is the universal handle returned for creation of all async
+// instruments.
+//
+// Callers use the Stop() API to unregister the callback passed at instrument
+// creation.
+type AsyncInstrument interface {
+	Stop()
+}
+
+// Int64Callback describes a function invoked when an async int64 instrument is
+// read.
+type Int64Callback func(context.Context, Int64Observer)
+
+// Int64Observer is the interface passed to async int64 instruments.
+//
+// Callers use the Observe() API of this interface to report metrics to the
+// underlying collector.
+type Int64Observer interface {
+	Observe(context.Context, int64, ...RecordMetricOption)
+}
+
+// Float64Callback describes a function invoked when an async float64
+// instrument is read.
+type Float64Callback func(context.Context, Float64Observer)
+
+// Float64Observer is the interface passed to async int64 instruments.
+//
+// Callers use the Observe() API of this interface to report metrics to the
+// underlying collector.
+type Float64Observer interface {
+	Observe(context.Context, float64, ...RecordMetricOption)
+}
+
+// RecordMetricOption applies configuration to a recorded metric.
+type RecordMetricOption func(o *RecordMetricOptions)
+
+// RecordMetricOptions represents configuration for a recorded metric.
+type RecordMetricOptions struct {
+	Properties smithy.Properties
+}

--- a/metrics/nop.go
+++ b/metrics/nop.go
@@ -1,0 +1,67 @@
+package metrics
+
+import "context"
+
+// NopMeterProvider is a no-op metrics implementation.
+type NopMeterProvider struct{}
+
+var _ MeterProvider = (*NopMeterProvider)(nil)
+
+// Meter returns a meter which creates no-op instruments.
+func (NopMeterProvider) Meter(string, ...MeterOption) Meter {
+	return nopMeter{}
+}
+
+type nopMeter struct{}
+
+var _ Meter = (*nopMeter)(nil)
+
+func (nopMeter) Int64Counter(string, ...InstrumentOption) (Int64Counter, error) {
+	return nopInstrument[int64]{}, nil
+}
+func (nopMeter) Int64UpDownCounter(string, ...InstrumentOption) (Int64UpDownCounter, error) {
+	return nopInstrument[int64]{}, nil
+}
+func (nopMeter) Int64Gauge(string, ...InstrumentOption) (Int64Gauge, error) {
+	return nopInstrument[int64]{}, nil
+}
+func (nopMeter) Int64Histogram(string, ...InstrumentOption) (Int64Histogram, error) {
+	return nopInstrument[int64]{}, nil
+}
+func (nopMeter) Int64AsyncCounter(string, Int64Callback, ...InstrumentOption) (AsyncInstrument, error) {
+	return nopInstrument[int64]{}, nil
+}
+func (nopMeter) Int64AsyncUpDownCounter(string, Int64Callback, ...InstrumentOption) (AsyncInstrument, error) {
+	return nopInstrument[int64]{}, nil
+}
+func (nopMeter) Int64AsyncGauge(string, Int64Callback, ...InstrumentOption) (AsyncInstrument, error) {
+	return nopInstrument[int64]{}, nil
+}
+func (nopMeter) Float64Counter(string, ...InstrumentOption) (Float64Counter, error) {
+	return nopInstrument[float64]{}, nil
+}
+func (nopMeter) Float64UpDownCounter(string, ...InstrumentOption) (Float64UpDownCounter, error) {
+	return nopInstrument[float64]{}, nil
+}
+func (nopMeter) Float64Gauge(string, ...InstrumentOption) (Float64Gauge, error) {
+	return nopInstrument[float64]{}, nil
+}
+func (nopMeter) Float64Histogram(string, ...InstrumentOption) (Float64Histogram, error) {
+	return nopInstrument[float64]{}, nil
+}
+func (nopMeter) Float64AsyncCounter(string, Float64Callback, ...InstrumentOption) (AsyncInstrument, error) {
+	return nopInstrument[float64]{}, nil
+}
+func (nopMeter) Float64AsyncUpDownCounter(string, Float64Callback, ...InstrumentOption) (AsyncInstrument, error) {
+	return nopInstrument[float64]{}, nil
+}
+func (nopMeter) Float64AsyncGauge(string, Float64Callback, ...InstrumentOption) (AsyncInstrument, error) {
+	return nopInstrument[float64]{}, nil
+}
+
+type nopInstrument[N any] struct{}
+
+func (nopInstrument[N]) Add(context.Context, N, ...RecordMetricOption)    {}
+func (nopInstrument[N]) Sample(context.Context, N, ...RecordMetricOption) {}
+func (nopInstrument[N]) Record(context.Context, N, ...RecordMetricOption) {}
+func (nopInstrument[_]) Stop()                                            {}

--- a/metrics/smithy-otel-metrics/async.go
+++ b/metrics/smithy-otel-metrics/async.go
@@ -1,0 +1,62 @@
+package smithyotelmetrics
+
+import (
+	"context"
+
+	"github.com/aws/smithy-go/metrics"
+	otelmetric "go.opentelemetry.io/otel/metric"
+)
+
+type asyncInstrument struct {
+	otel otelmetric.Registration
+}
+
+var _ metrics.AsyncInstrument = (*asyncInstrument)(nil)
+
+func (i *asyncInstrument) Stop() {
+	i.otel.Unregister()
+}
+
+// int64Observer wraps an untyped, multi-instrument OTEL Observer to Observe()
+// against a single int64 instrument.
+type int64Observer struct {
+	observer   otelmetric.Observer
+	instrument otelmetric.Int64Observable
+}
+
+var _ metrics.Int64Observer = (*int64Observer)(nil)
+
+func (o *int64Observer) Observe(ctx context.Context, v int64, opts ...metrics.RecordMetricOption) {
+	o.observer.ObserveInt64(o.instrument, v, withMetricProps(opts...))
+}
+
+// adaptInt64CB wraps an OTEL async instrument callback, binding it to a single
+// int64 instrument.
+func adaptInt64CB(io otelmetric.Int64Observable, cb metrics.Int64Callback) otelmetric.Callback {
+	return func(ctx context.Context, o otelmetric.Observer) error {
+		cb(ctx, &int64Observer{o, io})
+		return nil
+	}
+}
+
+// float64Observer wraps an untyped, multi-instrument OTEL Observer to Observe()
+// against a single float64 instrument.
+type float64Observer struct {
+	observer   otelmetric.Observer
+	instrument otelmetric.Float64Observable
+}
+
+var _ metrics.Float64Observer = (*float64Observer)(nil)
+
+func (o *float64Observer) Observe(ctx context.Context, v float64, opts ...metrics.RecordMetricOption) {
+	o.observer.ObserveFloat64(o.instrument, v, withMetricProps(opts...))
+}
+
+// adaptFloat64CB wraps an OTEL async instrument callback, binding it to a single
+// float64 instrument.
+func adaptFloat64CB(io otelmetric.Float64Observable, cb metrics.Float64Callback) otelmetric.Callback {
+	return func(ctx context.Context, o otelmetric.Observer) error {
+		cb(ctx, &float64Observer{o, io})
+		return nil
+	}
+}

--- a/metrics/smithy-otel-metrics/async.go
+++ b/metrics/smithy-otel-metrics/async.go
@@ -26,7 +26,7 @@ type int64Observer struct {
 
 var _ metrics.Int64Observer = (*int64Observer)(nil)
 
-func (o *int64Observer) Observe(ctx context.Context, v int64, opts ...metrics.RecordMetricOption) {
+func (o *int64Observer) Observe(_ context.Context, v int64, opts ...metrics.RecordMetricOption) {
 	o.observer.ObserveInt64(o.instrument, v, withMetricProps(opts...))
 }
 
@@ -48,7 +48,7 @@ type float64Observer struct {
 
 var _ metrics.Float64Observer = (*float64Observer)(nil)
 
-func (o *float64Observer) Observe(ctx context.Context, v float64, opts ...metrics.RecordMetricOption) {
+func (o *float64Observer) Observe(_ context.Context, v float64, opts ...metrics.RecordMetricOption) {
 	o.observer.ObserveFloat64(o.instrument, v, withMetricProps(opts...))
 }
 

--- a/metrics/smithy-otel-metrics/attribute.go
+++ b/metrics/smithy-otel-metrics/attribute.go
@@ -1,0 +1,67 @@
+package smithyotelmetrics
+
+import (
+	"fmt"
+
+	"github.com/aws/smithy-go"
+	otelattribute "go.opentelemetry.io/otel/attribute"
+)
+
+// IMPORTANT: The contents of this file are mirrored in
+// smithyoteltracing/attribute.go. Any changes made here must be replicated in
+// that module's copy of the file, although that will probably never happen, as
+// the set of attribute types supported by the OTEL API cannot reasonably
+// expand to include anything else that would be useful.
+//
+// This is done in order to avoid the one-way door of exposing an internal-only
+// module for what is effectively a simple value mapper (that will likely never
+// change).
+//
+// While the contents of the file are mirrored, the tests are only present
+// in the other version.
+
+func toOTELKeyValue(k, v any) otelattribute.KeyValue {
+	kk := str(k)
+
+	switch vv := v.(type) {
+	case bool:
+		return otelattribute.Bool(kk, vv)
+	case []bool:
+		return otelattribute.BoolSlice(kk, vv)
+	case int:
+		return otelattribute.Int(kk, vv)
+	case []int:
+		return otelattribute.IntSlice(kk, vv)
+	case int64:
+		return otelattribute.Int64(kk, vv)
+	case []int64:
+		return otelattribute.Int64Slice(kk, vv)
+	case float64:
+		return otelattribute.Float64(kk, vv)
+	case []float64:
+		return otelattribute.Float64Slice(kk, vv)
+	case string:
+		return otelattribute.String(kk, vv)
+	case []string:
+		return otelattribute.StringSlice(kk, vv)
+	default:
+		return otelattribute.String(kk, str(v))
+	}
+}
+
+func toOTELKeyValues(props smithy.Properties) []otelattribute.KeyValue {
+	var kvs []otelattribute.KeyValue
+	for k, v := range props.Values() {
+		kvs = append(kvs, toOTELKeyValue(k, v))
+	}
+	return kvs
+}
+
+func str(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	} else if s, ok := v.(fmt.Stringer); ok {
+		return s.String()
+	}
+	return fmt.Sprintf("%#v", v)
+}

--- a/metrics/smithy-otel-metrics/doc.go
+++ b/metrics/smithy-otel-metrics/doc.go
@@ -1,0 +1,40 @@
+// Package smithyotelmetrics implements a Smithy client metrics adapter for the
+// OTEL Go SDK.
+//
+// # Usage
+//
+// Callers use the [Adapt] API in this package to wrap a concrete OTEL SDK
+// MeterProvider.
+//
+// The following example uses the AWS SDK for S3:
+//
+//	import (
+//		"github.com/aws/aws-sdk-go-v2/config"
+//		"github.com/aws/aws-sdk-go-v2/service/s3"
+//		smithyotelmetrics "github.com/aws/smithy-go/metrics/smithy-otel-metrics"
+//		"go.opentelemetry.io/otel/sdk/metric"
+//		"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+//	)
+//
+//	func main() {
+//		cfg, err := config.LoadDefaultConfig(context.Background())
+//		if err != nil {
+//			panic(err)
+//		}
+//
+//		// export via OTLP - perhaps to the otel collector, etc.
+//		exporter, err := otlpmetrichttp.New(ctx, otlpmetrichttp.WithEndpointURL("http://localhost:4318"))
+//		if err != nil {
+//			panic(err)
+//		}
+//
+//		// aggressive reader interval for demonstration purposes
+//		reader := metric.NewPeriodicReader(exporter, metric.WithInterval(time.Second))
+//		provider := metric.NewMeterProvider(metric.WithReader(reader)
+//
+//		svc := s3.NewFromConfig(cfg, func(o *s3.Options) {
+//			o.MeterProvider = smithyotelmetrics.Adapt(provider)
+//		})
+//		// ...
+//	}
+package smithyotelmetrics

--- a/metrics/smithy-otel-metrics/float64.go
+++ b/metrics/smithy-otel-metrics/float64.go
@@ -1,0 +1,43 @@
+package smithyotelmetrics
+
+import (
+	"context"
+
+	"github.com/aws/smithy-go/metrics"
+	otelmetric "go.opentelemetry.io/otel/metric"
+)
+
+type otelFloat64Add interface {
+	Add(context.Context, float64, ...otelmetric.AddOption)
+}
+
+type float64Counter struct {
+	otel otelFloat64Add
+}
+
+var _ metrics.Float64Counter = (*float64Counter)(nil)
+var _ metrics.Float64UpDownCounter = (*float64Counter)(nil)
+
+func (i *float64Counter) Add(ctx context.Context, v float64, opts ...metrics.RecordMetricOption) {
+	i.otel.Add(ctx, v, withMetricProps(opts...))
+}
+
+type float64Gauge struct {
+	otel otelmetric.Float64Gauge
+}
+
+var _ metrics.Float64Gauge = (*float64Gauge)(nil)
+
+func (i *float64Gauge) Sample(ctx context.Context, v float64, opts ...metrics.RecordMetricOption) {
+	i.otel.Record(ctx, v, withMetricProps(opts...))
+}
+
+type float64Histogram struct {
+	otel otelmetric.Float64Histogram
+}
+
+var _ metrics.Float64Histogram = (*float64Histogram)(nil)
+
+func (i *float64Histogram) Record(ctx context.Context, v float64, opts ...metrics.RecordMetricOption) {
+	i.otel.Record(ctx, v, withMetricProps(opts...))
+}

--- a/metrics/smithy-otel-metrics/go.mod
+++ b/metrics/smithy-otel-metrics/go.mod
@@ -1,11 +1,11 @@
-module github.com/aws/smithy-go/tracing/smithy-otel-tracing
+module github.com/aws/smithy-go/metrics/smithy-otel-metrics
 
 go 1.22
 
 require (
 	github.com/aws/smithy-go v1.20.4
 	go.opentelemetry.io/otel v1.29.0
-	go.opentelemetry.io/otel/trace v1.29.0
+	go.opentelemetry.io/otel/metric v1.29.0
 )
 
 replace github.com/aws/smithy-go => ../../

--- a/metrics/smithy-otel-metrics/go.sum
+++ b/metrics/smithy-otel-metrics/go.sum
@@ -1,5 +1,9 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
+github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
+github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -8,6 +12,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.opentelemetry.io/otel v1.29.0 h1:PdomN/Al4q/lN6iBJEN3AwPvUiHPMlt93c8bqTG5Llw=
 go.opentelemetry.io/otel v1.29.0/go.mod h1:N/WtXPs1CNCUEx+Agz5uouwCba+i+bJGFicT8SR4NP8=
+go.opentelemetry.io/otel/metric v1.29.0 h1:vPf/HFWTNkPu1aYeIsc98l4ktOQaL6LeSoeV2g+8YLc=
+go.opentelemetry.io/otel/metric v1.29.0/go.mod h1:auu/QWieFVWx+DmQOUMgj0F8LHWdgalxXqvp7BII/W8=
 go.opentelemetry.io/otel/trace v1.29.0 h1:J/8ZNK4XgR7a21DZUAsbF8pZ5Jcw1VhACmnYt39JTi4=
 go.opentelemetry.io/otel/trace v1.29.0/go.mod h1:eHl3w0sp3paPkYstJOmAimxhiFXPg+MMTlEh3nsQgWQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/metrics/smithy-otel-metrics/int64.go
+++ b/metrics/smithy-otel-metrics/int64.go
@@ -1,0 +1,41 @@
+package smithyotelmetrics
+
+import (
+	"context"
+
+	"github.com/aws/smithy-go/metrics"
+	otelmetric "go.opentelemetry.io/otel/metric"
+)
+
+type int64Counter struct {
+	otel interface {
+		Add(context.Context, int64, ...otelmetric.AddOption)
+	}
+}
+
+var _ metrics.Int64Counter = (*int64Counter)(nil)
+var _ metrics.Int64UpDownCounter = (*int64Counter)(nil)
+
+func (i *int64Counter) Add(ctx context.Context, v int64, opts ...metrics.RecordMetricOption) {
+	i.otel.Add(ctx, v, withMetricProps(opts...))
+}
+
+type int64Gauge struct {
+	otel otelmetric.Int64Gauge
+}
+
+var _ metrics.Int64Gauge = (*int64Gauge)(nil)
+
+func (i *int64Gauge) Sample(ctx context.Context, v int64, opts ...metrics.RecordMetricOption) {
+	i.otel.Record(ctx, v, withMetricProps(opts...))
+}
+
+type int64Histogram struct {
+	otel otelmetric.Int64Histogram
+}
+
+var _ metrics.Int64Histogram = (*int64Histogram)(nil)
+
+func (i *int64Histogram) Record(ctx context.Context, v int64, opts ...metrics.RecordMetricOption) {
+	i.otel.Record(ctx, v, withMetricProps(opts...))
+}

--- a/metrics/smithy-otel-metrics/metrics.go
+++ b/metrics/smithy-otel-metrics/metrics.go
@@ -1,0 +1,188 @@
+package smithyotelmetrics
+
+import (
+	"github.com/aws/smithy-go/metrics"
+	otelmetric "go.opentelemetry.io/otel/metric"
+)
+
+// Adapt wraps a concrete OpenTelemetry SDK MeterProvider for use with Smithy
+// SDK clients.
+//
+// Adapt can be called multiple times on a single MeterProvider.
+func Adapt(mp otelmetric.MeterProvider) metrics.MeterProvider {
+	return &meterProvider{mp}
+}
+
+type meterProvider struct {
+	otel otelmetric.MeterProvider
+}
+
+var _ metrics.MeterProvider = (*meterProvider)(nil)
+
+func (p *meterProvider) Meter(scope string, opts ...metrics.MeterOption) metrics.Meter {
+	var options metrics.MeterOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	m := p.otel.Meter(scope, otelmetric.WithInstrumentationAttributes(
+		toOTELKeyValues(options.Properties)...,
+	))
+	return &meter{m}
+}
+
+type meter struct {
+	otel otelmetric.Meter
+}
+
+var _ metrics.Meter = (*meter)(nil)
+
+func (m *meter) Int64Counter(name string, opts ...metrics.InstrumentOption) (metrics.Int64Counter, error) {
+	unit, desc := toInstrumentOpts(opts...)
+	i, err := m.otel.Int64Counter(name, otelmetric.WithUnit(unit), otelmetric.WithDescription(desc))
+	if err != nil {
+		return nil, err
+	}
+	return &int64Counter{i}, nil
+}
+
+func (m *meter) Int64UpDownCounter(name string, opts ...metrics.InstrumentOption) (metrics.Int64UpDownCounter, error) {
+	unit, desc := toInstrumentOpts(opts...)
+	i, err := m.otel.Int64UpDownCounter(name, otelmetric.WithUnit(unit), otelmetric.WithDescription(desc))
+	if err != nil {
+		return nil, err
+	}
+	return &int64Counter{i}, nil
+}
+
+func (m *meter) Int64Gauge(name string, opts ...metrics.InstrumentOption) (metrics.Int64Gauge, error) {
+	unit, desc := toInstrumentOpts(opts...)
+	i, err := m.otel.Int64Gauge(name, otelmetric.WithUnit(unit), otelmetric.WithDescription(desc))
+	if err != nil {
+		return nil, err
+	}
+	return &int64Gauge{i}, nil
+}
+
+func (m *meter) Int64Histogram(name string, opts ...metrics.InstrumentOption) (metrics.Int64Histogram, error) {
+	unit, desc := toInstrumentOpts(opts...)
+	i, err := m.otel.Int64Histogram(name, otelmetric.WithUnit(unit), otelmetric.WithDescription(desc))
+	if err != nil {
+		return nil, err
+	}
+	return &int64Histogram{i}, nil
+}
+
+func (m *meter) Int64AsyncCounter(name string, callback metrics.Int64Callback, opts ...metrics.InstrumentOption) (metrics.AsyncInstrument, error) {
+	unit, desc := toInstrumentOpts(opts...)
+	i, err := m.otel.Int64ObservableCounter(name, otelmetric.WithUnit(unit), otelmetric.WithDescription(desc))
+	if err != nil {
+		return nil, err
+	}
+
+	return m.registerAsyncInt64(i, callback)
+}
+
+func (m *meter) Int64AsyncUpDownCounter(name string, callback metrics.Int64Callback, opts ...metrics.InstrumentOption) (metrics.AsyncInstrument, error) {
+	unit, desc := toInstrumentOpts(opts...)
+	i, err := m.otel.Int64ObservableUpDownCounter(name, otelmetric.WithUnit(unit), otelmetric.WithDescription(desc))
+	if err != nil {
+		return nil, err
+	}
+
+	return m.registerAsyncInt64(i, callback)
+}
+
+func (m *meter) Int64AsyncGauge(name string, callback metrics.Int64Callback, opts ...metrics.InstrumentOption) (metrics.AsyncInstrument, error) {
+	unit, desc := toInstrumentOpts(opts...)
+	i, err := m.otel.Int64ObservableGauge(name, otelmetric.WithUnit(unit), otelmetric.WithDescription(desc))
+	if err != nil {
+		return nil, err
+	}
+
+	return m.registerAsyncInt64(i, callback)
+}
+
+func (m *meter) Float64Counter(name string, opts ...metrics.InstrumentOption) (metrics.Float64Counter, error) {
+	unit, desc := toInstrumentOpts(opts...)
+	i, err := m.otel.Float64Counter(name, otelmetric.WithUnit(unit), otelmetric.WithDescription(desc))
+	if err != nil {
+		return nil, err
+	}
+	return &float64Counter{i}, nil
+}
+
+func (m *meter) Float64UpDownCounter(name string, opts ...metrics.InstrumentOption) (metrics.Float64UpDownCounter, error) {
+	unit, desc := toInstrumentOpts(opts...)
+	i, err := m.otel.Float64UpDownCounter(name, otelmetric.WithUnit(unit), otelmetric.WithDescription(desc))
+	if err != nil {
+		return nil, err
+	}
+	return &float64Counter{i}, nil
+}
+
+func (m *meter) Float64Gauge(name string, opts ...metrics.InstrumentOption) (metrics.Float64Gauge, error) {
+	unit, desc := toInstrumentOpts(opts...)
+	i, err := m.otel.Float64Gauge(name, otelmetric.WithUnit(unit), otelmetric.WithDescription(desc))
+	if err != nil {
+		return nil, err
+	}
+	return &float64Gauge{i}, nil
+}
+
+func (m *meter) Float64Histogram(name string, opts ...metrics.InstrumentOption) (metrics.Float64Histogram, error) {
+	unit, desc := toInstrumentOpts(opts...)
+	i, err := m.otel.Float64Histogram(name, otelmetric.WithUnit(unit), otelmetric.WithDescription(desc))
+	if err != nil {
+		return nil, err
+	}
+	return &float64Histogram{i}, nil
+}
+
+func (m *meter) Float64AsyncCounter(name string, callback metrics.Float64Callback, opts ...metrics.InstrumentOption) (metrics.AsyncInstrument, error) {
+	unit, desc := toInstrumentOpts(opts...)
+	i, err := m.otel.Float64ObservableCounter(name, otelmetric.WithUnit(unit), otelmetric.WithDescription(desc))
+	if err != nil {
+		return nil, err
+	}
+
+	return m.registerAsyncFloat64(i, callback)
+}
+
+func (m *meter) Float64AsyncUpDownCounter(name string, callback metrics.Float64Callback, opts ...metrics.InstrumentOption) (metrics.AsyncInstrument, error) {
+	unit, desc := toInstrumentOpts(opts...)
+	i, err := m.otel.Float64ObservableUpDownCounter(name, otelmetric.WithUnit(unit), otelmetric.WithDescription(desc))
+	if err != nil {
+		return nil, err
+	}
+
+	return m.registerAsyncFloat64(i, callback)
+}
+
+func (m *meter) Float64AsyncGauge(name string, callback metrics.Float64Callback, opts ...metrics.InstrumentOption) (metrics.AsyncInstrument, error) {
+	unit, desc := toInstrumentOpts(opts...)
+	i, err := m.otel.Float64ObservableGauge(name, otelmetric.WithUnit(unit), otelmetric.WithDescription(desc))
+	if err != nil {
+		return nil, err
+	}
+
+	return m.registerAsyncFloat64(i, callback)
+}
+
+func (m *meter) registerAsyncInt64(i otelmetric.Int64Observable, cb metrics.Int64Callback) (metrics.AsyncInstrument, error) {
+	r, err := m.otel.RegisterCallback(adaptInt64CB(i, cb), i)
+	if err != nil {
+		return nil, err
+	}
+
+	return &asyncInstrument{r}, nil
+}
+
+func (m *meter) registerAsyncFloat64(i otelmetric.Float64Observable, cb metrics.Float64Callback) (metrics.AsyncInstrument, error) {
+	r, err := m.otel.RegisterCallback(adaptFloat64CB(i, cb), i)
+	if err != nil {
+		return nil, err
+	}
+
+	return &asyncInstrument{r}, nil
+}

--- a/metrics/smithy-otel-metrics/option.go
+++ b/metrics/smithy-otel-metrics/option.go
@@ -1,0 +1,23 @@
+package smithyotelmetrics
+
+import (
+	"github.com/aws/smithy-go/metrics"
+	otelmetric "go.opentelemetry.io/otel/metric"
+)
+
+func toInstrumentOpts(opts ...metrics.InstrumentOption) (unit, desc string) {
+	var o metrics.InstrumentOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o.UnitLabel, o.Description
+}
+
+func withMetricProps(opts ...metrics.RecordMetricOption) otelmetric.MeasurementOption {
+	var o metrics.RecordMetricOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return otelmetric.WithAttributes(toOTELKeyValues(o.Properties)...)
+
+}

--- a/middleware/context.go
+++ b/middleware/context.go
@@ -1,0 +1,41 @@
+package middleware
+
+import "context"
+
+type (
+	serviceIDKey     struct{}
+	operationNameKey struct{}
+)
+
+// WithServiceID adds a service ID to the context, scoped to middleware stack
+// values.
+//
+// This API is called in the client runtime when bootstrapping an operation and
+// should not typically be used directly.
+func WithServiceID(parent context.Context, id string) context.Context {
+	return WithStackValue(parent, serviceIDKey{}, id)
+}
+
+// GetServiceID retrieves the service ID from the context. This is typically
+// the service shape's name from its Smithy model. Service clients for specific
+// systems (e.g. AWS SDK) may use an alternate designated value.
+func GetServiceID(ctx context.Context) string {
+	id, _ := GetStackValue(ctx, serviceIDKey{}).(string)
+	return id
+}
+
+// WithOperationName adds the operation name to the context, scoped to
+// middleware stack values.
+//
+// This API is called in the client runtime when bootstrapping an operation and
+// should not typically be used directly.
+func WithOperationName(parent context.Context, id string) context.Context {
+	return WithStackValue(parent, operationNameKey{}, id)
+}
+
+// GetOperationName retrieves the operation name from the context. This is
+// typically the operation shape's name from its Smithy model.
+func GetOperationName(ctx context.Context) string {
+	name, _ := GetStackValue(ctx, operationNameKey{}).(string)
+	return name
+}

--- a/tracing/smithy-otel-tracing/adapt.go
+++ b/tracing/smithy-otel-tracing/adapt.go
@@ -2,11 +2,8 @@ package smithyoteltracing
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/tracing"
-	otelattribute "go.opentelemetry.io/otel/attribute"
 	otelcodes "go.opentelemetry.io/otel/codes"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
@@ -140,50 +137,4 @@ func toOTELSpanStatus(v tracing.SpanStatus) otelcodes.Code {
 	default:
 		return otelcodes.Unset
 	}
-}
-
-func toOTELKeyValue(k, v any) otelattribute.KeyValue {
-	kk := str(k)
-
-	switch vv := v.(type) {
-	case bool:
-		return otelattribute.Bool(kk, vv)
-	case []bool:
-		return otelattribute.BoolSlice(kk, vv)
-	case int:
-		return otelattribute.Int(kk, vv)
-	case []int:
-		return otelattribute.IntSlice(kk, vv)
-	case int64:
-		return otelattribute.Int64(kk, vv)
-	case []int64:
-		return otelattribute.Int64Slice(kk, vv)
-	case float64:
-		return otelattribute.Float64(kk, vv)
-	case []float64:
-		return otelattribute.Float64Slice(kk, vv)
-	case string:
-		return otelattribute.String(kk, vv)
-	case []string:
-		return otelattribute.StringSlice(kk, vv)
-	default:
-		return otelattribute.String(kk, str(v))
-	}
-}
-
-func toOTELKeyValues(props smithy.Properties) []otelattribute.KeyValue {
-	var kvs []otelattribute.KeyValue
-	for k, v := range props.Values() {
-		kvs = append(kvs, toOTELKeyValue(k, v))
-	}
-	return kvs
-}
-
-func str(v any) string {
-	if s, ok := v.(string); ok {
-		return s
-	} else if s, ok := v.(fmt.Stringer); ok {
-		return s.String()
-	}
-	return fmt.Sprintf("%#v", v)
 }

--- a/tracing/smithy-otel-tracing/adapt_test.go
+++ b/tracing/smithy-otel-tracing/adapt_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/aws/smithy-go/tracing"
-	otelattribute "go.opentelemetry.io/otel/attribute"
 	otelcodes "go.opentelemetry.io/otel/codes"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
@@ -45,44 +44,6 @@ func TestToOTELSpanStatus(t *testing.T) {
 		name := fmt.Sprintf("%v -> %v", tt.In, tt.Expect)
 		t.Run(name, func(t *testing.T) {
 			actual := toOTELSpanStatus(tt.In)
-			if tt.Expect != actual {
-				t.Errorf("%v != %v", tt.Expect, actual)
-			}
-		})
-	}
-}
-
-type stringer struct{}
-
-func (s stringer) String() string {
-	return "stringer"
-}
-
-type notstringer struct{}
-
-func TestToOTELKeyValue(t *testing.T) {
-	for _, tt := range []struct {
-		K, V   any
-		Expect otelattribute.KeyValue
-	}{
-		{1, "asdf", otelattribute.String("1", "asdf")},               // non-string key
-		{"key", stringer{}, otelattribute.String("key", "stringer")}, // stringer
-		// unsupported value type
-		{"key", notstringer{}, otelattribute.String("key", "smithyoteltracing.notstringer{}")},
-		{"key", true, otelattribute.Bool("key", true)},
-		{"key", []bool{true, false}, otelattribute.BoolSlice("key", []bool{true, false})},
-		{"key", int(1), otelattribute.Int("key", 1)},
-		{"key", []int{1, 2}, otelattribute.IntSlice("key", []int{1, 2})},
-		{"key", int64(1), otelattribute.Int64("key", 1)},
-		{"key", []int64{1, 2}, otelattribute.Int64Slice("key", []int64{1, 2})},
-		{"key", float64(1), otelattribute.Float64("key", 1)},
-		{"key", []float64{1, 2}, otelattribute.Float64Slice("key", []float64{1, 2})},
-		{"key", "value", otelattribute.String("key", "value")},
-		{"key", []string{"v1", "v2"}, otelattribute.StringSlice("key", []string{"v1", "v2"})},
-	} {
-		name := fmt.Sprintf("(%v, %v) -> %v", tt.K, tt.V, tt.Expect)
-		t.Run(name, func(t *testing.T) {
-			actual := toOTELKeyValue(tt.K, tt.V)
 			if tt.Expect != actual {
 				t.Errorf("%v != %v", tt.Expect, actual)
 			}

--- a/tracing/smithy-otel-tracing/attribute.go
+++ b/tracing/smithy-otel-tracing/attribute.go
@@ -1,0 +1,67 @@
+package smithyoteltracing
+
+import (
+	"fmt"
+
+	"github.com/aws/smithy-go"
+	otelattribute "go.opentelemetry.io/otel/attribute"
+)
+
+// IMPORTANT: The contents of this file are mirrored in
+// smithyotelmetrics/attribute.go. Any changes made here must be replicated in
+// that module's copy of the file, although that will probably never happen, as
+// the set of attribute types supported by the OTEL API cannot reasonably
+// expand to include anything else that would be useful.
+//
+// This is done in order to avoid the one-way door of exposing an internal-only
+// module for what is effectively a simple value mapper (that will likely never
+// change).
+//
+// While the contents of the file are mirrored, the tests are only present
+// here.
+
+func toOTELKeyValue(k, v any) otelattribute.KeyValue {
+	kk := str(k)
+
+	switch vv := v.(type) {
+	case bool:
+		return otelattribute.Bool(kk, vv)
+	case []bool:
+		return otelattribute.BoolSlice(kk, vv)
+	case int:
+		return otelattribute.Int(kk, vv)
+	case []int:
+		return otelattribute.IntSlice(kk, vv)
+	case int64:
+		return otelattribute.Int64(kk, vv)
+	case []int64:
+		return otelattribute.Int64Slice(kk, vv)
+	case float64:
+		return otelattribute.Float64(kk, vv)
+	case []float64:
+		return otelattribute.Float64Slice(kk, vv)
+	case string:
+		return otelattribute.String(kk, vv)
+	case []string:
+		return otelattribute.StringSlice(kk, vv)
+	default:
+		return otelattribute.String(kk, str(v))
+	}
+}
+
+func toOTELKeyValues(props smithy.Properties) []otelattribute.KeyValue {
+	var kvs []otelattribute.KeyValue
+	for k, v := range props.Values() {
+		kvs = append(kvs, toOTELKeyValue(k, v))
+	}
+	return kvs
+}
+
+func str(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	} else if s, ok := v.(fmt.Stringer); ok {
+		return s.String()
+	}
+	return fmt.Sprintf("%#v", v)
+}

--- a/tracing/smithy-otel-tracing/attribute_test.go
+++ b/tracing/smithy-otel-tracing/attribute_test.go
@@ -1,0 +1,46 @@
+package smithyoteltracing
+
+import (
+	"fmt"
+	"testing"
+
+	otelattribute "go.opentelemetry.io/otel/attribute"
+)
+
+type stringer struct{}
+
+func (s stringer) String() string {
+	return "stringer"
+}
+
+type notstringer struct{}
+
+func TestToOTELKeyValue(t *testing.T) {
+	for _, tt := range []struct {
+		K, V   any
+		Expect otelattribute.KeyValue
+	}{
+		{1, "asdf", otelattribute.String("1", "asdf")},               // non-string key
+		{"key", stringer{}, otelattribute.String("key", "stringer")}, // stringer
+		// unsupported value type
+		{"key", notstringer{}, otelattribute.String("key", "smithyoteltracing.notstringer{}")},
+		{"key", true, otelattribute.Bool("key", true)},
+		{"key", []bool{true, false}, otelattribute.BoolSlice("key", []bool{true, false})},
+		{"key", int(1), otelattribute.Int("key", 1)},
+		{"key", []int{1, 2}, otelattribute.IntSlice("key", []int{1, 2})},
+		{"key", int64(1), otelattribute.Int64("key", 1)},
+		{"key", []int64{1, 2}, otelattribute.Int64Slice("key", []int64{1, 2})},
+		{"key", float64(1), otelattribute.Float64("key", 1)},
+		{"key", []float64{1, 2}, otelattribute.Float64Slice("key", []float64{1, 2})},
+		{"key", "value", otelattribute.String("key", "value")},
+		{"key", []string{"v1", "v2"}, otelattribute.StringSlice("key", []string{"v1", "v2"})},
+	} {
+		name := fmt.Sprintf("(%v, %v) -> %v", tt.K, tt.V, tt.Expect)
+		t.Run(name, func(t *testing.T) {
+			actual := toOTELKeyValue(tt.K, tt.V)
+			if tt.Expect != actual {
+				t.Errorf("%v != %v", tt.Expect, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Metrics component of #470 (and downstream https://github.com/aws/aws-sdk-go-v2/issues/1744).

* adds metrics APIs
* adds `smithy-otel-metrics` library which binds a concrete OTEL SDK meter provider to the Smithy version of the API
* adds the following operation metrics as histograms - the units are in seconds per the OTEL spec. all by default have dimensions of (service, method), additional dimensions listed in parentheses where applicable
  * `client.call.duration` - entire elapsed time of call from start to finish
  * `client.call.serialization_duration` - time elapsed to serialize request, including any http bindings
  * `client.call.deserialization_duration`- time elapsed to deserialize request, including http bindings and error deserialization
  * `client.call.resolve_identity_duration` - time elapsed to get credentials (auth scheme id)
  * `client.call.resolve_endpoint_duration` - time elapsed to execute endpoint rules to get an endpoint
  * `client.call.signing_duration` - time elapsed to sign a request (auth scheme id)
* minor tracing adjustment: switches to using package const ServiceID for rpc.service attribute rather than re-deriving in codegen