### PR TITLE
Allow unused required parameters in endpoint rule set

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolverGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolverGenerator.java
@@ -189,9 +189,11 @@ public final class EndpointResolverGenerator {
                                     continue;
                                 }
                                 switch (param.getType()) {
-                                    case STRING, BOOLEAN ->
+                                    case STRING, BOOLEAN -> {
                                         w.write("$L := *$L",
                                                 getLocalVarParameterName(param), getMemberParameterName(param));
+                                        w.write("_ = $L", getLocalVarParameterName(param));
+                                    }
                                     case STRING_ARRAY -> {
                                         w.write("$L := stringSlice($L)",
                                                 getLocalVarParameterName(param), getMemberParameterName(param));

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolverGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolverGenerator.java
@@ -200,6 +200,7 @@ public final class EndpointResolverGenerator {
                                     case STRING_ARRAY -> {
                                         w.write("$L := stringSlice($L)",
                                                 getLocalVarParameterName(param), getMemberParameterName(param));
+                                        w.write("_ = $L", getLocalVarParameterName(param));
                                     }
                                     default -> throw new CodegenException("unrecognized parameter type");
                                 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolverGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolverGenerator.java
@@ -192,6 +192,9 @@ public final class EndpointResolverGenerator {
                                     case STRING, BOOLEAN -> {
                                         w.write("$L := *$L",
                                                 getLocalVarParameterName(param), getMemberParameterName(param));
+                                        // even if the parameter is required, it's not guaranteed that it will be used
+                                        // so we generate a blank identifier to prevent a compiler error if the
+                                        // variable is not used
                                         w.write("_ = $L", getLocalVarParameterName(param));
                                     }
                                     case STRING_ARRAY -> {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Famously, Go fails to compile if a variable is declared but not used.

While testing, I noticed that when generating code for Smithy's [endpoint rule engine](https://smithy.io/2.0/additional-specs/rules-engine/index.html), if you declare a variable as `required` but don't actually use it, the generated code fails to compile.

This is because we always generate an intermediate variable for required parameters, and if unused, we fail to compile.

This change generates an intermediate throwaway to make the compiler happy, but breaking my heart.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
