### PR TITLE
Move CBOR deserialization timers to AFTER calling middleware.Next

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/DeserializeResponseMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/DeserializeResponseMiddleware.java
@@ -62,11 +62,13 @@ public abstract class DeserializeResponseMiddleware implements GoWriter.Writable
 
     private GoWriter.Writable generateHandleDeserialize() {
         return goTemplate("""
+                out, metadata, err = next.HandleDeserialize(ctx, in)
+
                 _, span := $startSpan:T(ctx, "OperationDeserializer")
                 endTimer := startMetricTimer(ctx, "client.call.deserialization_duration")
                 defer endTimer()
                 defer span.End()
-                out, metadata, err = next.HandleDeserialize(ctx, in)
+
                 if err != nil {
                     return out, metadata, err
                 }
@@ -78,8 +80,6 @@ public abstract class DeserializeResponseMiddleware implements GoWriter.Writable
 
                 $deserialize:W
 
-                endTimer()
-                span.End()
                 return out, metadata, nil
                 """,
                 MapUtils.of(


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Followup to #578
Deserialization timers were being called before we called `middleware.Next`, meaning that all middleware had to be invoked before we started the deserialization timers. This inflates the deserialization to take almost as long as the whole request.

This is already how this works on other protocols, see [existing code](https://github.com/aws/aws-sdk-go-v2/blob/6e064fa4372d87aabe78e74bc76ffda4445646d2/service/s3/deserializers.go#L50)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
