### PR TITLE
add missing waiter retry breakout on non-nil non-matched error

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/Waiters.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/Waiters.java
@@ -670,6 +670,7 @@ public class Waiters implements GoIntegration {
                     });
 
                     writer.write("");
+                    writer.write("if err != nil { return false, err }");
                     writer.write("return true, nil");
                 });
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/Waiters2.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/Waiters2.java
@@ -649,6 +649,7 @@ public class Waiters2 implements GoIntegration {
                     });
 
                     writer.write("");
+                    writer.write("if err != nil { return false, err }");
                     writer.write("return true, nil");
                 });
     }


### PR DESCRIPTION
Needed for https://github.com/aws/aws-sdk-go-v2/issues/2937

From [waiter workflow](https://smithy.io/2.0/additional-specs/waiters.html#waiter-workflow) step 4:

> If none of the acceptors are matched and an error was encountered while calling the operation, then transition to the failure state and stop waiting.

Our implementation, for reasons probably lost to time, omits this step, causing waiters to spin longer than they should. This change adds that missing behavior.