### PR TITLE
Revert "Change defaults when generating a client via smithy CLI (#558)"

### DIFF
--- a/codegen/smithy-go-codegen-test/smithy-build.json
+++ b/codegen/smithy-go-codegen-test/smithy-build.json
@@ -6,14 +6,14 @@
             "module": "github.com/aws/smithy-go/internal/tests/service/weather",
             "moduleVersion": "0.0.1",
             "generateGoMod": true,
-            "goDirective": "1.21"
+            "goDirective": "1.18"
         },
         "go-server-codegen": {
             "service": "example.weather#Weather",
             "module": "github.com/aws/smithy-go/internal/tests/server/weather",
             "moduleVersion": "0.0.1",
             "generateGoMod": true,
-            "goDirective": "1.21"
+            "goDirective": "1.18"
         }
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoModuleInfo.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoModuleInfo.java
@@ -27,7 +27,7 @@ import software.amazon.smithy.utils.SmithyBuilder;
 
 public final class GoModuleInfo {
 
-    public static final String DEFAULT_GO_DIRECTIVE = "1.21";
+    public static final String DEFAULT_GO_DIRECTIVE = "1.15";
 
     private List<SymbolDependency> dependencies;
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoSettings.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoSettings.java
@@ -92,7 +92,7 @@ public final class GoSettings {
         settings.setModuleDescription(config.getStringMemberOrDefault(
                 MODULE_DESCRIPTION, settings.getModuleName() + " client"));
         settings.setModuleVersion(config.getStringMemberOrDefault(MODULE_VERSION, null));
-        settings.setGenerateGoMod(config.getBooleanMemberOrDefault(GENERATE_GO_MOD, true));
+        settings.setGenerateGoMod(config.getBooleanMemberOrDefault(GENERATE_GO_MOD, false));
         settings.setGoDirective(config.getStringMemberOrDefault(GO_DIRECTIVE, GoModuleInfo.DEFAULT_GO_DIRECTIVE));
         return settings;
     }


### PR DESCRIPTION
This reverts commit 95ba31879b6b65f46a57f2ca510ce0ce6e860c9e.

This feature may interact in unexpected ways with existing SDK codegen, so while we figure it out we'll roll back these changes. They will be re-applied later.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
