### PR TITLE
Update identity test to not rely on comparing pointers to zero-sized objects

### DIFF
--- a/transport/http/identity_test.go
+++ b/transport/http/identity_test.go
@@ -3,16 +3,15 @@ package http
 import (
 	"context"
 	"testing"
-	smithy "github.com/aws/smithy-go"
+
+	"github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/auth"
 )
 
 func TestIdentity(t *testing.T) {
-	var expected auth.Identity = &auth.AnonymousIdentity{}
-
 	resolver := auth.AnonymousIdentityResolver{}
-	actual, _ := resolver.GetIdentity(context.TODO(), smithy.Properties{})
-	if expected != actual {
-		t.Errorf("Anonymous identity resolver does not produce correct identity")
+	identity, _ := resolver.GetIdentity(context.TODO(), smithy.Properties{})
+	if _, ok := identity.(*auth.AnonymousIdentity); !ok {
+		t.Errorf("Anonymous identity resolver does not produce correct identity, expected it to be of type auth.AnonymousIdentity")
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*
#568 

*Description of changes:*
Changes coming to Go 1.25 may break existing tests (see issue for more details) Updating how we do comparisons in the test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
