### PR TITLE
Change defaults when generating a client via smithy CLI

### DIFF
--- a/codegen/smithy-go-codegen-test/smithy-build.json
+++ b/codegen/smithy-go-codegen-test/smithy-build.json
@@ -6,14 +6,14 @@
             "module": "github.com/aws/smithy-go/internal/tests/service/weather",
             "moduleVersion": "0.0.1",
             "generateGoMod": true,
-            "goDirective": "1.18"
+            "goDirective": "1.21"
         },
         "go-server-codegen": {
             "service": "example.weather#Weather",
             "module": "github.com/aws/smithy-go/internal/tests/server/weather",
             "moduleVersion": "0.0.1",
             "generateGoMod": true,
-            "goDirective": "1.18"
+            "goDirective": "1.21"
         }
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoModuleInfo.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoModuleInfo.java
@@ -27,7 +27,7 @@ import software.amazon.smithy.utils.SmithyBuilder;
 
 public final class GoModuleInfo {
 
-    public static final String DEFAULT_GO_DIRECTIVE = "1.15";
+    public static final String DEFAULT_GO_DIRECTIVE = "1.21";
 
     private List<SymbolDependency> dependencies;
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoSettings.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoSettings.java
@@ -92,7 +92,7 @@ public final class GoSettings {
         settings.setModuleDescription(config.getStringMemberOrDefault(
                 MODULE_DESCRIPTION, settings.getModuleName() + " client"));
         settings.setModuleVersion(config.getStringMemberOrDefault(MODULE_VERSION, null));
-        settings.setGenerateGoMod(config.getBooleanMemberOrDefault(GENERATE_GO_MOD, false));
+        settings.setGenerateGoMod(config.getBooleanMemberOrDefault(GENERATE_GO_MOD, true));
         settings.setGoDirective(config.getStringMemberOrDefault(GO_DIRECTIVE, GoModuleInfo.DEFAULT_GO_DIRECTIVE));
         return settings;
     }


### PR DESCRIPTION
We have very old defaults currently. Update this to use our latest Go version (1.21) and add a module file, since

> The go directive sets the minimum version of Go required to use this module. Before Go 1.21, the directive was advisory only; now it is a mandatory requirement: Go toolchains refuse to use modules declaring newer Go versions.

[ref](https://go.dev/doc/modules/gomod-ref)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
