### PR TITLE
fix: allow empty headers on prefix headers

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -877,11 +877,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                             writer.write("hv := encoder.Headers($S)", getCanonicalHeader(locationName));
                             writer.addUseImports(SmithyGoDependency.NET_HTTP);
                             writer.openBlock("for mapKey, mapVal := range $L {", "}", operand, () -> {
-                                GoValueAccessUtils.writeIfNonZeroValue(context.getModel(), writer, valueMemberShape,
-                                        "mapVal", false, false, () -> {
-                                            writeHeaderBinding(context, valueMemberShape, "mapVal", location,
-                                                    "http.CanonicalHeaderKey(mapKey)", "hv");
-                                        });
+                                writeHeaderBinding(context, valueMemberShape, "mapVal", location,
+                                        "http.CanonicalHeaderKey(mapKey)", "hv");
                             });
                             break;
                         case LABEL:


### PR DESCRIPTION
*Issue #, if available:*
Had an issue where calling S3 with metadata with an empty value caused SDKs to not serialize the value and not send the header. This change allows prefix headers to have an empty value.

*Description of changes:*
Remove restriction of not serializing empty values for prefix headers

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
