### PR TITLE
fixup jmespath multiselect codegen

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGenerator.java
@@ -266,9 +266,9 @@ public class GoJmespathExpressionGenerator {
             var deref = lookahead.shape instanceof CollectionShape || lookahead.shape instanceof MapShape
                     ? "" : "*"; // ...but slices/maps do not get dereferenced
             writer.write("""
-                    if $2L != nil {
-                        $1L = append($1L, $3L$2L)
-                    }""", ident, projected.ident, deref);
+                    if $1L != nil {
+                        $2L = append($2L, $3L$1L)
+                    }""", projected.ident, ident, deref);
         } else {
             writer.write("$1L = append($1L, $2L)", ident, projected.ident);
         }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGenerator.java
@@ -21,9 +21,9 @@ import static software.amazon.smithy.go.codegen.SymbolUtils.sliceOf;
 import static software.amazon.smithy.go.codegen.util.ShapeUtil.BOOL_SHAPE;
 import static software.amazon.smithy.go.codegen.util.ShapeUtil.INT_SHAPE;
 import static software.amazon.smithy.go.codegen.util.ShapeUtil.STRING_SHAPE;
-import static software.amazon.smithy.go.codegen.util.ShapeUtil.listOf;
 import static software.amazon.smithy.utils.StringUtils.capitalize;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import software.amazon.smithy.codegen.core.CodegenException;
@@ -63,6 +63,12 @@ public class GoJmespathExpressionGenerator {
     private final GoWriter writer;
 
     private int idIndex = 0;
+
+    // as we traverse an expression, we may produce intermediate "synthetic" lists - e.g. list of string, list of list
+    // of string, etc.
+    // we may need to pull the member shapes back out later, but they're not guaranteed to be in the model - so keep a
+    // shadow map of synthetic -> member to short-circuit the model lookup
+    private final Map<Shape, Shape> synthetics = new HashMap<>();
 
     public GoJmespathExpressionGenerator(GoCodegenContext ctx, GoWriter writer) {
         this.ctx = ctx;
@@ -121,8 +127,17 @@ public class GoJmespathExpressionGenerator {
         var first = items.get(0);
 
         var ident = nextIdent();
-        writer.write("$L := []$P{$L}", ident, first.type,
-                String.join(",", items.stream().map(it -> it.ident).toList()));
+        writer.write("$L := []$T{}", ident, first.type);
+        for (var item : items) {
+            if (isPointable(item.type)) {
+                writer.write("""
+                        if $2L != nil {
+                            $1L = append($1L, *$2L)
+                        }""", ident, item.ident);
+            } else {
+                writer.write("$1L = append($1L, $2L)", ident, item.ident);
+            }
+        }
 
         return new Variable(listOf(first.shape), ident, sliceOf(first.type));
     }
@@ -247,11 +262,13 @@ public class GoJmespathExpressionGenerator {
         writer.indent();
         // projected.shape is the _member_ of the resulting list
         var projected = visit(expr.getRight(), new Variable(leftMember, "v", leftSymbol));
-        if (isPointable(lookahead.type)) { // projections implicitly filter out nil evaluations of RHS
+        if (isPointable(lookahead.type)) { // projections implicitly filter out nil evaluations of RHS...
+            var deref = lookahead.shape instanceof CollectionShape || lookahead.shape instanceof MapShape
+                    ? "" : "*"; // ...but slices/maps do not get dereferenced
             writer.write("""
                     if $2L != nil {
-                        $1L = append($1L, *$2L)
-                    }""", ident, projected.ident);
+                        $1L = append($1L, $3L$2L)
+                    }""", ident, projected.ident, deref);
         } else {
             writer.write("$1L = append($1L, $2L)", ident, projected.ident);
         }
@@ -348,22 +365,22 @@ public class GoJmespathExpressionGenerator {
         return "v" + idIndex;
     }
 
+    private Shape listOf(Shape shape) {
+        var list = ShapeUtil.listOf(shape);
+        synthetics.putIfAbsent(list, shape);
+        return list;
+    }
+
     private Shape expectMember(CollectionShape shape) {
-        return switch (shape.getMember().getTarget().toString()) {
-            case "smithy.go.synthetic#StringList" -> listOf(STRING_SHAPE);
-            case "smithy.go.synthetic#IntegerList" -> listOf(INT_SHAPE);
-            case "smithy.go.synthetic#BooleanList" -> listOf(BOOL_SHAPE);
-            default -> ShapeUtil.expectMember(ctx.model(), shape);
-        };
+        return synthetics.containsKey(shape)
+                ? synthetics.get(shape)
+                : ShapeUtil.expectMember(ctx.model(), shape);
     }
 
     private Shape expectMember(MapShape shape) {
-        return switch (shape.getValue().getTarget().toString()) {
-            case "smithy.go.synthetic#StringList" -> listOf(STRING_SHAPE);
-            case "smithy.go.synthetic#IntegerList" -> listOf(INT_SHAPE);
-            case "smithy.go.synthetic#BooleanList" -> listOf(BOOL_SHAPE);
-            default -> ShapeUtil.expectMember(ctx.model(), shape);
-        };
+        return synthetics.containsKey(shape)
+                ? synthetics.get(shape)
+                : ShapeUtil.expectMember(ctx.model(), shape);
     }
 
     // helper to generate comparisons from two results, automatically handling any dereferencing in the process

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/util/ShapeUtil.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/util/ShapeUtil.java
@@ -27,15 +27,15 @@ import software.amazon.smithy.model.shapes.StringShape;
 
 public final class ShapeUtil {
     public static final StringShape STRING_SHAPE = StringShape.builder()
-            .id("smithy.api#String")
+            .id("smithy.api#PrimitiveString")
             .build();
 
     public static final IntegerShape INT_SHAPE = IntegerShape.builder()
-            .id("smithy.api#Integer")
+            .id("smithy.api#PrimitiveInteger")
             .build();
 
     public static final BooleanShape BOOL_SHAPE = BooleanShape.builder()
-            .id("smithy.api#Boolean")
+            .id("smithy.api#PrimitiveBoolean")
             .build();
 
     private ShapeUtil() {}

--- a/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGeneratorTest.java
+++ b/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGeneratorTest.java
@@ -489,7 +489,13 @@ public class GoJmespathExpressionGeneratorTest {
         assertThat(writer.toString(), Matchers.containsString("""
                 v1 := input.SimpleShape
                 v2 := input.SimpleShape2
-                v3 := []*string{v1,v2}
+                v3 := []string{}
+                if v1 != nil {
+                    v3 = append(v3, *v1)
+                }
+                if v2 != nil {
+                    v3 = append(v3, *v2)
+                }
                 """));
     }
 
@@ -510,9 +516,12 @@ public class GoJmespathExpressionGeneratorTest {
                 var v2 [][]string
                 for _, v := range v1 {
                     v3 := v.Key
-                    v4 := []*string{v3}
+                    v4 := []string{}
+                    if v3 != nil {
+                        v4 = append(v4, *v3)
+                    }
                     if v4 != nil {
-                        v2 = append(v2, *v4)
+                        v2 = append(v2, v4)
                     }
                 }
                 var v5 []string


### PR DESCRIPTION
* fix up various codegen issues w/ jmespath multiselect around shape lookup and null typing
  * remove the selective deref logic we previously had when mapping string array endpoint params in operation context param bindings - this is no longer necessary, since jmespath projection and multiselect implicitly filter nil, and string array params are `[]string`, the types will always align
* fix endpoint rules generator to not try to dereference string slices inside conditions