### PR TITLE
upgrade smithy, correct serialization of empty-prefix httpPrefixHeaders

### DIFF
--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,2 +1,2 @@
-smithyVersion=1.52.1
+smithyVersion=1.58.0
 smithyGradleVersion=0.7.0

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -862,6 +862,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                             writeHeaderBinding(context, memberShape, operand, location, "locationName", "encoder");
                             break;
                         case PREFIX_HEADERS:
+                            // the prefix is allowed to be empty for headers, this simply means that there is none
+                            // and map keys are used directly as headers
+                            var prefix = binding.getLocationName();
+
                             MemberShape valueMemberShape = model.expectShape(targetShape.getId(),
                                     MapShape.class).getValue();
                             Shape valueMemberTarget = model.expectShape(valueMemberShape.getTarget());
@@ -872,7 +876,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                                         + valueMemberShape.getId());
                             }
 
-                            writer.write("hv := encoder.Headers($S)", getCanonicalHeader(locationName));
+                            writer.write("hv := encoder.Headers($S)", getCanonicalHeader(prefix));
                             writer.addUseImports(SmithyGoDependency.NET_HTTP);
                             writer.openBlock("for mapKey, mapVal := range $L {", "}", operand, () -> {
                                 writeHeaderBinding(context, valueMemberShape, "mapVal", location,


### PR DESCRIPTION
Pulls our version of smithy up to the current.

In smithy 1.56.0 there was an update to the HTTP binding protocol spec to allow an empty prefix in `@httpPrefixHeaders`. This patch includes a code generator update to account for that as there are now protocol tests that verify that behavior.

Verified downstream that the protocol tests pass after regeneration.