### PR TITLE
transport/http: fix go doc typo

### DIFF
--- a/transport/http/host.go
+++ b/transport/http/host.go
@@ -69,7 +69,7 @@ func ValidPortNumber(port string) bool {
 	return true
 }
 
-// ValidHostLabel returns whether the label is a valid RFC 3986 host abel.
+// ValidHostLabel returns whether the label is a valid RFC 3986 host label.
 func ValidHostLabel(label string) bool {
 	if l := len(label); l == 0 || l > 63 {
 		return false


### PR DESCRIPTION
*Issue #, if available:*
N/a

*Description of changes:*
Fixes a small typo in the go doc of the `ValidHostLabel` function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
