### PR TITLE
Fix: URI path element replace issue due to elements name overlap

### DIFF
--- a/.changelog/3efb0d073e5544c2a9b84abdab930700.json
+++ b/.changelog/3efb0d073e5544c2a9b84abdab930700.json
@@ -1,0 +1,8 @@
+{
+    "id": "3efb0d07-3e55-44c2-a9b8-4abdab930700",
+    "type": "bugfix",
+    "description": "Fix the uri path element replace issue caused by prefix overlap",
+    "modules": [
+        "."
+    ]
+}

--- a/.changelog/3efb0d073e5544c2a9b84abdab930700.json
+++ b/.changelog/3efb0d073e5544c2a9b84abdab930700.json
@@ -1,8 +1,0 @@
-{
-    "id": "3efb0d07-3e55-44c2-a9b8-4abdab930700",
-    "type": "bugfix",
-    "description": "Fix the uri path element replace issue caused by prefix overlap",
-    "modules": [
-        "."
-    ]
-}

--- a/encoding/httpbinding/path_replace.go
+++ b/encoding/httpbinding/path_replace.go
@@ -39,7 +39,6 @@ func replacePathElement(path, fieldBuf []byte, key, val string, escape bool) ([]
 
 		start = bytes.Index(path, fieldBuf)
 		if start < 0 {
-			// TODO what to do about error?
 			return path, fieldBuf, fmt.Errorf("invalid path index, start=%d. %s", start, path)
 		}
 		encodeSep = false

--- a/encoding/httpbinding/path_replace.go
+++ b/encoding/httpbinding/path_replace.go
@@ -22,6 +22,7 @@ func bufCap(b []byte, n int) []byte {
 // replacePathElement replaces a single element in the path []byte.
 // Escape is used to control whether the value will be escaped using Amazon path escape style.
 func replacePathElement(path, fieldBuf []byte, key, val string, escape bool) ([]byte, []byte, error) {
+	// search for "{<key>}". If not found, search for the greedy version "{<key>+}". If none are found, return error
 	fieldBuf = bufCap(fieldBuf, len(key)+2) // { <key> }
 	fieldBuf = append(fieldBuf, uriTokenStart)
 	fieldBuf = append(fieldBuf, key...)

--- a/encoding/httpbinding/path_replace.go
+++ b/encoding/httpbinding/path_replace.go
@@ -22,32 +22,32 @@ func bufCap(b []byte, n int) []byte {
 // replacePathElement replaces a single element in the path []byte.
 // Escape is used to control whether the value will be escaped using Amazon path escape style.
 func replacePathElement(path, fieldBuf []byte, key, val string, escape bool) ([]byte, []byte, error) {
-	fieldBuf = bufCap(fieldBuf, len(key)+3) // { <key> [+] }
+	fieldBuf = bufCap(fieldBuf, len(key)+2) // { <key> }
 	fieldBuf = append(fieldBuf, uriTokenStart)
 	fieldBuf = append(fieldBuf, key...)
+	fieldBuf = append(fieldBuf, uriTokenStop)
 
 	start := bytes.Index(path, fieldBuf)
-	end := start + len(fieldBuf)
-	if start < 0 || len(path[end:]) == 0 {
-		// TODO what to do about error?
-		return path, fieldBuf, fmt.Errorf("invalid path index, start=%d,end=%d. %s", start, end, path)
-	}
-
 	encodeSep := true
-	if path[end] == uriTokenSkip {
-		// '+' token means do not escape slashes
+	if start < 0 {
+		fieldBuf = bufCap(fieldBuf, len(key)+3) // { <key> [+] }
+		fieldBuf = append(fieldBuf, uriTokenStart)
+		fieldBuf = append(fieldBuf, key...)
+		fieldBuf = append(fieldBuf, uriTokenSkip)
+		fieldBuf = append(fieldBuf, uriTokenStop)
+
+		start = bytes.Index(path, fieldBuf)
+		if start < 0 {
+			// TODO what to do about error?
+			return path, fieldBuf, fmt.Errorf("invalid path index, start=%d. %s", start, path)
+		}
 		encodeSep = false
-		end++
 	}
+	end := start + len(fieldBuf)
 
 	if escape {
 		val = EscapePath(val, encodeSep)
 	}
-
-	if path[end] != uriTokenStop {
-		return path, fieldBuf, fmt.Errorf("invalid path element, does not contain token stop, %s", path)
-	}
-	end++
 
 	fieldBuf = bufCap(fieldBuf, len(val))
 	fieldBuf = append(fieldBuf, val...)

--- a/encoding/httpbinding/path_replace_test.go
+++ b/encoding/httpbinding/path_replace_test.go
@@ -40,6 +40,18 @@ func TestPathReplace(t *testing.T) {
 			ExpRawPath: []byte("/reallylongvaluegoesheregrowingarray/{key+}"),
 			Key:        "bucket", Val: "reallylongvaluegoesheregrowingarray",
 		},
+		{
+			Orig:       []byte("/{namespace}/{name}"),
+			ExpPath:    []byte("/{namespace}/value"),
+			ExpRawPath: []byte("/{namespace}/value"),
+			Key:        "name", Val: "value",
+		},
+		{
+			Orig:       []byte("/{name}/{namespace}"),
+			ExpPath:    []byte("/value/{namespace}"),
+			ExpRawPath: []byte("/value/{namespace}"),
+			Key:        "name", Val: "value",
+		},
 	}
 
 	var buffer [64]byte

--- a/encoding/httpbinding/path_replace_test.go
+++ b/encoding/httpbinding/path_replace_test.go
@@ -9,6 +9,7 @@ func TestPathReplace(t *testing.T) {
 	cases := []struct {
 		Orig, ExpPath, ExpRawPath []byte
 		Key, Val                  string
+		ExpectErr                 bool
 	}{
 		{
 			Orig:       []byte("/{bucket}/{key+}"),
@@ -52,6 +53,11 @@ func TestPathReplace(t *testing.T) {
 			ExpRawPath: []byte("/value/{namespace}"),
 			Key:        "name", Val: "value",
 		},
+		{
+			Orig: []byte("/{namespace}/{name+}"),
+			Key:  "nam", Val: "value",
+			ExpectErr: true,
+		},
 	}
 
 	var buffer [64]byte
@@ -62,8 +68,17 @@ func TestPathReplace(t *testing.T) {
 
 		path, _, err := replacePathElement(c.Orig, buffer[:0], c.Key, c.Val, false)
 		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
+			if !c.ExpectErr {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		} else if c.ExpectErr {
+			t.Fatalf("expect error, got none")
 		}
+
+		if c.ExpectErr {
+			return
+		}
+
 		rawPath, _, err := replacePathElement(origRaw, buffer[:0], c.Key, c.Val, true)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)


### PR DESCRIPTION
*Issue #, if available:*
fixes #552 

*Description of changes:*
Old serialization code only indexes first occurrence of target element with left bracket (e.g. `{key`) without considering common prefix cases like `{key1111}` and `{key}`. this pr fixes that by directly searching index of the whole element with the format of `{element}` or `{element+}`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
