### PR TITLE
add go-shape-codegen plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This repository implements the following Smithy build plugins:
 |----|------------|-------------|
 | `go-codegen`        | `software.amazon.smithy.go:smithy-go-codegen` | Implements Go client code generation for Smithy models. |
 | `go-server-codegen` | `software.amazon.smithy.go:smithy-go-codegen` | Implements Go server code generation for Smithy models. |
+| `go-shape-codegen` | `software.amazon.smithy.go:smithy-go-codegen` | Implements Go shape code generation (types only) for Smithy models. |
 
 **NOTE: Build plugins are not currently published to mavenCentral. You must publish to mavenLocal to make the build plugins visible to the Smithy CLI. The artifact version is currently fixed at 0.1.0.**
 
@@ -84,6 +85,10 @@ example created from `smithy init`:
 ```
 
 ## `go-server-codegen`
+
+This plugin is a work-in-progress and is currently undocumented.
+
+## `go-shape-codegen`
 
 This plugin is a work-in-progress and is currently undocumented.
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeCodegenPlugin.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeCodegenPlugin.java
@@ -1,0 +1,16 @@
+package software.amazon.smithy.go.codegen;
+
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.build.SmithyBuildPlugin;
+
+public class ShapeCodegenPlugin implements SmithyBuildPlugin {
+    @Override
+    public String getName() {
+        return "go-shape-codegen";
+    }
+
+    @Override
+    public void execute(PluginContext context) {
+        AbstractDirectedCodegen.run(context, new ShapeDirectedCodegen());
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeDirectedCodegen.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ShapeDirectedCodegen.java
@@ -1,0 +1,10 @@
+package software.amazon.smithy.go.codegen;
+
+import software.amazon.smithy.codegen.core.directed.GenerateServiceDirective;
+
+public class ShapeDirectedCodegen extends AbstractDirectedCodegen {
+    @Override
+    public void generateService(GenerateServiceDirective<GoCodegenContext, GoSettings> directive) {
+        // pass
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/server/ServerCodegenPlugin.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/server/ServerCodegenPlugin.java
@@ -19,6 +19,7 @@ import java.util.logging.Logger;
 import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.build.SmithyBuildPlugin;
 import software.amazon.smithy.codegen.core.directed.CodegenDirector;
+import software.amazon.smithy.go.codegen.AbstractDirectedCodegen;
 import software.amazon.smithy.go.codegen.GoCodegenContext;
 import software.amazon.smithy.go.codegen.GoSettings;
 import software.amazon.smithy.go.codegen.GoWriter;
@@ -61,27 +62,6 @@ public final class ServerCodegenPlugin implements SmithyBuildPlugin {
     }
 
     private void generate(PluginContext context) {
-        CodegenDirector<GoWriter,
-                GoIntegration,
-                GoCodegenContext,
-                GoSettings> runner = new CodegenDirector<>();
-
-        runner.model(context.getModel());
-        runner.directedCodegen(new ServerDirectedCodegen());
-
-        runner.integrationClass(GoIntegration.class);
-
-        runner.fileManifest(context.getFileManifest());
-
-        GoSettings settings = runner.settings(GoSettings.class,
-                context.getSettings());
-
-        runner.service(settings.getService());
-
-        runner.performDefaultCodegenTransforms();
-        runner.createDedicatedInputsAndOutputs();
-        runner.changeStringEnumsToEnumShapes(false);
-
-        runner.run();
+        AbstractDirectedCodegen.run(context, new ServerDirectedCodegen());
     }
 }

--- a/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.build.SmithyBuildPlugin
+++ b/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.build.SmithyBuildPlugin
@@ -1,2 +1,3 @@
 software.amazon.smithy.go.codegen.GoCodegenPlugin
 software.amazon.smithy.go.codegen.server.ServerCodegenPlugin
+software.amazon.smithy.go.codegen.ShapeCodegenPlugin


### PR DESCRIPTION
Base plugin for shape codegen, which is basically just client/server codegen without the service/operations. Doesn't affect the generated output of the downstream SDK at all.

Related to #571 but doesn't really close it.