### PR TITLE
transport/http: fix metrics race condition

### DIFF
--- a/.changelog/c898d340-9c15-4b9a-a5da-93a340a9d5f8.json
+++ b/.changelog/c898d340-9c15-4b9a-a5da-93a340a9d5f8.json
@@ -1,0 +1,9 @@
+{
+  "id": "c898d340-9c15-4b9a-a5da-93a340a9d5f8",
+  "type": "bugfix",
+  "collapse": true,
+  "description": "transport/http: fix metrics race condition",
+  "modules": [
+    "transport/http"
+  ]
+}

--- a/.changelog/c898d340-9c15-4b9a-a5da-93a340a9d5f8.json
+++ b/.changelog/c898d340-9c15-4b9a-a5da-93a340a9d5f8.json
@@ -1,7 +1,7 @@
 {
   "id": "c898d340-9c15-4b9a-a5da-93a340a9d5f8",
   "type": "bugfix",
-  "collapse": true,
+  "collapse": false,
   "description": "transport/http: fix metrics race condition",
   "modules": [
     "."

--- a/.changelog/c898d340-9c15-4b9a-a5da-93a340a9d5f8.json
+++ b/.changelog/c898d340-9c15-4b9a-a5da-93a340a9d5f8.json
@@ -2,7 +2,7 @@
   "id": "c898d340-9c15-4b9a-a5da-93a340a9d5f8",
   "type": "bugfix",
   "collapse": false,
-  "description": "transport/http: fix metrics race condition",
+  "description": "Fix HTTP metrics data race.",
   "modules": [
     "."
   ]

--- a/.changelog/c898d340-9c15-4b9a-a5da-93a340a9d5f8.json
+++ b/.changelog/c898d340-9c15-4b9a-a5da-93a340a9d5f8.json
@@ -4,6 +4,6 @@
   "collapse": true,
   "description": "transport/http: fix metrics race condition",
   "modules": [
-    "transport/http"
+    "."
   ]
 }


### PR DESCRIPTION
This PR fixes a race condition reported by #548,
by introducing a simple wrapper for time.Time.

While by default aws-sdk-go-v2 uses NopMeterProvider, the transport/http internals are still instrumenting the http requests (the withMetrics func).

Maybe there is a room for improvement, to not call httptrace.WithClientTrace when the meter is nop,
however this is out of scope for this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
