### PR TITLE
Added support for SIG4/SIGV4A querystring authentication.

### DIFF
--- a/aws-http-auth/internal/v4/signer.go
+++ b/aws-http-auth/internal/v4/signer.go
@@ -58,7 +58,7 @@ func (s *Signer) Do() error {
 	// Build canonical headers first to get signedHeaders
 	canonHeaders, signedHeaders := s.buildCanonicalHeaders()
 
-	SignatureType v4.SignatureType
+	if s.SignatureType == v4.SignatureTypeQueryString {
 		s.addSignatureParametersToQuery(signedHeaders)
 	}
 
@@ -69,7 +69,7 @@ func (s *Signer) Do() error {
 		return err
 	}
 
-	SignatureType v4.SignatureType
+	if s.SignatureType == v4.SignatureTypeQueryString {
 		s.addSignatureToQuery(signature, signedHeaders)
 	} else {
 		s.Request.Header.Set("Authorization",
@@ -123,7 +123,7 @@ func (s *Signer) setRequiredHeaders() {
 	s.Request.Header.Set("Host", s.Request.Host)
 
 	// X-Amz-Date and X-Amz-Security-Token are only set as headers when using
-	SignatureType v4.SignatureType
+	if s.SignatureType == v4.SignatureTypeHeader {
 		s.Request.Header.Set("X-Amz-Date", s.Time.Format(TimeFormat))
 		if len(s.Credentials.SessionToken) > 0 {
 			s.Request.Header.Set("X-Amz-Security-Token", s.Credentials.SessionToken)

--- a/aws-http-auth/internal/v4/signer.go
+++ b/aws-http-auth/internal/v4/signer.go
@@ -33,6 +33,8 @@ type Signer struct {
 	Algorithm       string
 	CredentialScope string
 	Finalizer       Finalizer
+
+	SignatureType v4.SignatureType
 }
 
 // Finalizer performs the final step in v4 signing, deriving a signature for
@@ -53,15 +55,26 @@ func (s *Signer) Do() error {
 
 	s.setRequiredHeaders()
 
-	canonicalRequest, signedHeaders := s.buildCanonicalRequest()
+	// Build canonical headers first to get signedHeaders
+	canonHeaders, signedHeaders := s.buildCanonicalHeaders()
+
+	SignatureType v4.SignatureType
+		s.addSignatureParametersToQuery(signedHeaders)
+	}
+
+	canonicalRequest := s.buildCanonicalRequestWithHeaders(canonHeaders, signedHeaders)
 	stringToSign := s.buildStringToSign(canonicalRequest)
 	signature, err := s.Finalizer.SignString(stringToSign)
 	if err != nil {
 		return err
 	}
 
-	s.Request.Header.Set("Authorization",
-		s.buildAuthorizationHeader(signature, signedHeaders))
+	SignatureType v4.SignatureType
+		s.addSignatureToQuery(signature, signedHeaders)
+	} else {
+		s.Request.Header.Set("Authorization",
+			s.buildAuthorizationHeader(signature, signedHeaders))
+	}
 
 	return nil
 }
@@ -108,20 +121,32 @@ func (s *Signer) setRequiredHeaders() {
 	headers := s.Request.Header
 
 	s.Request.Header.Set("Host", s.Request.Host)
-	s.Request.Header.Set("X-Amz-Date", s.Time.Format(TimeFormat))
 
-	if len(s.Credentials.SessionToken) > 0 {
-		s.Request.Header.Set("X-Amz-Security-Token", s.Credentials.SessionToken)
+	// X-Amz-Date and X-Amz-Security-Token are only set as headers when using
+	SignatureType v4.SignatureType
+		s.Request.Header.Set("X-Amz-Date", s.Time.Format(TimeFormat))
+		if len(s.Credentials.SessionToken) > 0 {
+			s.Request.Header.Set("X-Amz-Security-Token", s.Credentials.SessionToken)
+		}
+	} else {
+		// For query string auth, ensure these headers are not present
+		s.Request.Header.Del("X-Amz-Date")
+		s.Request.Header.Del("X-Amz-Security-Token")
 	}
+
 	if len(s.PayloadHash) > 0 && s.Options.AddPayloadHashHeader {
 		headers.Set("X-Amz-Content-Sha256", payloadHashString(s.PayloadHash))
 	}
 }
 
 func (s *Signer) buildCanonicalRequest() (string, string) {
+	canonHeaders, signedHeaders := s.buildCanonicalHeaders()
+	canonicalRequest := s.buildCanonicalRequestWithHeaders(canonHeaders, signedHeaders)
+	return canonicalRequest, signedHeaders
+}
+
+func (s *Signer) buildCanonicalRequestWithHeaders(canonHeaders, signedHeaders string) string {
 	canonPath := s.Request.URL.EscapedPath()
-	// https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html:
-	// if input has no path, "/" is used
 	if len(canonPath) == 0 {
 		canonPath = "/"
 	}
@@ -135,8 +160,6 @@ func (s *Signer) buildCanonicalRequest() (string, string) {
 	}
 	canonQuery := strings.Replace(query.Encode(), "+", "%20", -1)
 
-	canonHeaders, signedHeaders := s.buildCanonicalHeaders()
-
 	req := strings.Join([]string{
 		s.Request.Method,
 		canonPath,
@@ -146,7 +169,7 @@ func (s *Signer) buildCanonicalRequest() (string, string) {
 		payloadHashString(s.PayloadHash),
 	}, "\n")
 
-	return req, signedHeaders
+	return req
 }
 
 func (s *Signer) buildCanonicalHeaders() (canon, signed string) {
@@ -201,6 +224,28 @@ func (s *Signer) buildAuthorizationHeader(signature, headers string) string {
 		s.Credentials.AccessKeyID+"/"+s.CredentialScope,
 		headers,
 		signature)
+}
+
+func (s *Signer) addSignatureParametersToQuery(signedHeaders string) {
+	query := s.Request.URL.Query()
+	query.Set("X-Amz-Algorithm", s.Algorithm)
+	query.Set("X-Amz-Credential", s.Credentials.AccessKeyID+"/"+s.CredentialScope)
+	query.Set("X-Amz-Date", s.Time.Format(TimeFormat))
+	query.Set("X-Amz-SignedHeaders", signedHeaders)
+
+	if len(s.Credentials.SessionToken) > 0 {
+		query.Set("X-Amz-Security-Token", s.Credentials.SessionToken)
+	}
+
+	s.Request.URL.RawQuery = query.Encode()
+}
+
+func (s *Signer) addSignatureToQuery(signature, signedHeaders string) {
+	query := s.Request.URL.Query()
+	query.Set("X-Amz-SignedHeaders", signedHeaders)
+	query.Set("X-Amz-Signature", signature)
+
+	s.Request.URL.RawQuery = query.Encode()
 }
 
 func payloadHashString(p []byte) string {

--- a/aws-http-auth/internal/v4/signer.go
+++ b/aws-http-auth/internal/v4/signer.go
@@ -122,7 +122,7 @@ func (s *Signer) setRequiredHeaders() {
 
 	s.Request.Header.Set("Host", s.Request.Host)
 
-	// X-Amz-Date and X-Amz-Security-Token are only set as headers when using
+	// X-Amz-Date and X-Amz-Security-Token are only set as headers when using a header signature type
 	if s.SignatureType == v4.SignatureTypeHeader {
 		s.Request.Header.Set("X-Amz-Date", s.Time.Format(TimeFormat))
 		if len(s.Credentials.SessionToken) > 0 {

--- a/aws-http-auth/internal/v4/signer_test.go
+++ b/aws-http-auth/internal/v4/signer_test.go
@@ -49,7 +49,7 @@ func TestQueryStringAuth_IncludesSignedHeadersInCanonicalRequest(t *testing.T) {
 		Algorithm:            "AWS4-HMAC-SHA256",
 		CredentialScope:      "20240101/us-east-1/service/aws4_request",
 		Finalizer:            identityFinalizer{},
-	SignatureType: v4.SignatureTypeQueryString,
+		SignatureType: v4.SignatureTypeQueryString,
 	}
 
 	err = s.Do()
@@ -92,7 +92,7 @@ func TestQueryStringAuth_WithSessionToken(t *testing.T) {
 		Algorithm:            "AWS4-HMAC-SHA256",
 		CredentialScope:      "20240101/us-east-1/service/aws4_request",
 		Finalizer:            identityFinalizer{},
-	SignatureType: v4.SignatureTypeQueryString,
+		SignatureType: v4.SignatureTypeQueryString,
 	}
 
 	err = s.Do()
@@ -128,7 +128,7 @@ func TestQueryStringAuth_WithRegionSet(t *testing.T) {
 		Algorithm:            "AWS4-ECDSA-P256-SHA256",
 		CredentialScope:      "20240101/service/aws4_request",
 		Finalizer:            identityFinalizer{},
-	SignatureType: v4.SignatureTypeQueryString,
+		SignatureType: v4.SignatureTypeQueryString,
 	}
 
 	err = s.Do()

--- a/aws-http-auth/internal/v4/signer_test.go
+++ b/aws-http-auth/internal/v4/signer_test.go
@@ -49,7 +49,7 @@ func TestQueryStringAuth_IncludesSignedHeadersInCanonicalRequest(t *testing.T) {
 		Algorithm:            "AWS4-HMAC-SHA256",
 		CredentialScope:      "20240101/us-east-1/service/aws4_request",
 		Finalizer:            identityFinalizer{},
-	SignatureType v4.SignatureType
+	SignatureType: v4.SignatureTypeQueryString,
 	}
 
 	err = s.Do()
@@ -92,7 +92,7 @@ func TestQueryStringAuth_WithSessionToken(t *testing.T) {
 		Algorithm:            "AWS4-HMAC-SHA256",
 		CredentialScope:      "20240101/us-east-1/service/aws4_request",
 		Finalizer:            identityFinalizer{},
-	SignatureType v4.SignatureType
+	SignatureType: v4.SignatureTypeQueryString,
 	}
 
 	err = s.Do()
@@ -128,7 +128,7 @@ func TestQueryStringAuth_WithRegionSet(t *testing.T) {
 		Algorithm:            "AWS4-ECDSA-P256-SHA256",
 		CredentialScope:      "20240101/service/aws4_request",
 		Finalizer:            identityFinalizer{},
-	SignatureType v4.SignatureType
+	SignatureType: v4.SignatureTypeQueryString,
 	}
 
 	err = s.Do()

--- a/aws-http-auth/sigv4/sigv4.go
+++ b/aws-http-auth/sigv4/sigv4.go
@@ -17,6 +17,8 @@ import (
 
 const algorithm = "AWS4-HMAC-SHA256"
 
+
+
 // Signer signs requests with AWS Signature version 4.
 type Signer struct {
 	options v4.SignerOptions
@@ -66,6 +68,9 @@ type SignRequestInput struct {
 	// If the zero-value is given (generally by the caller not setting it), the
 	// signer will instead use the current system clock time for the signature.
 	Time time.Time
+
+	// How the signature is transmitted (header or query string).
+	SignatureType v4.SignatureType
 }
 
 // SignRequest signs an HTTP request with AWS Signature Version 4, modifying
@@ -107,8 +112,9 @@ func (s *Signer) SignRequest(in *SignRequestInput, opts ...v4.SignerOption) erro
 		Credentials: in.Credentials,
 		Options:     options,
 
-		Algorithm:       algorithm,
-		CredentialScope: scope(tm, in.Region, in.Service),
+		Algorithm:            algorithm,
+		CredentialScope:      scope(tm, in.Region, in.Service),
+	SignatureType v4.SignatureType
 		Finalizer: &finalizer{
 			Secret:  in.Credentials.SecretAccessKey,
 			Service: in.Service,

--- a/aws-http-auth/sigv4/sigv4.go
+++ b/aws-http-auth/sigv4/sigv4.go
@@ -114,7 +114,7 @@ func (s *Signer) SignRequest(in *SignRequestInput, opts ...v4.SignerOption) erro
 
 		Algorithm:            algorithm,
 		CredentialScope:      scope(tm, in.Region, in.Service),
-	SignatureType v4.SignatureType
+		SignatureType:        in.SignatureType,
 		Finalizer: &finalizer{
 			Secret:  in.Credentials.SecretAccessKey,
 			Service: in.Service,

--- a/aws-http-auth/sigv4/sigv4_test.go
+++ b/aws-http-auth/sigv4/sigv4_test.go
@@ -244,11 +244,12 @@ func TestSignRequestQueryString(t *testing.T) {
 	if query.Get("X-Amz-Date") != "20130801T000000Z" {
 		t.Errorf("expected X-Amz-Date=20130801T000000Z, got %s", query.Get("X-Amz-Date"))
 	}
-	if query.Get("X-Amz-SignedHeaders") == "" {
-		t.Error("expected X-Amz-SignedHeaders to be set")
+	if query.Get("X-Amz-SignedHeaders") != "host" {
+		t.Errorf("expected X-Amz-SignedHeaders=host, got %s", query.Get("X-Amz-SignedHeaders"))
 	}
-	if query.Get("X-Amz-Signature") == "" {
-		t.Error("expected X-Amz-Signature to be set")
+	expectedSignature := "16e17486c8e6bb97596d140876d8a23164a13552e644900b81dba01ad092bdac"
+	if query.Get("X-Amz-Signature") != expectedSignature {
+		t.Errorf("expected X-Amz-Signature=%s, got %s", expectedSignature, query.Get("X-Amz-Signature"))
 	}
 
 	// Should preserve existing query params
@@ -276,8 +277,15 @@ func TestSignRequestQueryStringWithSession(t *testing.T) {
 	}
 
 	query := req.URL.Query()
+	if query.Get("X-Amz-SignedHeaders") != "host" {
+		t.Errorf("expected X-Amz-SignedHeaders=host, got %s", query.Get("X-Amz-SignedHeaders"))
+	}
 	if query.Get("X-Amz-Security-Token") != "SESSION" {
 		t.Errorf("expected X-Amz-Security-Token=SESSION, got %s", query.Get("X-Amz-Security-Token"))
+	}
+	expectedSignature := "485caefdc25560b950ea52c7cd87bc607084a43193387b1737bd2290ba3b699a"
+	if query.Get("X-Amz-Signature") != expectedSignature {
+		t.Errorf("expected X-Amz-Signature=%s, got %s", expectedSignature, query.Get("X-Amz-Signature"))
 	}
 }
 func TestSignRequestHeaderDoesNotAlterQueryString(t *testing.T) {

--- a/aws-http-auth/sigv4/sigv4_test.go
+++ b/aws-http-auth/sigv4/sigv4_test.go
@@ -209,3 +209,134 @@ func TestSignRequest(t *testing.T) {
 		})
 	}
 }
+func TestSignRequestQueryString(t *testing.T) {
+	signer := New()
+
+	req := newRequest(nil)
+	req.URL.RawQuery = "existing=param"
+
+	err := signer.SignRequest(&SignRequestInput{
+		Request:              req,
+		Credentials:          credsNoSession,
+		Service:              "s3",
+		Region:               "us-east-1",
+		Time:                 time.Unix(1375315200, 0),
+		SignatureType v4.SignatureType
+	})
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Should not have Authorization header
+	if auth := req.Header.Get("Authorization"); auth != "" {
+		t.Errorf("expected no Authorization header, got %s", auth)
+	}
+
+	// Should have query parameters
+	query := req.URL.Query()
+	if query.Get("X-Amz-Algorithm") != "AWS4-HMAC-SHA256" {
+		t.Errorf("expected X-Amz-Algorithm=AWS4-HMAC-SHA256, got %s", query.Get("X-Amz-Algorithm"))
+	}
+	if !strings.Contains(query.Get("X-Amz-Credential"), "AKID/20130801/us-east-1/s3/aws4_request") {
+		t.Errorf("unexpected X-Amz-Credential: %s", query.Get("X-Amz-Credential"))
+	}
+	if query.Get("X-Amz-Date") != "20130801T000000Z" {
+		t.Errorf("expected X-Amz-Date=20130801T000000Z, got %s", query.Get("X-Amz-Date"))
+	}
+	if query.Get("X-Amz-SignedHeaders") == "" {
+		t.Error("expected X-Amz-SignedHeaders to be set")
+	}
+	if query.Get("X-Amz-Signature") == "" {
+		t.Error("expected X-Amz-Signature to be set")
+	}
+
+	// Should preserve existing query params
+	if query.Get("existing") != "param" {
+		t.Errorf("expected existing=param, got existing=%s", query.Get("existing"))
+	}
+}
+
+func TestSignRequestQueryStringWithSession(t *testing.T) {
+	signer := New()
+
+	req := newRequest(nil)
+
+	err := signer.SignRequest(&SignRequestInput{
+		Request:              req,
+		Credentials:          credsSession,
+		Service:              "s3",
+		Region:               "us-east-1",
+		Time:                 time.Unix(1375315200, 0),
+	SignatureType v4.SignatureType
+	})
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	query := req.URL.Query()
+	if query.Get("X-Amz-Security-Token") != "SESSION" {
+		t.Errorf("expected X-Amz-Security-Token=SESSION, got %s", query.Get("X-Amz-Security-Token"))
+	}
+}
+func TestSignRequestHeaderDoesNotAlterQueryString(t *testing.T) {
+	signer := New()
+
+	req := newRequest(nil)
+	req.URL.RawQuery = "existing=param&another=value"
+	originalQuery := req.URL.RawQuery
+
+	err := signer.SignRequest(&SignRequestInput{
+		Request:              req,
+		Credentials:          credsNoSession,
+		Service:              "s3",
+		Region:               "us-east-1",
+		Time:                 time.Unix(1375315200, 0),
+	SignatureType v4.SignatureType
+	})
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Should have Authorization header
+	if auth := req.Header.Get("Authorization"); auth == "" {
+		t.Error("expected Authorization header to be set")
+	}
+
+	// Query string should be unchanged
+	if req.URL.RawQuery != originalQuery {
+		t.Errorf("expected query string unchanged, got %s, want %s", req.URL.RawQuery, originalQuery)
+	}
+}
+func TestBackwardsCompatibility(t *testing.T) {
+	signer := New()
+
+	req := newRequest(nil)
+
+	SignatureType v4.SignatureType
+	err := signer.SignRequest(&SignRequestInput{
+		Request:     req,
+		Credentials: credsNoSession,
+		Service:     "s3",
+		Region:      "us-east-1",
+		Time:        time.Unix(1375315200, 0),
+	SignatureType v4.SignatureType
+	})
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Should behave like header method (old behavior)
+	if auth := req.Header.Get("Authorization"); auth == "" {
+		t.Error("expected Authorization header to be set for backwards compatibility")
+	}
+
+	// Should not have query parameters
+	query := req.URL.Query()
+	if query.Get("X-Amz-Algorithm") != "" {
+		t.Error("expected no X-Amz-Algorithm in query string for backwards compatibility")
+	}
+}

--- a/aws-http-auth/sigv4/sigv4_test.go
+++ b/aws-http-auth/sigv4/sigv4_test.go
@@ -221,7 +221,7 @@ func TestSignRequestQueryString(t *testing.T) {
 		Service:              "s3",
 		Region:               "us-east-1",
 		Time:                 time.Unix(1375315200, 0),
-		SignatureType v4.SignatureType
+		SignatureType: v4.SignatureTypeQueryString,
 	})
 
 	if err != nil {
@@ -268,7 +268,7 @@ func TestSignRequestQueryStringWithSession(t *testing.T) {
 		Service:              "s3",
 		Region:               "us-east-1",
 		Time:                 time.Unix(1375315200, 0),
-	SignatureType v4.SignatureType
+	SignatureType: v4.SignatureTypeQueryString,
 	})
 
 	if err != nil {
@@ -293,7 +293,7 @@ func TestSignRequestHeaderDoesNotAlterQueryString(t *testing.T) {
 		Service:              "s3",
 		Region:               "us-east-1",
 		Time:                 time.Unix(1375315200, 0),
-	SignatureType v4.SignatureType
+	SignatureType: v4.SignatureTypeHeader,
 	})
 
 	if err != nil {
@@ -315,14 +315,12 @@ func TestBackwardsCompatibility(t *testing.T) {
 
 	req := newRequest(nil)
 
-	SignatureType v4.SignatureType
 	err := signer.SignRequest(&SignRequestInput{
 		Request:     req,
 		Credentials: credsNoSession,
 		Service:     "s3",
 		Region:      "us-east-1",
 		Time:        time.Unix(1375315200, 0),
-	SignatureType v4.SignatureType
 	})
 
 	if err != nil {

--- a/aws-http-auth/sigv4a/sigv4a.go
+++ b/aws-http-auth/sigv4a/sigv4a.go
@@ -154,7 +154,7 @@ func (s *Signer) SignRequest(in *SignRequestInput, opts ...v4.SignerOption) erro
 
 	// For query string auth, add X-Amz-Region-Set as query parameter
 	// For header auth, add it as header
-	SignatureType v4.SignatureType
+	if in.SignatureType == v4.SignatureTypeQueryString {
 		query := in.Request.URL.Query()
 		query.Set("X-Amz-Region-Set", strings.Join(in.RegionSet, ","))
 		in.Request.URL.RawQuery = query.Encode()
@@ -170,7 +170,7 @@ func (s *Signer) SignRequest(in *SignRequestInput, opts ...v4.SignerOption) erro
 
 		Algorithm:            algorithm,
 		CredentialScope:      scope(tm, in.Service),
-	SignatureType v4.SignatureType
+		SignatureType:        in.SignatureType,
 		Finalizer:            &finalizer{priv},
 	}
 	if err := signer.Do(); err != nil {

--- a/aws-http-auth/sigv4a/sigv4a_test.go
+++ b/aws-http-auth/sigv4a/sigv4a_test.go
@@ -404,3 +404,80 @@ func TestSignRequest_SignStringError(t *testing.T) {
 		t.Errorf("error mismatch: %v != %v", expect, err.Error())
 	}
 }
+func TestSignRequestQueryString(t *testing.T) {
+	signer := New()
+
+	req := newRequest(nil)
+	req.URL.RawQuery = "existing=param"
+
+	err := signer.SignRequest(&SignRequestInput{
+		Request:              req,
+		Credentials:          credsNoSession,
+		Service:              "s3",
+		RegionSet:            []string{"us-east-1"},
+		Time:                 time.Unix(1375315200, 0),
+		SignatureType v4.SignatureType
+	})
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Should not have Authorization header
+	if auth := req.Header.Get("Authorization"); auth != "" {
+		t.Errorf("expected no Authorization header, got %s", auth)
+	}
+
+	// Should have query parameters
+	query := req.URL.Query()
+	if query.Get("X-Amz-Algorithm") != "AWS4-ECDSA-P256-SHA256" {
+		t.Errorf("expected X-Amz-Algorithm=AWS4-ECDSA-P256-SHA256, got %s", query.Get("X-Amz-Algorithm"))
+	}
+	if !strings.Contains(query.Get("X-Amz-Credential"), "AKID/20130801/s3/aws4_request") {
+		t.Errorf("unexpected X-Amz-Credential: %s", query.Get("X-Amz-Credential"))
+	}
+	if query.Get("X-Amz-Date") != "20130801T000000Z" {
+		t.Errorf("expected X-Amz-Date=20130801T000000Z, got %s", query.Get("X-Amz-Date"))
+	}
+	if query.Get("X-Amz-SignedHeaders") == "" {
+		t.Error("expected X-Amz-SignedHeaders to be set")
+	}
+	if query.Get("X-Amz-Signature") == "" {
+		t.Error("expected X-Amz-Signature to be set")
+	}
+
+	// Should preserve existing query params
+	if query.Get("existing") != "param" {
+		t.Errorf("expected existing=param, got existing=%s", query.Get("existing"))
+	}
+}
+func TestSignRequestHeaderDoesNotAlterQueryString(t *testing.T) {
+	signer := New()
+
+	req := newRequest(nil)
+	req.URL.RawQuery = "existing=param&another=value"
+	originalQuery := req.URL.RawQuery
+
+	err := signer.SignRequest(&SignRequestInput{
+		Request:              req,
+		Credentials:          credsNoSession,
+		Service:              "s3",
+		RegionSet:            []string{"us-east-1"},
+		Time:                 time.Unix(1375315200, 0),
+	SignatureType v4.SignatureType
+	})
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Should have Authorization header
+	if auth := req.Header.Get("Authorization"); auth == "" {
+		t.Error("expected Authorization header to be set")
+	}
+
+	// Query string should be unchanged
+	if req.URL.RawQuery != originalQuery {
+		t.Errorf("expected query string unchanged, got %s, want %s", req.URL.RawQuery, originalQuery)
+	}
+}

--- a/aws-http-auth/sigv4a/sigv4a_test.go
+++ b/aws-http-auth/sigv4a/sigv4a_test.go
@@ -396,6 +396,12 @@ func TestSignRequest_SignStringError(t *testing.T) {
 	err := s.SignRequest(&SignRequestInput{
 		Request:     newRequest(http.NoBody),
 		PayloadHash: v4.UnsignedPayload(),
+		Credentials: credentials.Credentials{
+			AccessKeyID:     "AKID",
+			SecretAccessKey: "SECRET",
+		},
+		Service:   "s3",
+		RegionSet: []string{"us-east-1"},
 	})
 	if err == nil {
 		t.Fatal("expect error but didn't get one")
@@ -416,7 +422,7 @@ func TestSignRequestQueryString(t *testing.T) {
 		Service:              "s3",
 		RegionSet:            []string{"us-east-1"},
 		Time:                 time.Unix(1375315200, 0),
-		SignatureType v4.SignatureType
+		SignatureType: v4.SignatureTypeQueryString,
 	})
 
 	if err != nil {
@@ -464,7 +470,7 @@ func TestSignRequestHeaderDoesNotAlterQueryString(t *testing.T) {
 		Service:              "s3",
 		RegionSet:            []string{"us-east-1"},
 		Time:                 time.Unix(1375315200, 0),
-	SignatureType v4.SignatureType
+	SignatureType: v4.SignatureTypeHeader,
 	})
 
 	if err != nil {

--- a/aws-http-auth/v4/v4.go
+++ b/aws-http-auth/v4/v4.go
@@ -1,6 +1,17 @@
 // Package v4 exposes common APIs for AWS Signature Version 4.
 package v4
 
+// SignatureType specifies how the signature is transmitted.
+type SignatureType int
+
+const (
+	// SignatureTypeHeader transmits signature via Authorization header (default).
+	SignatureTypeHeader SignatureType = iota
+	// SignatureTypeQueryString transmits signature via query parameters.
+	// See https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
+	SignatureTypeQueryString
+)
+
 // SignerOption applies configuration to a signer.
 type SignerOption func(*SignerOptions)
 


### PR DESCRIPTION
This change adds support for SIGV4 and SIGV4A querystring signing. 

This is a feature of AWS Signature Version 4 request signing which places the computed request signature and related signing parameters directly into the request’s query string. This allows the service to authenticate requests based solely on URL parameters, without relying on HTTP headers for signature delivery.

* https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.