### PR TITLE
Fix for #1697

### DIFF
--- a/.changelog/8206b4c7-5e21-4471-9b3c-a1da254fedaf.json
+++ b/.changelog/8206b4c7-5e21-4471-9b3c-a1da254fedaf.json
@@ -1,0 +1,9 @@
+{
+  "id": "8206b4c7-5e21-4471-9b3c-a1da254fedaf",
+  "type": "bugfix",
+  "collapse": false,
+  "description": "Fix context.Context with deadline and timeout.",
+  "modules": [
+    "."
+  ]
+}

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -98,6 +98,7 @@ func (c ClientHandler) Handle(ctx context.Context, input interface{}) (
 			Body:   http.NoBody,
 		}
 	}
+
 	if err != nil {
 		err = &RequestSendError{Err: err}
 
@@ -106,6 +107,13 @@ func (c ClientHandler) Handle(ctx context.Context, input interface{}) (
 		case <-ctx.Done():
 			err = &smithy.CanceledError{Err: ctx.Err()}
 		default:
+		}
+
+	} else {
+
+		// Even if there is no error, we're checking context has timed out
+		if ctx.Err() != nil {
+			err = &smithy.CanceledError{Err: ctx.Err()}
 		}
 	}
 


### PR DESCRIPTION
DynamoDB: Using context.WithDeadline to set a timeout hides helpful errors.

Fixes [#1697](https://github.com/aws/aws-sdk-go-v2/issues/1697) for all clients.