### PR TITLE
Run vet and unit-race tests on GH runner instead of plain test

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,4 +23,4 @@ jobs:
         go-version: ${{ matrix.go-version }}
 
     - name: Test
-      run: go test -v ./...
+      run: make unit-race

--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,10 @@ cover:
 .PHONY: unit unit-race unit-test unit-race-test
 
 unit: verify
-	go vet ${BUILD_TAGS} --all ./... && \
 	go test ${BUILD_TAGS} ${RUN_NONE} ./... && \
 	go test -timeout=1m ${UNIT_TEST_TAGS} ./...
 
 unit-race: verify
-	go vet ${BUILD_TAGS} --all ./... && \
 	go test ${BUILD_TAGS} ${RUN_NONE} ./... && \
 	go test -timeout=1m ${UNIT_TEST_TAGS} -race -cpu=4 ./...
 

--- a/document/cbor/decode.go
+++ b/document/cbor/decode.go
@@ -48,7 +48,7 @@ func (d *decoder) Decode(v cbor.Value, to interface{}) error {
 
 	rv := reflect.ValueOf(to)
 	if rv.Kind() != reflect.Ptr || rv.IsNil() || !rv.IsValid() {
-		return &document.InvalidUnmarshalError{reflect.TypeOf(to)}
+		return &document.InvalidUnmarshalError{Type: reflect.TypeOf(to)}
 	}
 
 	return d.decode(v, rv, serde.Tag{})

--- a/document/cbor/encode.go
+++ b/document/cbor/encode.go
@@ -145,7 +145,7 @@ func (e *encoder) encodeMap(rv reflect.Value) (cbor.Map, error) {
 	for _, key := range rv.MapKeys() {
 		keyName := fmt.Sprint(key.Interface())
 		if keyName == "" {
-			return nil, &document.InvalidMarshalError{"map key cannot be empty"}
+			return nil, &document.InvalidMarshalError{Message: "map key cannot be empty"}
 		}
 
 		cv, err := e.encode(rv.MapIndex(key), serde.Tag{})


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Noticed that our current runner just executes `go test`. We have a makefile that runs go vet and test with the race flag. We should use that. This change

* Change GH runner to run `make unit-race`
* Fixes couple issues pointed by `vet`
* Remove redundant run of `go vet` since it's already covered by depending on `verify` target

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
