### PR TITLE
coerce nil numbers to 0 in jmespath codegen

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGenerator.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.go.codegen;
 
+import static software.amazon.smithy.go.codegen.GoWriter.emptyGoTemplate;
 import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
 import static software.amazon.smithy.go.codegen.SymbolUtils.isNilable;
 import static software.amazon.smithy.go.codegen.SymbolUtils.isPointable;
@@ -407,8 +408,30 @@ public class GoJmespathExpressionGenerator {
             return goTemplate("$1L := $5L($2L) $4L $5L($3L)", ident, left.ident, right.ident, cmp, cast);
         }
 
+        // undocumented jmespath behavior: null in numeric comparisons coerces to 0
+        // this means the subsequent nil checks for numerics are moot, but it's either this or branch the codegen even
+        // further for questionable benefit
+        var nilCoerceLeft = emptyGoTemplate();
+        var nilCoerceRight = emptyGoTemplate();
+        if (isLPtr && left.shape instanceof NumberShape) {
+            nilCoerceLeft = goTemplate("""
+                    if ($1L == nil) {
+                        $1L = new($2T)
+                        *$1L = 0
+                    }""", left.ident, left.type);
+        }
+        if (isRPtr && right.shape instanceof NumberShape) {
+            nilCoerceRight = goTemplate("""
+                    if ($1L == nil) {
+                        $1L = new($2T)
+                        *$1L = 0
+                    }""", right.ident, right.type);
+        }
+
         return goTemplate("""
                  var $ident:L bool
+                 $nilCoerceLeft:W
+                 $nilCoerceRight:W
                  if $lif:L $amp:L $rif:L {
                      $ident:L = $cast:L($lhs:L) $cmp:L $cast:L($rhs:L)
                  }""",
@@ -420,7 +443,9 @@ public class GoJmespathExpressionGenerator {
                         "cmp", cmp,
                         "lhs", isLPtr ? "*" + left.ident : left.ident,
                         "rhs", isRPtr ? "*" + right.ident : right.ident,
-                        "cast", cast
+                        "cast", cast,
+                        "nilCoerceLeft", nilCoerceLeft,
+                        "nilCoerceRight", nilCoerceRight
                 ));
     }
 

--- a/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGeneratorTest.java
+++ b/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGeneratorTest.java
@@ -608,4 +608,50 @@ public class GoJmespathExpressionGeneratorTest {
                 }
                 """));
     }
+
+    @Test
+    public void testEqualBothNullable() {
+        var expr = "nullableIntegerA == nullableIntegerB";
+
+        var writer = testWriter();
+        var generator = new GoJmespathExpressionGenerator(testContext(), writer);
+        var actual = generator.generate(JmespathExpression.parse(expr), new GoJmespathExpressionGenerator.Variable(
+                TEST_MODEL.expectShape(ShapeId.from("smithy.go.test#Struct")),
+                "input"
+        ));
+        assertThat(actual.shape().toShapeId().toString(), Matchers.equalTo("smithy.api#PrimitiveBoolean"));
+        assertThat(actual.ident(), Matchers.equalTo("v3"));
+        assertThat(writer.toString(), Matchers.containsString("""
+                v1 := input.NullableIntegerA
+                v2 := input.NullableIntegerB
+                var v3 bool
+
+                if v1 != nil && v2 != nil {
+                    v3 = int64(*v1) == int64(*v2)
+                }else { v3 = v1 == nil && v2 == nil }
+                """));
+    }
+
+    @Test
+    public void testNotEqualBothNullable() {
+        var expr = "nullableIntegerA != nullableIntegerB";
+
+        var writer = testWriter();
+        var generator = new GoJmespathExpressionGenerator(testContext(), writer);
+        var actual = generator.generate(JmespathExpression.parse(expr), new GoJmespathExpressionGenerator.Variable(
+                TEST_MODEL.expectShape(ShapeId.from("smithy.go.test#Struct")),
+                "input"
+        ));
+        assertThat(actual.shape().toShapeId().toString(), Matchers.equalTo("smithy.api#PrimitiveBoolean"));
+        assertThat(actual.ident(), Matchers.equalTo("v3"));
+        assertThat(writer.toString(), Matchers.containsString("""
+                v1 := input.NullableIntegerA
+                v2 := input.NullableIntegerB
+                var v3 bool
+
+                if v1 != nil && v2 != nil {
+                    v3 = int64(*v1) != int64(*v2)
+                }else { v3 = (v1 == nil && v2 != nil) || (v1 != nil && v2 == nil) }
+                """));
+    }
 }

--- a/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGeneratorTest.java
+++ b/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGeneratorTest.java
@@ -379,7 +379,7 @@ public class GoJmespathExpressionGeneratorTest {
 
                 if v2 != nil && v4 != nil {
                     v5 = string(*v2) == string(*v4)
-                }
+                }else { v5 = v2 == nil && v4 == nil }
                 """));
     }
 
@@ -553,7 +553,7 @@ public class GoJmespathExpressionGeneratorTest {
     }
 
     @Test
-    public void testComparatorNumberCoercesLeftNullable() {
+    public void testOrderComparatorNumberCoercesLeftNullable() {
         var expr = "nullableIntegerA > `9`";
 
         var writer = testWriter();
@@ -580,7 +580,7 @@ public class GoJmespathExpressionGeneratorTest {
     }
 
     @Test
-    public void testComparatorNumberCoercesBothNullable() {
+    public void testOrderComparatorNumberCoercesBothNullable() {
         var expr = "nullableIntegerA > nullableIntegerB";
 
         var writer = testWriter();

--- a/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGeneratorTest.java
+++ b/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGeneratorTest.java
@@ -43,6 +43,8 @@ public class GoJmespathExpressionGeneratorTest {
                 objectList: ObjectList
                 objectMap: ObjectMap
                 nested: NestedStruct
+                nullableIntegerA: Integer
+                nullableIntegerB: Integer
             }
 
             structure Object {
@@ -318,6 +320,7 @@ public class GoJmespathExpressionGeneratorTest {
                 }
                 v4 := "foo"
                 var v5 bool
+
                 if v2 != nil   {
                     v5 = string(*v2) == string(v4)
                 }
@@ -345,6 +348,7 @@ public class GoJmespathExpressionGeneratorTest {
                     v3 = v4
                 }
                 var v5 bool
+
                 if   v3 != nil {
                     v5 = string(v1) == string(*v3)
                 }
@@ -372,6 +376,7 @@ public class GoJmespathExpressionGeneratorTest {
                 }
                 v4 := input.SimpleShape
                 var v5 bool
+
                 if v2 != nil && v4 != nil {
                     v5 = string(*v2) == string(*v4)
                 }
@@ -543,6 +548,63 @@ public class GoJmespathExpressionGeneratorTest {
                 var v5 []string
                 for _, v := range v2 {
                     v5 = append(v5, v...)
+                }
+                """));
+    }
+
+    @Test
+    public void testComparatorNumberCoercesLeftNullable() {
+        var expr = "nullableIntegerA > `9`";
+
+        var writer = testWriter();
+        var generator = new GoJmespathExpressionGenerator(testContext(), writer);
+        var actual = generator.generate(JmespathExpression.parse(expr), new GoJmespathExpressionGenerator.Variable(
+                TEST_MODEL.expectShape(ShapeId.from("smithy.go.test#Struct")),
+                "input"
+        ));
+        assertThat(actual.shape().toShapeId().toString(), Matchers.equalTo("smithy.api#PrimitiveBoolean"));
+        assertThat(actual.ident(), Matchers.equalTo("v3"));
+        assertThat(writer.toString(), Matchers.containsString("""
+                v1 := input.NullableIntegerA
+                v2 := 9
+                var v3 bool
+                if (v1 == nil) {
+                    v1 = new(int32)
+                    *v1 = 0
+                }
+
+                if v1 != nil   {
+                    v3 = int64(*v1) > int64(v2)
+                }
+                """));
+    }
+
+    @Test
+    public void testComparatorNumberCoercesBothNullable() {
+        var expr = "nullableIntegerA > nullableIntegerB";
+
+        var writer = testWriter();
+        var generator = new GoJmespathExpressionGenerator(testContext(), writer);
+        var actual = generator.generate(JmespathExpression.parse(expr), new GoJmespathExpressionGenerator.Variable(
+                TEST_MODEL.expectShape(ShapeId.from("smithy.go.test#Struct")),
+                "input"
+        ));
+        assertThat(actual.shape().toShapeId().toString(), Matchers.equalTo("smithy.api#PrimitiveBoolean"));
+        assertThat(actual.ident(), Matchers.equalTo("v3"));
+        assertThat(writer.toString(), Matchers.containsString("""
+                v1 := input.NullableIntegerA
+                v2 := input.NullableIntegerB
+                var v3 bool
+                if (v1 == nil) {
+                    v1 = new(int32)
+                    *v1 = 0
+                }
+                if (v2 == nil) {
+                    v2 = new(int32)
+                    *v2 = 0
+                }
+                if v1 != nil && v2 != nil {
+                    v3 = int64(*v1) > int64(*v2)
                 }
                 """));
     }


### PR DESCRIPTION
There's an undocumented quirk in jmespath (as far as i could [find](https://jmespath.org/specification.html)) where `nil` numerics are coerced to 0 for order comparison.

e.g.

<img width="1002" alt="image" src="https://github.com/user-attachments/assets/2a18055a-94df-48b3-833a-a1b7b3b53aa6" />
<img width="990" alt="image" src="https://github.com/user-attachments/assets/c9231759-ed1f-4ba7-a52a-c97a59a90ab7" />
<img width="950" alt="image" src="https://github.com/user-attachments/assets/efc9846d-4a68-4bc5-bbf8-40a5bb596687" />

This fixes that in codegen. We caught this while attempting to turn on generated jmespath waiters for `autoscaling` in the Go SDK. This will be further verified when those changes are pulled in there.