### PR TITLE
Add a check for Gradle daemon status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ smithy-clean:
 GRADLE_RETRIES := 3
 GRADLE_SLEEP := 2
 
+# We're making a call to ./gradlew to trigger downloading Gradle and
+# starting the daemon. Any call works, so using `./gradlew help`
 ensure-gradle-up:
 	@cd codegen && for i in $(shell seq 1 $(GRADLE_RETRIES)); do \
 		echo "Checking if Gradle daemon is up, attempt $$i..."; \

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,22 @@ smithy-build:
 smithy-clean:
 	cd codegen && ./gradlew clean
 
+GRADLE_RETRIES := 3
+GRADLE_SLEEP := 2
+
+ensure-gradle-up:
+	@cd codegen && for i in $(shell seq 1 $(GRADLE_RETRIES)); do \
+		echo "Checking if Gradle daemon is up, attempt $$i..."; \
+		if ./gladlew help; then \
+			echo "Gradle daemon is up!"; \
+			exit 0; \
+		fi; \
+		echo "Failed to start Gradle, retrying in $(GRADLE_SLEEP) seconds..."; \
+		sleep $(GRADLE_SLEEP); \
+	done; \
+	echo "Failed to start Gradle after $(GRADLE_RETRIES) attempts."; \
+	exit 1
+
 ##################
 # Linting/Verify #
 ##################

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ GRADLE_SLEEP := 2
 ensure-gradle-up:
 	@cd codegen && for i in $(shell seq 1 $(GRADLE_RETRIES)); do \
 		echo "Checking if Gradle daemon is up, attempt $$i..."; \
-		if ./gladlew help; then \
+		if ./gradlew help; then \
 			echo "Gradle daemon is up!"; \
 			exit 0; \
 		fi; \


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
We've had some issues on our CI where the connection to Gradle gets killed. Adding a check to ensure the daemon is up. Will add this to our CI scripts

Ensured that this works by creating a `fail.sh` script that return 1 and ensuring that we wait the expected time and fail when invoking it

> why not only call `gradle status`?

Invoking just `gradle` can invoke a different version of Gradle than what we have on the wrapper

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
