### PR TITLE
Print output when executing commands when exit code != 0

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/testutils/ExecuteCommand.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/testutils/ExecuteCommand.java
@@ -19,8 +19,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/testutils/ExecuteCommand.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/testutils/ExecuteCommand.java
@@ -19,6 +19,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
@@ -59,6 +61,7 @@ public final class ExecuteCommand {
     public void execute() throws Exception {
         int exitCode;
         Process child;
+        var output = new StringBuilder();
         try {
             var cmdArray = new String[command.size()];
             command.toArray(cmdArray);
@@ -73,12 +76,16 @@ public final class ExecuteCommand {
                     InputStreamReader(child.getErrorStream(), Charset.defaultCharset()));
 
             String s;
+            output.append("stdout: ");
             while ((s = stdOut.readLine()) != null) {
                 LOGGER.info(s);
+                output.append(s);
             }
             stdOut.close();
+            output.append(" stderr: ");
             while ((s = stdErr.readLine()) != null) {
                 LOGGER.warning(s);
+                output.append(s);
             }
             stdErr.close();
         } catch (Exception e) {
@@ -87,7 +94,7 @@ public final class ExecuteCommand {
 
         if (exitCode != 0) {
             throw new Exception("Command existed with non-zero code, " + command
-                    + ", status code: " + exitCode);
+                    + ", status code: " + exitCode + " output: " + output);
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We had an issue where we had a hard time figuring out what the error was when running a test. Test was failing with

```
> Task :smithy-go-codegen:test

GenerateStandaloneGoModuleTest > testGenerateGoModule() FAILED
    java.lang.Exception at GenerateStandaloneGoModuleTest.java:93

75 tests completed, 1 failed

> Task :smithy-go-codegen:test FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':smithy-go-codegen:test'.
> There were failing tests. See the report at: file://place/smithy-go/codegen/smithy-go-codegen/build/reports/tests/test/index.html
```

and the test report had just

```
java.lang.Exception: Command existed with non-zero code, [go1.20.14, test, -v, ./...], status code: 1
```

Since the logger does not print to the HTML result, we miss whatever was printed to stdout and stderr. With this change, the report now has

```
java.lang.Exception: Command existed with non-zero code, [go1.20.14, test, -v, ./...], status code: 1 
output: stdout:  
stderr: go: errors parsing go.mod:
/private/var/folders/lj/djm7pnwn1cn9whm2yfnvxm_m0000gr/T/software.amazon.smithy.go.codegen.GenerateStandaloneGoModuleTest326470907733827070/go.mod:5: 
unknown directive: toolchain
```

Which would have been more useful to identify what the issue was on our local tooling

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
