### PR TITLE
Update string shape from synthetic to base

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/util/ShapeUtil.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/util/ShapeUtil.java
@@ -27,7 +27,7 @@ import software.amazon.smithy.model.shapes.StringShape;
 
 public final class ShapeUtil {
     public static final StringShape STRING_SHAPE = StringShape.builder()
-            .id("smithy.go.synthetic#String")
+            .id("smithy.api#String")
             .build();
 
     public static final IntegerShape INT_SHAPE = IntegerShape.builder()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While investigating an internal JMESPath expression, I noticed that it failed chaining a select at the end. After discussing it with @lucix-aws offline, this is because we had the wrong synthetic shape instead of the base one in Smithy.

Added a tests that covers this as well

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
