### PR TITLE
Close cbor serde timers to accurately measure middleware timing

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/DeserializeResponseMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/DeserializeResponseMiddleware.java
@@ -78,6 +78,8 @@ public abstract class DeserializeResponseMiddleware implements GoWriter.Writable
 
                 $deserialize:W
 
+                endTimer()
+                span.End()
                 return out, metadata, nil
                 """,
                 MapUtils.of(

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/SerializeRequestMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/SerializeRequestMiddleware.java
@@ -82,6 +82,9 @@ public abstract class SerializeRequestMiddleware implements GoWriter.Writable {
 
                 $serialize:W
 
+                endTimer()
+                span.End()
+
                 return next.HandleSerialize(ctx, in)
                 """,
                 MapUtils.of(


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Similar to how we do on other [protocol generators](https://github.com/aws/smithy-go/blob/e6338ca9b5ee30c6317ea908173a369a9d3eb236/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java#L363), we should manually close the serialization timers after we're done with serde. Otherwise, the timer will only be closed after the `defer` statement, which will happen after ALL the middleware has run.

`endTimer()` has a guard against being called multiple times and will only take the first value, so it's fine to add a manual call [ref](https://github.com/aws/smithy-go/blob/b17b84403740243c69345be7cd349d057ce6cbd3/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/OperationMetricsStruct.java#L166)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
