### PR TITLE
sort map keys in JSON Document shape encodes

### DIFF
--- a/.changelog/ed10934bf38a4ea9a93df3498ffdfd8a.json
+++ b/.changelog/ed10934bf38a4ea9a93df3498ffdfd8a.json
@@ -1,0 +1,8 @@
+{
+    "id": "ed10934b-f38a-4ea9-a93d-f3498ffdfd8a",
+    "type": "feature",
+    "description": "Sort map keys in JSON Document types.",
+    "modules": [
+        "."
+    ]
+}

--- a/document/json/encoder_test.go
+++ b/document/json/encoder_test.go
@@ -67,6 +67,32 @@ func TestNewEncoderUnsupportedTypes(t *testing.T) {
 	}
 }
 
+func TestDeterministicMapOrder(t *testing.T) {
+	value := struct {
+		Map map[string]string
+	}{
+		Map: map[string]string{
+			"foo": "bar",
+			"a":   "b",
+			"bar": "baz",
+			"b":   "c",
+			"baz": "qux",
+			"c":   "d",
+		},
+	}
+	expect := `{"Map":{"a":"b","b":"c","bar":"baz","baz":"qux","c":"d","foo":"bar"}}`
+
+	encoder := json.NewEncoder()
+	actual, err := encoder.Encode(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if expect != string(actual) {
+		t.Errorf("encode determinstic order:\n%q !=\n%q", expect, actual)
+	}
+}
+
 func testEncode(t *testing.T, tt testCase) {
 	t.Helper()
 

--- a/document/json/shared_test.go
+++ b/document/json/shared_test.go
@@ -27,6 +27,8 @@ type StructA struct {
 	FieldNestedStruct          *StructA `document:"field_nested_struct"`
 	FieldNestedStructOmitEmpty *StructA `document:"field_nested_struct_omit_empty,omitempty"`
 
+	FieldMap map[string]string `document:",omitempty"`
+
 	fieldUnexported string
 
 	StructB
@@ -88,6 +90,14 @@ var sharedObjectTests = map[string]testCase{
 	},
 	"filled json structure": {
 		json: []byte(`{
+  "FieldMap": {
+    "a": "b",
+    "bar": "baz",
+    "baz": "qux",
+    "c": "d",
+    "foo": "bar",
+    "z": "a"
+  },
   "FieldName": "a",
   "FieldPtrName": "b",
   "field_rename": "c",
@@ -115,6 +125,14 @@ var sharedObjectTests = map[string]testCase{
 			return &v
 		}(),
 		want: &StructA{
+			FieldMap: map[string]string{
+				"foo": "bar",
+				"bar": "baz",
+				"baz": "qux",
+				"a":   "b",
+				"c":   "d",
+				"z":   "a",
+			},
 			FieldName:            "a",
 			FieldPtrName:         ptr.String("b"),
 			FieldRename:          "c",


### PR DESCRIPTION
We've gotten correspondence about this a handful of times over the last quarter and it appears to be a behavioral requirement for some downstream AWS services in caching scenarios, so I'm just doing it. It also makes unit testing easier.

This DOES NOT cover general map serialization, that will have to be addressed downstream.