### PR TITLE
serde2: use our own json

### DIFF
--- a/aws-protocols/awsjson10/awsjson10.go
+++ b/aws-protocols/awsjson10/awsjson10.go
@@ -1,0 +1,191 @@
+package awsjson10
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/aws/smithy-go"
+	awsjson "github.com/aws/smithy-go/aws-protocols/internal/json"
+	smithyio "github.com/aws/smithy-go/io"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+// New returns an instance of the awsJson 1.0 protocol.
+func New() *Protocol {
+	return &Protocol{}
+}
+
+// Protocol implements aws.protocols#awsJson10.
+type Protocol struct {
+	UseQueryCompatible bool
+}
+
+var _ smithyhttp.ClientProtocol = (*Protocol)(nil)
+
+// ID identifies the protocol.
+func (*Protocol) ID() string {
+	return "aws.protocols#awsJson10"
+}
+
+// SerializeRequest serializes a request for AWS Json 1.0.
+func (p *Protocol) SerializeRequest(
+	ctx context.Context,
+	in smithy.Serializable,
+	req *smithyhttp.Request,
+) error {
+	req.Method = http.MethodPost
+	req.Header.Set("X-Amz-Target", fmt.Sprintf("%s.%s", middleware.GetServiceName(ctx), middleware.GetOperationName(ctx)))
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	if p.UseQueryCompatible {
+		req.Header.Set("X-Amzn-Query-Compatible", "true")
+	}
+
+	ss := awsjson.NewShapeSerializer()
+	in.Serialize(ss)
+
+	sreq, err := req.SetStream(bytes.NewReader(ss.Bytes()))
+	if err != nil {
+		return fmt.Errorf("set stream: %w", err)
+	}
+
+	*req = *sreq
+	return nil
+}
+
+// DeserializeResponse deserializes a response for AWS Json 1.0.
+func (p *Protocol) DeserializeResponse(
+	ctx context.Context,
+	types *smithy.TypeRegistry,
+	resp *smithyhttp.Response,
+	out smithy.Deserializable,
+) error {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return p.deserializeError(types, resp)
+	}
+
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return &smithy.DeserializationError{Err: err}
+	}
+
+	if len(payload) == 0 {
+		return nil
+	}
+
+	sd := awsjson.NewShapeDeserializer(payload)
+	if err := out.Deserialize(sd); err != nil {
+		return &smithy.DeserializationError{Err: err}
+	}
+
+	return nil
+}
+
+func (p *Protocol) deserializeError(types *smithy.TypeRegistry, response *smithyhttp.Response) error {
+	var errorBuffer bytes.Buffer
+	if _, err := io.Copy(&errorBuffer, response.Body); err != nil {
+		return &smithy.DeserializationError{Err: fmt.Errorf("failed to copy error response body, %w", err)}
+	}
+	errorBody := bytes.NewReader(errorBuffer.Bytes())
+
+	errorCode := "UnknownError"
+	errorMessage := errorCode
+
+	var headerCode string
+	headerCode = response.Header.Get("X-Amzn-ErrorType")
+
+	var buff [1024]byte
+	ringBuffer := smithyio.NewRingBuffer(buff[:])
+
+	body := io.TeeReader(errorBody, ringBuffer)
+	decoder := json.NewDecoder(body)
+	decoder.UseNumber()
+	bodyInfo, err := getProtocolErrorInfo(decoder)
+	if err != nil {
+		var snapshot bytes.Buffer
+		io.Copy(&snapshot, ringBuffer)
+		err = &smithy.DeserializationError{
+			Err:      fmt.Errorf("failed to decode response body, %w", err),
+			Snapshot: snapshot.Bytes(),
+		}
+		return err
+	}
+
+	errorBody.Seek(0, io.SeekStart)
+	if typ, ok := resolveProtocolErrorType(headerCode, bodyInfo); ok {
+		errorCode = typ
+	}
+	if len(bodyInfo.Message) != 0 {
+		errorMessage = bodyInfo.Message
+	}
+
+	errorCode = sanitizeErrorCode(errorCode)
+
+	perr, ok := types.DeserializableError(errorCode)
+	if !ok {
+		return &smithy.GenericAPIError{
+			Code:    errorCode,
+			Message: errorMessage,
+		}
+
+	}
+
+	errorBody.Seek(0, io.SeekStart)
+	errorBytes, _ := io.ReadAll(errorBody)
+	if len(errorBytes) > 0 {
+		deser := awsjson.NewShapeDeserializer(errorBytes)
+		if err := perr.Deserialize(deser); err != nil {
+			return &smithy.DeserializationError{Err: err}
+		}
+	}
+
+	return perr
+}
+
+type protocolErrorInfo struct {
+	Type    string `json:"__type"`
+	Message string
+
+	// nonstandard, but some AWS services do present the type here
+	Code any
+}
+
+func getProtocolErrorInfo(decoder *json.Decoder) (protocolErrorInfo, error) {
+	var errInfo protocolErrorInfo
+	if err := decoder.Decode(&errInfo); err != nil {
+		if err == io.EOF {
+			return errInfo, nil
+		}
+		return errInfo, err
+	}
+
+	return errInfo, nil
+}
+
+func resolveProtocolErrorType(headerType string, bodyInfo protocolErrorInfo) (string, bool) {
+	if len(headerType) != 0 {
+		return headerType, true
+	} else if len(bodyInfo.Type) != 0 {
+		return bodyInfo.Type, true
+	} else if code, ok := bodyInfo.Code.(string); ok && len(code) != 0 {
+		return code, true
+	}
+	return "", false
+}
+
+// sanitizeErrorCode strips namespace prefixes and URI suffixes from error
+// codes received on the wire.
+func sanitizeErrorCode(code string) string {
+	if idx := strings.Index(code, ":"); idx != -1 {
+		code = code[:idx]
+	}
+	if idx := strings.Index(code, "#"); idx != -1 {
+		code = code[idx+1:]
+	}
+	return code
+}

--- a/aws-protocols/go.mod
+++ b/aws-protocols/go.mod
@@ -1,0 +1,7 @@
+module github.com/aws/smithy-go/aws-protocols
+
+go 1.24
+
+require github.com/aws/smithy-go v1.24.0
+
+replace github.com/aws/smithy-go => ../

--- a/aws-protocols/internal/json/codec.go
+++ b/aws-protocols/internal/json/codec.go
@@ -1,0 +1,20 @@
+package json
+
+import (
+	"github.com/aws/smithy-go"
+)
+
+// Codec is a JSON codec.
+type Codec struct{}
+
+var _ smithy.Codec = (*Codec)(nil)
+
+// Serializer returns a JSON shape serializer.
+func (c *Codec) Serializer() smithy.ShapeSerializer {
+	return NewShapeSerializer()
+}
+
+// Deserializer returns a JSON shape deserializer.
+func (c *Codec) Deserializer(p []byte) smithy.ShapeDeserializer {
+	return NewShapeDeserializer(p)
+}

--- a/aws-protocols/internal/json/scanner.go
+++ b/aws-protocols/internal/json/scanner.go
@@ -1,0 +1,331 @@
+package json
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+)
+
+// tokenizer scans json tokens without the allocation overhead of json.Token.
+// It does not care about the syntactic validity of the json at all, that is
+// handled by [parser].
+//
+// Largely inspired by https://dave.cheney.net/paste/gophercon-sg-2023.html
+// although this version operates on a fully buffered input since we are
+// generally dealing with smaller RPC-style payloads.
+type tokenizer struct {
+	p []byte
+	i int
+}
+
+func (s *tokenizer) Next() ([]byte, error) {
+	for ; s.i < len(s.p); s.i++ {
+		c := s.p[s.i]
+		if whitespace[c] {
+			continue
+		}
+
+		switch c {
+		case '{', '}', '[', ']', ':', ',':
+			s.i++
+			return s.p[s.i-1 : s.i], nil
+		case '"':
+			return s.scanString()
+		case 't':
+			return s.scanLiteral("true")
+		case 'f':
+			return s.scanLiteral("false")
+		case 'n':
+			return s.scanLiteral("null")
+		default:
+			return s.scanNumber()
+		}
+	}
+
+	return nil, io.EOF
+}
+
+func (s *tokenizer) IsEOF() bool {
+	return s.i >= len(s.p)
+}
+
+func (s *tokenizer) scanString() ([]byte, error) {
+	start := s.i
+	s.i++ // skip opening "
+
+	for s.i < len(s.p) {
+		c := s.p[s.i]
+		if ctrlchars[c] {
+			return nil, fmt.Errorf("invalid control character at offset %d", s.i)
+		}
+
+		if c == '\\' { // escaped char
+			s.i += 2
+			continue
+		}
+
+		if c == '"' {
+			s.i++
+
+			// we want the quotes here because this lets the token consumer
+			// know that it's a string without additional identifying data
+			// (e.g. a token type enum)
+			return s.p[start:s.i], nil
+		}
+
+		s.i++
+	}
+	return nil, fmt.Errorf("unterminated string at offset %d", start)
+}
+
+func (s *tokenizer) scanNumber() ([]byte, error) {
+	start := s.i
+	if s.i < len(s.p) && s.p[s.i] == '-' {
+		s.i++
+	}
+	s.scanDigits()
+	if s.i < len(s.p) && s.p[s.i] == '.' {
+		s.i++
+		s.scanDigits()
+	}
+	if s.i < len(s.p) && (s.p[s.i] == 'e' || s.p[s.i] == 'E') {
+		s.i++
+		if s.i < len(s.p) && (s.p[s.i] == '+' || s.p[s.i] == '-') {
+			s.i++
+		}
+		s.scanDigits()
+	}
+	if s.i == start {
+		return nil, fmt.Errorf("unexpected token at offset %d", start)
+	}
+	return s.p[start:s.i], nil
+}
+
+func (s *tokenizer) scanDigits() {
+	for s.i < len(s.p) && s.p[s.i] >= '0' && s.p[s.i] <= '9' {
+		s.i++
+	}
+}
+
+func (s *tokenizer) scanLiteral(lit string) ([]byte, error) {
+	end := s.i + len(lit)
+	if end > len(s.p) || string(s.p[s.i:end]) != lit {
+		return nil, fmt.Errorf("invalid literal at offset %d", s.i)
+	}
+	start := s.i
+	s.i = end
+	return s.p[start:end], nil
+}
+
+var whitespace = [256]bool{
+	' ':  true,
+	'\t': true,
+	'\n': true,
+	'\r': true,
+}
+
+var ctrlchars = [256]bool{
+	'\n': true,
+	'\r': true,
+}
+
+const (
+	inObject = iota
+	inArray
+)
+
+// parser wraps tokenizer to pull tokens from a JSON body but also validate
+// that the syntax of the JSON is valid.
+type parser struct {
+	tok   tokenizer
+	stack stackT[int8]
+
+	// parse changes as tokens are called to handle state transitions
+	//
+	// per the Dave Cheney article, https://www.json.org/json-en.html has flow
+	// diagrams that help us build out the state transitions
+	parse func(*parser, []byte) ([]byte, error)
+}
+
+func (p *parser) Next() ([]byte, error) {
+	next, err := p.tok.Next()
+	if err != nil {
+		return nil, err
+	}
+
+	return p.parse(p, next)
+}
+
+func (p *parser) Skip() error {
+	var depth int
+	for {
+		tok, err := p.Next()
+		if err != nil {
+			return err
+		}
+		switch tok[0] {
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+		}
+		if depth == 0 {
+			return nil
+		}
+	}
+}
+
+func (p *parser) Value() (any, error) {
+	tok, err := p.Next()
+	if err != nil {
+		return nil, err
+	}
+	return p.value(tok)
+}
+
+func (p *parser) parseValue(tok []byte) ([]byte, error) {
+	switch tok[0] {
+	case '{':
+		p.parse = (*parser).parseObjectKey
+		p.stack.Push(inObject)
+		return tok, nil
+	case '[':
+		p.parse = (*parser).parseArrayValue
+		p.stack.Push(inArray)
+		return tok, nil
+	case ',', ':', '}', ']':
+		return nil, fmt.Errorf("unexpected '%c' in json value", tok[0])
+	}
+
+	p.afterValue()
+	return tok, nil
+}
+
+func (p *parser) parseObjectKey(tok []byte) ([]byte, error) {
+	switch tok[0] {
+	case '"':
+		p.parse = (*parser).parseObjectColon
+		return tok, nil
+	case '}':
+		p.close()
+		return tok, nil
+	default:
+		return nil, fmt.Errorf("unexpected '%c' in json object key", tok[0])
+	}
+}
+
+func (p *parser) parseObjectColon(tok []byte) ([]byte, error) {
+	if tok[0] != ':' {
+		return nil, fmt.Errorf("expected ':', got '%c'", tok[0])
+	}
+	p.parse = (*parser).parseValue
+	return p.Next()
+}
+
+func (p *parser) parseObjectComma(tok []byte) ([]byte, error) {
+	switch tok[0] {
+	case ',':
+		p.parse = (*parser).parseObjectKey
+		return p.Next()
+	case '}':
+		p.close()
+		return tok, nil
+	default:
+		return nil, fmt.Errorf("unexpected '%c' in json object", tok[0])
+	}
+}
+
+func (p *parser) parseArrayValue(tok []byte) ([]byte, error) {
+	if tok[0] == ']' {
+		p.close()
+		return tok, nil
+	}
+	return p.parseValue(tok)
+}
+
+func (p *parser) parseArrayComma(tok []byte) ([]byte, error) {
+	switch tok[0] {
+	case ',':
+		p.parse = (*parser).parseValue
+		return p.Next()
+	case ']':
+		p.close()
+		return tok, nil
+	default:
+		return nil, fmt.Errorf("unexpected '%c' in json array", tok[0])
+	}
+}
+
+func (p *parser) eof(tok []byte) ([]byte, error) {
+	return nil, io.EOF
+}
+
+func (p *parser) value(tok []byte) (any, error) {
+	switch tok[0] {
+	case 'n':
+		return nil, nil
+	case 't':
+		return true, nil
+	case 'f':
+		return false, nil
+	case '"':
+		return strconv.Unquote(string(tok))
+	case '{':
+		m := map[string]any{}
+		for {
+			ktok, err := p.Next()
+			if err != nil {
+				return nil, err
+			}
+			if ktok[0] == '}' {
+				return m, nil
+			}
+			key, err := strconv.Unquote(string(ktok))
+			if err != nil {
+				return nil, err
+			}
+			val, err := p.Value()
+			if err != nil {
+				return nil, err
+			}
+			m[key] = val
+		}
+	case '[':
+		var list []any
+		for {
+			tok, err := p.Next()
+			if err != nil {
+				return nil, err
+			}
+			if tok[0] == ']' {
+				if list == nil {
+					list = []any{}
+				}
+				return list, nil
+			}
+			val, err := p.value(tok)
+			if err != nil {
+				return nil, err
+			}
+			list = append(list, val)
+		}
+	default:
+		return strconv.ParseFloat(string(tok), 64)
+	}
+}
+
+func (p *parser) close() {
+	p.stack.Pop()
+	p.afterValue()
+}
+
+func (p *parser) afterValue() {
+	switch p.stack.Top() {
+	case inObject:
+		p.parse = (*parser).parseObjectComma
+	case inArray:
+		p.parse = (*parser).parseArrayComma
+	default:
+		p.parse = (*parser).eof
+	}
+}

--- a/aws-protocols/internal/json/shape_deserializer.go
+++ b/aws-protocols/internal/json/shape_deserializer.go
@@ -486,7 +486,7 @@ func (d *ShapeDeserializer) ReadDocument(schema *smithy.Schema, v *document.Valu
 	if err != nil {
 		return err
 	}
-	*v = &document.Opaque{vv}
+	*v = &document.Opaque{Value: vv}
 	return nil
 }
 

--- a/aws-protocols/internal/json/shape_deserializer.go
+++ b/aws-protocols/internal/json/shape_deserializer.go
@@ -1,0 +1,568 @@
+package json
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/document"
+	smithytime "github.com/aws/smithy-go/time"
+	"github.com/aws/smithy-go/traits"
+)
+
+// ShapeDeserializer implements unmarshaling of JSON into Smithy shapes.
+type ShapeDeserializer struct {
+	dec  *json.Decoder
+	head stack
+
+	// json.Decoder does not have a Peek() but we need to be able to
+	// "lookahead" for conditionally pulling a null token out in ReadNil.
+	peeked  json.Token
+	hasPeek bool
+}
+
+// NewShapeDeserializer creates a new ShapeDeserializer.
+func NewShapeDeserializer(p []byte) *ShapeDeserializer {
+	dec := json.NewDecoder(bytes.NewReader(p))
+	dec.UseNumber()
+	return &ShapeDeserializer{dec: dec}
+}
+
+var _ smithy.ShapeDeserializer = (*ShapeDeserializer)(nil)
+
+func (d *ShapeDeserializer) token() (json.Token, error) {
+	if d.hasPeek {
+		d.hasPeek = false
+		return d.peeked, nil
+	}
+	return d.dec.Token()
+}
+
+func (d *ShapeDeserializer) more() bool {
+	if d.hasPeek {
+		return true
+	}
+	return d.dec.More()
+}
+
+func (d *ShapeDeserializer) expectDelim(e json.Delim) error {
+	tok, err := d.token()
+	if err != nil {
+		return err
+	}
+
+	if a, ok := tok.(json.Delim); ok {
+		if e != a {
+			return fmt.Errorf("expect %s, got %s", e, a)
+		}
+		return nil
+	}
+
+	return fmt.Errorf("expect delim, got %T", tok)
+}
+
+// ReadNil implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadNil(s *smithy.Schema) (bool, error) {
+	tok, err := d.token()
+	if err != nil {
+		return false, err
+	}
+	if tok == nil {
+		return true, nil
+	}
+
+	// The only way to "unread" it is to note it and have token() return it
+	// next time.
+	d.peeked = tok
+	d.hasPeek = true
+	return false, nil
+}
+
+// ReadInt8 implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt8(s *smithy.Schema, v *int8) error {
+	n, err := d.readInt(math.MinInt8, math.MaxInt8)
+	*v = int8(n)
+	return err
+}
+
+// ReadInt16 implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt16(s *smithy.Schema, v *int16) error {
+	n, err := d.readInt(math.MinInt16, math.MaxInt16)
+	*v = int16(n)
+	return err
+}
+
+// ReadInt32 implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt32(s *smithy.Schema, v *int32) error {
+	n, err := d.readInt(math.MinInt32, math.MaxInt32)
+	*v = int32(n)
+	return err
+}
+
+// ReadInt64 implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt64(s *smithy.Schema, v *int64) error {
+	n, err := d.readInt(math.MinInt64, math.MaxInt64)
+	*v = n
+	return err
+}
+
+// ReadInt8Ptr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt8Ptr(s *smithy.Schema, v **int8) error {
+	if *v == nil {
+		*v = new(int8)
+	}
+	return d.ReadInt8(s, *v)
+}
+
+// ReadInt16Ptr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt16Ptr(s *smithy.Schema, v **int16) error {
+	if *v == nil {
+		*v = new(int16)
+	}
+	return d.ReadInt16(s, *v)
+}
+
+// ReadInt32Ptr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt32Ptr(s *smithy.Schema, v **int32) error {
+	if *v == nil {
+		*v = new(int32)
+	}
+	return d.ReadInt32(s, *v)
+}
+
+// ReadInt64Ptr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt64Ptr(s *smithy.Schema, v **int64) error {
+	if *v == nil {
+		*v = new(int64)
+	}
+	return d.ReadInt64(s, *v)
+}
+
+func (d *ShapeDeserializer) readInt(min, max int64) (int64, error) {
+	tok, err := d.token()
+	if err != nil {
+		return 0, err
+	}
+
+	num, ok := tok.(json.Number)
+	if !ok {
+		return 0, fmt.Errorf("expected number, got %T", tok)
+	}
+
+	n, err := num.Int64()
+	if err != nil {
+		return 0, err
+	}
+
+	if n < min || n > max {
+		return 0, fmt.Errorf("int %d exceeds range [%d, %d]", n, min, max)
+	}
+
+	return n, nil
+}
+
+// ReadFloat32 implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadFloat32(s *smithy.Schema, v *float32) error {
+	n, err := d.readFloat()
+	*v = float32(n)
+	return err
+}
+
+// ReadFloat64 implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadFloat64(s *smithy.Schema, v *float64) error {
+	n, err := d.readFloat()
+	*v = n
+	return err
+}
+
+// ReadFloat32Ptr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadFloat32Ptr(s *smithy.Schema, v **float32) error {
+	if *v == nil {
+		*v = new(float32)
+	}
+	return d.ReadFloat32(s, *v)
+}
+
+// ReadFloat64Ptr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadFloat64Ptr(s *smithy.Schema, v **float64) error {
+	if *v == nil {
+		*v = new(float64)
+	}
+	return d.ReadFloat64(s, *v)
+}
+
+func (d *ShapeDeserializer) readFloat() (float64, error) {
+	tok, err := d.token()
+	if err != nil {
+		return 0, err
+	}
+
+	switch v := tok.(type) {
+	case json.Number:
+		return v.Float64()
+	case string:
+		switch {
+		case strings.EqualFold(v, "NaN"):
+			return math.NaN(), nil
+		case strings.EqualFold(v, "Infinity"):
+			return math.Inf(1), nil
+		case strings.EqualFold(v, "-Infinity"):
+			return math.Inf(-1), nil
+		default:
+			return 0, fmt.Errorf("unexpected string value for float: %s", v)
+		}
+	default:
+		return 0, fmt.Errorf("expected number, got %T", tok)
+	}
+}
+
+// ReadBool implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadBool(s *smithy.Schema, v *bool) error {
+	tok, err := d.token()
+	if err != nil {
+		return err
+	}
+
+	b, ok := tok.(bool)
+	if !ok {
+		return fmt.Errorf("expected bool, got %T", tok)
+	}
+
+	*v = b
+	return nil
+}
+
+// ReadBoolPtr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadBoolPtr(s *smithy.Schema, v **bool) error {
+	if *v == nil {
+		*v = new(bool)
+	}
+	return d.ReadBool(s, *v)
+}
+
+// ReadString implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadString(s *smithy.Schema, v *string) error {
+	tok, err := d.token()
+	if err != nil {
+		return err
+	}
+
+	str, ok := tok.(string)
+	if !ok {
+		return fmt.Errorf("expected string, got %T", tok)
+	}
+
+	*v = str
+	return nil
+}
+
+// ReadStringPtr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadStringPtr(s *smithy.Schema, v **string) error {
+	if *v == nil {
+		*v = new(string)
+	}
+	return d.ReadString(s, *v)
+}
+
+// ReadTime implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadTime(schema *smithy.Schema, v *time.Time) error {
+	format := "epoch-seconds"
+	if t, ok := smithy.SchemaTrait[*traits.TimestampFormat](schema); ok {
+		format = t.Format
+	}
+
+	switch format {
+	case "epoch-seconds":
+		n, err := d.readFloat()
+		if err != nil {
+			return err
+		}
+		*v = smithytime.ParseEpochSeconds(n)
+		return nil
+	case "date-time":
+		var s string
+		if err := d.ReadString(schema, &s); err != nil {
+			return err
+		}
+		t, err := smithytime.ParseDateTime(s)
+		if err != nil {
+			return err
+		}
+		*v = t
+		return nil
+	case "http-date":
+		var s string
+		if err := d.ReadString(schema, &s); err != nil {
+			return err
+		}
+		t, err := smithytime.ParseHTTPDate(s)
+		if err != nil {
+			return err
+		}
+		*v = t
+		return nil
+	default:
+		return fmt.Errorf("unknown timestamp format: %s", format)
+	}
+}
+
+// ReadTimePtr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadTimePtr(schema *smithy.Schema, v **time.Time) error {
+	if *v == nil {
+		*v = new(time.Time)
+	}
+	return d.ReadTime(schema, *v)
+}
+
+// ReadBlob implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadBlob(s *smithy.Schema, v *[]byte) error {
+	tok, err := d.token()
+	if err != nil {
+		return err
+	}
+
+	str, ok := tok.(string)
+	if !ok {
+		return fmt.Errorf("expected string, got %T", tok)
+	}
+
+	b, err := base64.StdEncoding.DecodeString(str)
+	if err != nil {
+		return fmt.Errorf("decode base64 blob: %w", err)
+	}
+
+	*v = b
+	return nil
+}
+
+// ReadList implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadList(s *smithy.Schema) error {
+	tok, err := d.token()
+	if err != nil {
+		return err
+	}
+
+	delim, ok := tok.(json.Delim)
+	if !ok || delim != '[' {
+		return fmt.Errorf("expected '[', got %v", tok)
+	}
+
+	return nil
+}
+
+// ReadListItem implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadListItem(s *smithy.Schema) (bool, error) {
+	if !d.more() {
+		return false, d.expectDelim(']')
+	}
+
+	return true, nil
+}
+
+// ReadMap implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadMap(s *smithy.Schema) error {
+	tok, err := d.token()
+	if err != nil {
+		return err
+	}
+
+	delim, ok := tok.(json.Delim)
+	if !ok || delim != '{' {
+		return fmt.Errorf("expected '{', got %v", tok)
+	}
+
+	return nil
+}
+
+// ReadMapKey implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadMapKey(s *smithy.Schema) (string, bool, error) {
+	if !d.more() {
+		return "", false, d.expectDelim('}')
+	}
+
+	tok, err := d.token()
+	if err != nil {
+		return "", false, err
+	}
+
+	key, ok := tok.(string)
+	if !ok {
+		return "", false, fmt.Errorf("expected string key, got %T", tok)
+	}
+
+	return key, true, nil
+}
+
+// ReadStruct implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadStruct(s *smithy.Schema) error {
+	tok, err := d.token()
+	if err != nil {
+		return err
+	}
+
+	delim, ok := tok.(json.Delim)
+	if !ok || delim != '{' {
+		return fmt.Errorf("expected '{', got %v", tok)
+	}
+
+	d.head.Push(s)
+	return nil
+}
+
+// ReadStructMember implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadStructMember() (*smithy.Schema, error) {
+	if !d.more() {
+		d.head.Pop()
+		return nil, d.expectDelim('}')
+	}
+
+	tok, err := d.token()
+	if err != nil {
+		return nil, err
+	}
+
+	key, ok := tok.(string)
+	if !ok {
+		return nil, fmt.Errorf("expected string key, got %T", tok)
+	}
+
+	schema, ok := d.head.Top().(*smithy.Schema)
+	if !ok {
+		return nil, fmt.Errorf("ReadStructMember called without ReadStruct?")
+	}
+
+	member := schema.Member(key)
+	if member == nil {
+		// TODO smithy.api#jsonName
+		if err := d.skip(); err != nil {
+			return nil, err
+		}
+		return d.ReadStructMember() // just try the next one
+	}
+
+	return member, nil
+}
+
+// ReadUnion implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadUnion(s *smithy.Schema) (*smithy.Schema, error) {
+	// Decode the entire union object to find the non-null member.
+	var raw map[string]json.RawMessage
+	if err := d.dec.Decode(&raw); err != nil {
+		return nil, fmt.Errorf("decode union: %w", err)
+	}
+
+	for key, val := range raw {
+		if string(val) == "null" {
+			continue
+		}
+
+		member := s.Member(key)
+		if member == nil {
+			continue
+		}
+
+		// Replace the decoder with one that reads just this value
+		dec := json.NewDecoder(bytes.NewReader(val))
+		dec.UseNumber()
+		d.dec = dec
+		return member, nil
+	}
+
+	return nil, nil
+}
+
+// used to skip over a struct member that we didn't have a schema for, though
+// it also calls itself
+func (d *ShapeDeserializer) skip() error {
+	tok, err := d.token()
+	if err != nil {
+		return err
+	}
+
+	switch v := tok.(type) {
+	case json.Delim:
+		switch v {
+		case '{':
+			for d.more() {
+				if _, err := d.token(); err != nil { // the key
+					return err
+				}
+				if err := d.skip(); err != nil { // the value
+					return err
+				}
+			}
+			_, err := d.token() // the '}'
+			return err
+		case '[':
+			for d.more() {
+				if err := d.skip(); err != nil {
+					return err
+				}
+			}
+			_, err := d.token() // the ']'
+			return err
+		default:
+			return fmt.Errorf("unexpected delimiter: %v", v)
+		}
+	default:
+		return nil // scalar, don't have to do anything else
+	}
+}
+
+// ReadDocument reads a JSON value into a document Value.
+//
+// For now this produces an [document.Opaque] wrapping the raw decoded value,
+// which is what the legacy document bridge in generated code expects. The
+// jsonToValue conversion is available for future use when the new typed
+// document path is wired up end-to-end.
+func (d *ShapeDeserializer) ReadDocument(schema *smithy.Schema, v *document.Value) error {
+	var raw any
+	if err := d.dec.Decode(&raw); err != nil {
+		return err
+	}
+
+	*v = document.Opaque{Value: raw}
+	return nil
+}
+
+func jsonToValue(v any) (document.Value, error) {
+	switch vv := v.(type) {
+	case nil:
+		return document.Null{}, nil
+	case bool:
+		return document.Boolean(vv), nil
+	case json.Number:
+		return document.Number(vv.String()), nil
+	case float64:
+		return document.Number(fmt.Sprintf("%v", vv)), nil
+	case string:
+		return document.String(vv), nil
+	case []any:
+		list := make(document.List, len(vv))
+		for i, item := range vv {
+			dv, err := jsonToValue(item)
+			if err != nil {
+				return nil, err
+			}
+			list[i] = dv
+		}
+		return list, nil
+	case map[string]any:
+		m := make(document.Map, len(vv))
+		for k, item := range vv {
+			dv, err := jsonToValue(item)
+			if err != nil {
+				return nil, err
+			}
+			m[k] = dv
+		}
+		return m, nil
+	default:
+		return nil, fmt.Errorf("unexpected JSON type %T", v)
+	}
+}

--- a/aws-protocols/internal/json/shape_deserializer.go
+++ b/aws-protocols/internal/json/shape_deserializer.go
@@ -1,11 +1,11 @@
 package json
 
 import (
-	"bytes"
 	"encoding/base64"
-	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,69 +17,56 @@ import (
 
 // ShapeDeserializer implements unmarshaling of JSON into Smithy shapes.
 type ShapeDeserializer struct {
-	dec  *json.Decoder
-	head stack
+	p    parser
+	head stackT[*smithy.Schema]
 
-	// json.Decoder does not have a Peek() but we need to be able to
-	// "lookahead" for conditionally pulling a null token out in ReadNil.
-	peeked  json.Token
-	hasPeek bool
+	// it's easier to just maintain the "peeked" token here actually
+	peeked []byte
 }
 
 // NewShapeDeserializer creates a new ShapeDeserializer.
 func NewShapeDeserializer(p []byte) *ShapeDeserializer {
-	dec := json.NewDecoder(bytes.NewReader(p))
-	dec.UseNumber()
-	return &ShapeDeserializer{dec: dec}
+	return &ShapeDeserializer{
+		p: parser{
+			tok:   tokenizer{p: p},
+			parse: (*parser).parseValue,
+		},
+	}
 }
 
 var _ smithy.ShapeDeserializer = (*ShapeDeserializer)(nil)
 
-func (d *ShapeDeserializer) token() (json.Token, error) {
-	if d.hasPeek {
-		d.hasPeek = false
+func (d *ShapeDeserializer) next() ([]byte, error) {
+	if d.peeked != nil {
+		peeked := d.peeked
+		d.peeked = nil
+		return peeked, nil
+	}
+	return d.p.Next()
+}
+
+func (d *ShapeDeserializer) peek() ([]byte, error) {
+	if d.peeked != nil {
 		return d.peeked, nil
 	}
-	return d.dec.Token()
-}
-
-func (d *ShapeDeserializer) more() bool {
-	if d.hasPeek {
-		return true
-	}
-	return d.dec.More()
-}
-
-func (d *ShapeDeserializer) expectDelim(e json.Delim) error {
-	tok, err := d.token()
+	tok, err := d.p.Next()
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	if a, ok := tok.(json.Delim); ok {
-		if e != a {
-			return fmt.Errorf("expect %s, got %s", e, a)
-		}
-		return nil
-	}
-
-	return fmt.Errorf("expect delim, got %T", tok)
+	d.peeked = tok
+	return tok, nil
 }
 
 // ReadNil implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadNil(s *smithy.Schema) (bool, error) {
-	tok, err := d.token()
+	tok, err := d.peek()
 	if err != nil {
 		return false, err
 	}
-	if tok == nil {
+	if isN(tok) {
+		d.peeked = nil
 		return true, nil
 	}
-
-	// The only way to "unread" it is to note it and have token() return it
-	// next time.
-	d.peeked = tok
-	d.hasPeek = true
 	return false, nil
 }
 
@@ -144,17 +131,16 @@ func (d *ShapeDeserializer) ReadInt64Ptr(s *smithy.Schema, v **int64) error {
 }
 
 func (d *ShapeDeserializer) readInt(min, max int64) (int64, error) {
-	tok, err := d.token()
+	tok, err := d.next()
 	if err != nil {
 		return 0, err
 	}
 
-	num, ok := tok.(json.Number)
-	if !ok {
-		return 0, fmt.Errorf("expected number, got %T", tok)
+	if isS(tok) || isLCB(tok) || isLSB(tok) {
+		return 0, fmt.Errorf("expected number, got %s", tok)
 	}
 
-	n, err := num.Int64()
+	n, err := strconv.ParseInt(string(tok), 10, 64)
 	if err != nil {
 		return 0, err
 	}
@@ -197,44 +183,48 @@ func (d *ShapeDeserializer) ReadFloat64Ptr(s *smithy.Schema, v **float64) error 
 }
 
 func (d *ShapeDeserializer) readFloat() (float64, error) {
-	tok, err := d.token()
+	tok, err := d.next()
 	if err != nil {
 		return 0, err
 	}
 
-	switch v := tok.(type) {
-	case json.Number:
-		return v.Float64()
-	case string:
+	if isS(tok) {
+		s, err := str(tok)
+		if err != nil {
+			return 0, err
+		}
 		switch {
-		case strings.EqualFold(v, "NaN"):
+		case strings.EqualFold(s, "NaN"):
 			return math.NaN(), nil
-		case strings.EqualFold(v, "Infinity"):
+		case strings.EqualFold(s, "Infinity"):
 			return math.Inf(1), nil
-		case strings.EqualFold(v, "-Infinity"):
+		case strings.EqualFold(s, "-Infinity"):
 			return math.Inf(-1), nil
 		default:
-			return 0, fmt.Errorf("unexpected string value for float: %s", v)
+			return 0, fmt.Errorf("unexpected string value for float: %s", s)
 		}
-	default:
-		return 0, fmt.Errorf("expected number, got %T", tok)
 	}
+
+	return strconv.ParseFloat(string(tok), 64)
 }
 
 // ReadBool implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadBool(s *smithy.Schema, v *bool) error {
-	tok, err := d.token()
+	tok, err := d.next()
 	if err != nil {
 		return err
 	}
 
-	b, ok := tok.(bool)
-	if !ok {
-		return fmt.Errorf("expected bool, got %T", tok)
+	switch {
+	case isT(tok):
+		*v = true
+		return nil
+	case isF(tok):
+		*v = false
+		return nil
+	default:
+		return fmt.Errorf("expected bool, got %s", tok)
 	}
-
-	*v = b
-	return nil
 }
 
 // ReadBoolPtr implements [smithy.ShapeDeserializer].
@@ -247,14 +237,18 @@ func (d *ShapeDeserializer) ReadBoolPtr(s *smithy.Schema, v **bool) error {
 
 // ReadString implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadString(s *smithy.Schema, v *string) error {
-	tok, err := d.token()
+	tok, err := d.next()
 	if err != nil {
 		return err
 	}
 
-	str, ok := tok.(string)
-	if !ok {
-		return fmt.Errorf("expected string, got %T", tok)
+	if !isS(tok) {
+		return fmt.Errorf("expected string, got %s", tok)
+	}
+
+	str, err := str(tok)
+	if err != nil {
+		return err
 	}
 
 	*v = str
@@ -321,14 +315,18 @@ func (d *ShapeDeserializer) ReadTimePtr(schema *smithy.Schema, v **time.Time) er
 
 // ReadBlob implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadBlob(s *smithy.Schema, v *[]byte) error {
-	tok, err := d.token()
+	tok, err := d.next()
 	if err != nil {
 		return err
 	}
 
-	str, ok := tok.(string)
-	if !ok {
-		return fmt.Errorf("expected string, got %T", tok)
+	if !isS(tok) {
+		return fmt.Errorf("expected string, got %s", tok)
+	}
+
+	str, err := str(tok)
+	if err != nil {
+		return err
 	}
 
 	b, err := base64.StdEncoding.DecodeString(str)
@@ -342,107 +340,99 @@ func (d *ShapeDeserializer) ReadBlob(s *smithy.Schema, v *[]byte) error {
 
 // ReadList implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadList(s *smithy.Schema) error {
-	tok, err := d.token()
+	tok, err := d.next()
 	if err != nil {
 		return err
 	}
-
-	delim, ok := tok.(json.Delim)
-	if !ok || delim != '[' {
-		return fmt.Errorf("expected '[', got %v", tok)
+	if !isLSB(tok) {
+		return fmt.Errorf("expected '[', got %s", tok)
 	}
-
 	return nil
 }
 
 // ReadListItem implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadListItem(s *smithy.Schema) (bool, error) {
-	if !d.more() {
-		return false, d.expectDelim(']')
+	tok, err := d.peek()
+	if err != nil {
+		return false, err
 	}
-
+	if isRSB(tok) {
+		d.peeked = nil
+		return false, nil
+	}
 	return true, nil
 }
 
 // ReadMap implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadMap(s *smithy.Schema) error {
-	tok, err := d.token()
+	tok, err := d.next()
 	if err != nil {
 		return err
 	}
-
-	delim, ok := tok.(json.Delim)
-	if !ok || delim != '{' {
-		return fmt.Errorf("expected '{', got %v", tok)
+	if !isLCB(tok) {
+		return fmt.Errorf("expected '{', got %s", tok)
 	}
-
 	return nil
 }
 
 // ReadMapKey implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadMapKey(s *smithy.Schema) (string, bool, error) {
-	if !d.more() {
-		return "", false, d.expectDelim('}')
-	}
-
-	tok, err := d.token()
+	tok, err := d.next()
 	if err != nil {
 		return "", false, err
 	}
-
-	key, ok := tok.(string)
-	if !ok {
-		return "", false, fmt.Errorf("expected string key, got %T", tok)
+	if isRCB(tok) {
+		return "", false, nil
 	}
 
+	key, err := str(tok)
+	if err != nil {
+		return "", false, err
+	}
 	return key, true, nil
 }
 
 // ReadStruct implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadStruct(s *smithy.Schema) error {
-	tok, err := d.token()
+	tok, err := d.next()
 	if err != nil {
 		return err
 	}
-
-	delim, ok := tok.(json.Delim)
-	if !ok || delim != '{' {
-		return fmt.Errorf("expected '{', got %v", tok)
+	if !isLCB(tok) {
+		return fmt.Errorf("expected '{', got %s", tok)
 	}
-
 	d.head.Push(s)
 	return nil
 }
 
 // ReadStructMember implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadStructMember() (*smithy.Schema, error) {
-	if !d.more() {
+	tok, err := d.next()
+	if err != nil {
+		return nil, err
+	}
+	if isRCB(tok) {
 		d.head.Pop()
-		return nil, d.expectDelim('}')
+		return nil, nil
 	}
 
-	tok, err := d.token()
+	key, err := str(tok)
 	if err != nil {
 		return nil, err
 	}
 
-	key, ok := tok.(string)
-	if !ok {
-		return nil, fmt.Errorf("expected string key, got %T", tok)
-	}
-
-	schema, ok := d.head.Top().(*smithy.Schema)
-	if !ok {
+	schema := d.head.Top()
+	if schema == nil {
 		return nil, fmt.Errorf("ReadStructMember called without ReadStruct?")
 	}
 
 	member := schema.Member(key)
 	if member == nil {
 		// TODO smithy.api#jsonName
-		if err := d.skip(); err != nil {
+		if err := d.p.Skip(); err != nil {
 			return nil, err
 		}
-		return d.ReadStructMember() // just try the next one
+		return d.ReadStructMember()
 	}
 
 	return member, nil
@@ -450,119 +440,71 @@ func (d *ShapeDeserializer) ReadStructMember() (*smithy.Schema, error) {
 
 // ReadUnion implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadUnion(s *smithy.Schema) (*smithy.Schema, error) {
-	// Decode the entire union object to find the non-null member.
-	var raw map[string]json.RawMessage
-	if err := d.dec.Decode(&raw); err != nil {
-		return nil, fmt.Errorf("decode union: %w", err)
+	tok, err := d.next()
+	if err != nil {
+		return nil, err
+	}
+	if !isLCB(tok) {
+		return nil, fmt.Errorf("unexpected %s", tok)
 	}
 
-	for key, val := range raw {
-		if string(val) == "null" {
-			continue
+	for {
+		key, err := d.next()
+		if err != nil {
+			return nil, err
+		}
+		if isRCB(key) {
+			return nil, errors.New("empty union")
 		}
 
-		member := s.Member(key)
-		if member == nil {
-			continue
-		}
+		variant := s.Member(memberstr(key))
+		if variant != nil { // known member
+			value, err := d.peek()
+			if err != nil {
+				return nil, err
+			}
 
-		// Replace the decoder with one that reads just this value
-		dec := json.NewDecoder(bytes.NewReader(val))
-		dec.UseNumber()
-		d.dec = dec
-		return member, nil
+			if isN(value) { // explicit null, ignore it
+				d.next()
+				continue
+			}
+
+			// found the variant and we're set up to parse it next
+			return variant, nil
+		}
 	}
-
-	return nil, nil
 }
 
-// used to skip over a struct member that we didn't have a schema for, though
-// it also calls itself
-func (d *ShapeDeserializer) skip() error {
-	tok, err := d.token()
-	if err != nil {
-		return err
-	}
-
-	switch v := tok.(type) {
-	case json.Delim:
-		switch v {
-		case '{':
-			for d.more() {
-				if _, err := d.token(); err != nil { // the key
-					return err
-				}
-				if err := d.skip(); err != nil { // the value
-					return err
-				}
-			}
-			_, err := d.token() // the '}'
-			return err
-		case '[':
-			for d.more() {
-				if err := d.skip(); err != nil {
-					return err
-				}
-			}
-			_, err := d.token() // the ']'
-			return err
-		default:
-			return fmt.Errorf("unexpected delimiter: %v", v)
-		}
-	default:
-		return nil // scalar, don't have to do anything else
-	}
+func (d *ShapeDeserializer) CloseUnion(s *smithy.Schema) error {
+	_, err := d.next()
+	return err
 }
 
 // ReadDocument reads a JSON value into a document Value.
-//
-// For now this produces an [document.Opaque] wrapping the raw decoded value,
-// which is what the legacy document bridge in generated code expects. The
-// jsonToValue conversion is available for future use when the new typed
-// document path is wired up end-to-end.
 func (d *ShapeDeserializer) ReadDocument(schema *smithy.Schema, v *document.Value) error {
-	var raw any
-	if err := d.dec.Decode(&raw); err != nil {
+	vv, err := d.p.Value()
+	if err != nil {
 		return err
 	}
-
-	*v = document.Opaque{Value: raw}
+	*v = &document.Opaque{vv}
 	return nil
 }
 
-func jsonToValue(v any) (document.Value, error) {
-	switch vv := v.(type) {
-	case nil:
-		return document.Null{}, nil
-	case bool:
-		return document.Boolean(vv), nil
-	case json.Number:
-		return document.Number(vv.String()), nil
-	case float64:
-		return document.Number(fmt.Sprintf("%v", vv)), nil
-	case string:
-		return document.String(vv), nil
-	case []any:
-		list := make(document.List, len(vv))
-		for i, item := range vv {
-			dv, err := jsonToValue(item)
-			if err != nil {
-				return nil, err
-			}
-			list[i] = dv
-		}
-		return list, nil
-	case map[string]any:
-		m := make(document.Map, len(vv))
-		for k, item := range vv {
-			dv, err := jsonToValue(item)
-			if err != nil {
-				return nil, err
-			}
-			m[k] = dv
-		}
-		return m, nil
-	default:
-		return nil, fmt.Errorf("unexpected JSON type %T", v)
-	}
+func str(tok []byte) (string, error) {
+	return strconv.Unquote(string(tok))
 }
+
+// faster version of str specifically for member keys which we know won't have
+// ctrl chars
+func memberstr(tok []byte) string {
+	return string(tok[1 : len(tok)-1])
+}
+
+func isN(tok []byte) bool   { return tok[0] == 'n' }
+func isT(tok []byte) bool   { return tok[0] == 't' }
+func isF(tok []byte) bool   { return tok[0] == 'f' }
+func isS(tok []byte) bool   { return tok[0] == '"' }
+func isLCB(tok []byte) bool { return tok[0] == '{' }
+func isRCB(tok []byte) bool { return tok[0] == '}' }
+func isLSB(tok []byte) bool { return tok[0] == '[' }
+func isRSB(tok []byte) bool { return tok[0] == ']' }

--- a/aws-protocols/internal/json/shape_serializer.go
+++ b/aws-protocols/internal/json/shape_serializer.go
@@ -16,7 +16,7 @@ import (
 // ShapeSerializer implements marshaling of Smithy shapes to JSON.
 type ShapeSerializer struct {
 	root *smithyjson.Encoder
-	head stack
+	head stackT[any]
 
 	opts ShapeSerializerOptions
 }
@@ -474,29 +474,4 @@ func (s *ShapeSerializer) writeDocumentRaw(schema *smithy.Schema, p []byte) {
 	default:
 		s.root.Write(p)
 	}
-}
-
-type stack struct {
-	values []any
-}
-
-type empty struct{}
-
-func (s *stack) Top() any {
-	if len(s.values) == 0 {
-		return empty{}
-	}
-	return s.values[len(s.values)-1]
-}
-
-func (s *stack) Push(v any) {
-	s.values = append(s.values, v)
-}
-
-func (s *stack) Pop() {
-	s.values = s.values[:len(s.values)-1]
-}
-
-func (s *stack) Len() int {
-	return len(s.values)
 }

--- a/aws-protocols/internal/json/shape_serializer.go
+++ b/aws-protocols/internal/json/shape_serializer.go
@@ -1,0 +1,502 @@
+package json
+
+import (
+	"math"
+	"math/big"
+	"time"
+
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/document"
+	smithydocumentjson "github.com/aws/smithy-go/document/json"
+	smithyjson "github.com/aws/smithy-go/encoding/json"
+	smithytime "github.com/aws/smithy-go/time"
+	"github.com/aws/smithy-go/traits"
+)
+
+// ShapeSerializer implements marshaling of Smithy shapes to JSON.
+type ShapeSerializer struct {
+	root *smithyjson.Encoder
+	head stack
+
+	opts ShapeSerializerOptions
+}
+
+// ShapeSerializerOptions configures ShapeSerializer.
+type ShapeSerializerOptions struct {
+	// Controls whether scalar zero values (numbers, strings, bools) are
+	// written. If false (the default), zero values are not encoded.
+	//
+	// Pointer write methods are NOT affected by this option.
+	WriteZeroValues bool
+}
+
+var _ smithy.ShapeSerializer = (*ShapeSerializer)(nil)
+
+// NewShapeSerializer creates a new ShapeSerializer.
+func NewShapeSerializer(opts ...func(*ShapeSerializerOptions)) *ShapeSerializer {
+	o := ShapeSerializerOptions{}
+	for _, fn := range opts {
+		fn(&o)
+	}
+	return &ShapeSerializer{
+		root: smithyjson.NewEncoder(),
+		opts: o,
+	}
+}
+
+// Bytes returns the serialized JSON bytes.
+func (s *ShapeSerializer) Bytes() []byte {
+	return s.root.Bytes()
+}
+
+// WriteInt8Ptr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt8Ptr(schema *smithy.Schema, v *int8) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteInt8(schema, *v) })
+	}
+}
+
+// WriteInt16Ptr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt16Ptr(schema *smithy.Schema, v *int16) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteInt16(schema, *v) })
+	}
+}
+
+// WriteInt32Ptr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt32Ptr(schema *smithy.Schema, v *int32) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteInt32(schema, *v) })
+	}
+}
+
+// WriteInt64Ptr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt64Ptr(schema *smithy.Schema, v *int64) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteInt64(schema, *v) })
+	}
+}
+
+// WriteFloat32Ptr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteFloat32Ptr(schema *smithy.Schema, v *float32) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteFloat32(schema, *v) })
+	}
+}
+
+// WriteFloat64Ptr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteFloat64Ptr(schema *smithy.Schema, v *float64) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteFloat64(schema, *v) })
+	}
+}
+
+// WriteBoolPtr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteBoolPtr(schema *smithy.Schema, v *bool) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteBool(schema, *v) })
+	}
+}
+
+// WriteStringPtr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteStringPtr(schema *smithy.Schema, v *string) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteString(schema, *v) })
+	}
+}
+
+func (s *ShapeSerializer) withWriteZero(fn func()) {
+	prev := s.opts.WriteZeroValues
+	s.opts.WriteZeroValues = true
+	fn()
+	s.opts.WriteZeroValues = prev
+}
+
+// WriteBool implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteBool(schema *smithy.Schema, v bool) {
+	if !s.opts.WriteZeroValues && !v {
+		return
+	}
+	switch enc := s.head.Top().(type) {
+	case *smithyjson.Object:
+		enc.Key(schema.MemberName()).Boolean(v)
+	case *smithyjson.Array:
+		enc.Value().Boolean(v)
+	default:
+		s.root.Boolean(v)
+	}
+}
+
+// WriteInt8 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt8(schema *smithy.Schema, v int8) {
+	if !s.opts.WriteZeroValues && v == 0 {
+		return
+	}
+	switch enc := s.head.Top().(type) {
+	case *smithyjson.Object:
+		enc.Key(schema.MemberName()).Byte(v)
+	case *smithyjson.Array:
+		enc.Value().Byte(v)
+	default:
+		s.root.Byte(v)
+	}
+}
+
+// WriteInt16 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt16(schema *smithy.Schema, v int16) {
+	if !s.opts.WriteZeroValues && v == 0 {
+		return
+	}
+	switch enc := s.head.Top().(type) {
+	case *smithyjson.Object:
+		enc.Key(schema.MemberName()).Short(v)
+	case *smithyjson.Array:
+		enc.Value().Short(v)
+	default:
+		s.root.Short(v)
+	}
+}
+
+// WriteInt32 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt32(schema *smithy.Schema, v int32) {
+	if !s.opts.WriteZeroValues && v == 0 {
+		return
+	}
+	switch enc := s.head.Top().(type) {
+	case *smithyjson.Object:
+		enc.Key(schema.MemberName()).Integer(v)
+	case *smithyjson.Array:
+		enc.Value().Integer(v)
+	case smithyjson.Value:
+		enc.Integer(v)
+		s.head.Pop()
+	default:
+		s.root.Integer(v)
+	}
+}
+
+// WriteInt64 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt64(schema *smithy.Schema, v int64) {
+	if !s.opts.WriteZeroValues && v == 0 {
+		return
+	}
+	switch enc := s.head.Top().(type) {
+	case *smithyjson.Object:
+		enc.Key(schema.MemberName()).Long(v)
+	case *smithyjson.Array:
+		enc.Value().Long(v)
+	default:
+		s.root.Long(v)
+	}
+}
+
+// WriteFloat32 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteFloat32(schema *smithy.Schema, v float32) {
+	if !s.opts.WriteZeroValues && v == 0 {
+		return
+	}
+
+	var jv smithyjson.Value
+	switch enc := s.head.Top().(type) {
+	case *smithyjson.Object:
+		jv = enc.Key(schema.MemberName())
+	case *smithyjson.Array:
+		jv = enc.Value()
+	default:
+		s.root.Float(v)
+		return
+	}
+
+	if math.IsInf(float64(v), 1) {
+		jv.String("Infinity")
+	} else if math.IsInf(float64(v), -1) {
+		jv.String("-Infinity")
+	} else if math.IsNaN(float64(v)) {
+		jv.String("NaN")
+	}
+}
+
+// WriteFloat64 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteFloat64(schema *smithy.Schema, v float64) {
+	if !s.opts.WriteZeroValues && v == 0 {
+		return
+	}
+
+	var jv smithyjson.Value
+	switch enc := s.head.Top().(type) {
+	case *smithyjson.Object:
+		jv = enc.Key(schema.MemberName())
+	case *smithyjson.Array:
+		jv = enc.Value()
+	default:
+		s.root.Double(v)
+		return
+	}
+
+	if math.IsInf(v, 1) {
+		jv.String("Infinity")
+	} else if math.IsInf(v, -1) {
+		jv.String("-Infinity")
+	} else if math.IsNaN(v) {
+		jv.String("NaN")
+	}
+}
+
+// WriteString implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteString(schema *smithy.Schema, v string) {
+	if !s.opts.WriteZeroValues && v == "" {
+		return
+	}
+	switch enc := s.head.Top().(type) {
+	case *smithyjson.Object:
+		enc.Key(schema.MemberName()).String(v)
+	case *smithyjson.Array:
+		enc.Value().String(v)
+	case smithyjson.Value:
+		enc.String(v)
+		s.head.Pop()
+	default:
+		s.root.Value.String(v)
+	}
+}
+
+// WriteBlob implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteBlob(schema *smithy.Schema, v []byte) {
+	switch enc := s.head.Top().(type) {
+	case *smithyjson.Object:
+		enc.Key(schema.MemberName()).Base64EncodeBytes(v)
+	case *smithyjson.Array:
+		enc.Value().Base64EncodeBytes(v)
+	case smithyjson.Value:
+		enc.Base64EncodeBytes(v)
+		s.head.Pop()
+	default:
+		s.root.Value.Base64EncodeBytes(v)
+	}
+}
+
+// WriteList implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteList(schema *smithy.Schema) {
+	switch enc := s.head.Top().(type) {
+	case *smithyjson.Object:
+		s.head.Push(enc.Key(schema.MemberName()).Array())
+	case *smithyjson.Array:
+		s.head.Push(enc.Value().Array())
+	case smithyjson.Value:
+		s.head.Push(enc.Array())
+	default:
+		s.head.Push(s.root.Array())
+	}
+}
+
+// CloseList implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) CloseList() {
+	if enc, ok := s.head.Top().(*smithyjson.Array); ok {
+		enc.Close()
+		s.head.Pop()
+	}
+}
+
+// WriteMap implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteMap(schema *smithy.Schema) {
+	switch enc := s.head.Top().(type) {
+	case *smithyjson.Object:
+		s.head.Push(enc.Key(schema.MemberName()).Object())
+	case *smithyjson.Array:
+		s.head.Push(enc.Value().Object())
+	case smithyjson.Value:
+		s.head.Push(enc.Object())
+	default:
+		s.head.Push(s.root.Object())
+	}
+}
+
+// WriteKey implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteKey(schema *smithy.Schema, key string) {
+	if enc, ok := s.head.Top().(*smithyjson.Object); ok {
+		s.head.Push(enc.Key(key))
+	}
+}
+
+// CloseMap implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) CloseMap() {
+	if enc, ok := s.head.Top().(*smithyjson.Object); ok {
+		enc.Close()
+		s.head.Pop()
+
+		// if this is a map _inside_ a map, pop off the underlying key encoder
+		// as well (for scalar values that's not necessarily since we can
+		// deterministically do it there)
+		if _, ok := s.head.Top().(smithyjson.Value); ok {
+			s.head.Pop()
+		}
+	}
+}
+
+// WriteTime implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteTime(schema *smithy.Schema, v time.Time) {
+	format := "epoch-seconds"
+	if t, ok := smithy.SchemaTrait[*traits.TimestampFormat](schema); ok {
+		format = t.Format
+	}
+
+	switch format {
+	case "date-time":
+		s.WriteString(schema, smithytime.FormatDateTime(v))
+	case "http-date":
+		s.WriteString(schema, smithytime.FormatHTTPDate(v))
+	default:
+		s.WriteFloat64(schema, smithytime.FormatEpochSeconds(v))
+	}
+}
+
+// WriteTimePtr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteTimePtr(schema *smithy.Schema, v *time.Time) {
+	if v != nil {
+		s.WriteTime(schema, *v)
+	}
+}
+
+// WriteUnion implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteUnion(schema, variant *smithy.Schema, v smithy.Serializable) {
+	switch enc := s.head.Top().(type) {
+	case *smithyjson.Object:
+		s.head.Push(enc.Key(schema.MemberName()).Object())
+	case *smithyjson.Array:
+		s.head.Push(enc.Value().Object())
+	case smithyjson.Value:
+		s.head.Push(enc.Object())
+	default:
+		s.head.Push(s.root.Object())
+	}
+
+	top := s.head.Top().(*smithyjson.Object)
+	s.head.Push(top.Key(variant.MemberName()))
+
+	v.Serialize(s)
+
+	top.Close()
+	s.head.Pop()
+}
+
+// WriteStruct implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteStruct(schema *smithy.Schema, v smithy.Serializable) {
+	if v == nil {
+		return
+	}
+
+	switch enc := s.head.Top().(type) {
+	case *smithyjson.Object:
+		s.head.Push(enc.Key(schema.MemberName()))
+	case *smithyjson.Array:
+		s.head.Push(enc.Value())
+	}
+
+	v.Serialize(s)
+}
+
+// WriteNil implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteNil(schema *smithy.Schema) {
+	switch enc := s.head.Top().(type) {
+	case *smithyjson.Object:
+		enc.Key(schema.MemberName()).Null()
+	case *smithyjson.Array:
+		enc.Value().Null()
+	case smithyjson.Value:
+		enc.Null()
+		s.head.Pop()
+	default:
+		s.root.Null()
+	}
+}
+
+// WriteBigInteger is unimplemented and will panic.
+func (s *ShapeSerializer) WriteBigInteger(schema *smithy.Schema, v big.Int) {
+	panic("unimplemented")
+}
+
+// WriteBigDecimal is unimplemented and will panic.
+func (s *ShapeSerializer) WriteBigDecimal(schema *smithy.Schema, v big.Float) {
+	panic("unimplemented")
+}
+
+// WriteDocument writes a document value to JSON.
+func (s *ShapeSerializer) WriteDocument(schema *smithy.Schema, v document.Value) {
+	switch vv := v.(type) {
+	case document.Null:
+		s.WriteNil(schema)
+	case document.Boolean:
+		s.WriteBool(schema, bool(vv))
+	case document.Number:
+		s.writeDocumentRaw(schema, []byte(vv))
+	case document.String:
+		s.WriteString(schema, string(vv))
+	case document.Blob:
+		s.WriteBlob(schema, []byte(vv))
+	case document.Timestamp:
+		s.WriteTime(schema, time.Time(vv))
+	case document.List:
+		s.WriteList(schema)
+		for _, item := range vv {
+			s.WriteDocument(schema.ListMember(), item)
+		}
+		s.CloseList()
+	case document.Map:
+		s.WriteMap(schema)
+		for k, item := range vv {
+			s.WriteKey(schema.MapKey(), k)
+			s.WriteDocument(schema.MapValue(), item)
+		}
+		s.CloseMap()
+	case document.Structure:
+		s.WriteMap(schema)
+		for k, item := range vv.Members {
+			s.WriteKey(nil, k)
+			s.WriteDocument(nil, item)
+		}
+		s.CloseMap()
+	case document.Opaque:
+		denc := smithydocumentjson.NewEncoder()
+		p, _ := denc.Encode(vv.Value)
+		s.writeDocumentRaw(schema, p)
+	}
+}
+
+func (s *ShapeSerializer) writeDocumentRaw(schema *smithy.Schema, p []byte) {
+	switch enc := s.head.Top().(type) {
+	case *smithyjson.Object:
+		enc.Key(schema.MemberName()).Write(p)
+	case *smithyjson.Array:
+		enc.Value().Write(p)
+	case smithyjson.Value:
+		enc.Write(p)
+		s.head.Pop()
+	default:
+		s.root.Write(p)
+	}
+}
+
+type stack struct {
+	values []any
+}
+
+type empty struct{}
+
+func (s *stack) Top() any {
+	if len(s.values) == 0 {
+		return empty{}
+	}
+	return s.values[len(s.values)-1]
+}
+
+func (s *stack) Push(v any) {
+	s.values = append(s.values, v)
+}
+
+func (s *stack) Pop() {
+	s.values = s.values[:len(s.values)-1]
+}
+
+func (s *stack) Len() int {
+	return len(s.values)
+}

--- a/aws-protocols/internal/json/stack.go
+++ b/aws-protocols/internal/json/stack.go
@@ -1,0 +1,38 @@
+package json
+
+// chosen as an arbitrary average max depth for the RPC-style payloads we
+// typically deal with in an SDK client
+const initialCap = 8
+
+type stackT[T any] struct {
+	values   []T
+	sentinel T
+}
+
+func newStackT[T any](sentinel T) stackT[T] {
+	return stackT[T]{
+		values:   make([]T, 0, initialCap),
+		sentinel: sentinel,
+	}
+}
+
+func (s *stackT[T]) Push(v T) {
+	s.values = append(s.values, v)
+}
+
+func (s *stackT[T]) Pop() T {
+	if len(s.values) == 0 {
+		return s.sentinel
+	}
+	idx := len(s.values) - 1
+	v := s.values[idx]
+	s.values = s.values[:idx]
+	return v
+}
+
+func (s *stackT[T]) Top() T {
+	if len(s.values) == 0 {
+		return s.sentinel
+	}
+	return s.values[len(s.values)-1]
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/AbstractDirectedCodegen.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/AbstractDirectedCodegen.java
@@ -89,12 +89,9 @@ public abstract class AbstractDirectedCodegen implements DirectedCodegen<GoCodeg
         var delegator = directive.context().writerDelegator();
         delegator.useShapeWriter(directive.shape(), writer ->
                 new StructureGenerator(
-                        directive.model(),
-                        directive.symbolProvider(),
+                        directive.context(),
                         writer,
-                        directive.service(),
                         directive.shape(),
-                        directive.symbolProvider().toSymbol(directive.shape()),
                         null
                 ).run()
         );
@@ -105,12 +102,9 @@ public abstract class AbstractDirectedCodegen implements DirectedCodegen<GoCodeg
         var delegator = directive.context().writerDelegator();
         delegator.useShapeWriter(directive.shape(), writer ->
                 new StructureGenerator(
-                        directive.model(),
-                        directive.symbolProvider(),
+                        directive.context(),
                         writer,
-                        directive.service(),
                         directive.shape(),
-                        directive.symbolProvider().toSymbol(directive.shape()),
                         null
                 ).run()
         );

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/AbstractDirectedCodegen.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/AbstractDirectedCodegen.java
@@ -114,7 +114,7 @@ public abstract class AbstractDirectedCodegen implements DirectedCodegen<GoCodeg
     public void generateUnion(GenerateUnionDirective<GoCodegenContext, GoSettings> directive) {
         var delegator = directive.context().writerDelegator();
         delegator.useShapeWriter(directive.shape(), writer ->
-                new UnionGenerator(directive.model(), directive.symbolProvider(), directive.shape())
+                new UnionGenerator(directive.context(), directive.model(), directive.symbolProvider(), directive.shape())
                         .generateUnion(writer)
         );
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ChainWritable.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ChainWritable.java
@@ -11,6 +11,8 @@ import software.amazon.smithy.utils.ListUtils;
  * Chains together multiple Writables that can be composed into one Writable.
  */
 public final class ChainWritable {
+    // FUTURE: move statics to Writable, make this file- or package-private
+
     private final List<Writable> writables;
 
     public ChainWritable() {
@@ -26,6 +28,14 @@ public final class ChainWritable {
     public static ChainWritable of(Collection<Writable> writables) {
         var chain = new ChainWritable();
         chain.writables.addAll(writables);
+        return chain;
+    }
+
+    public static <T> ChainWritable of(Collection<T> values, Function<T, Writable> mapper) {
+        var chain = new ChainWritable();
+        chain.writables.addAll(values.stream()
+                .map(mapper)
+                .toList());
         return chain;
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ClientOptions.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ClientOptions.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.go.codegen;
 
+import static software.amazon.smithy.go.codegen.GoWriter.emptyGoTemplate;
 import static software.amazon.smithy.go.codegen.GoWriter.goDocTemplate;
 import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
 
@@ -40,13 +41,15 @@ import software.amazon.smithy.utils.MapUtils;
 public class ClientOptions implements Writable {
     public static final String NAME = "Options";
 
+    private final GoCodegenContext ctx;
     private final ProtocolGenerator.GenerationContext context;
     private final ApplicationProtocol protocol;
 
     private final List<ConfigField> fields;
     private final Map<ShapeId, AuthSchemeDefinition> authSchemes;
 
-    public ClientOptions(ProtocolGenerator.GenerationContext context, ApplicationProtocol protocol) {
+    public ClientOptions(GoCodegenContext ctx, ProtocolGenerator.GenerationContext context, ApplicationProtocol protocol) {
+        this.ctx = ctx;
         this.context = context;
         this.protocol = protocol;
 
@@ -82,6 +85,8 @@ public class ClientOptions implements Writable {
 
                     $fields:W
 
+                    $experimentalSerdeProtocolFields:W
+
                     $protocolFields:W
                 }
 
@@ -100,8 +105,19 @@ public class ClientOptions implements Writable {
                         "protocolFields", generateProtocolFields(),
                         "copy", generateCopy(),
                         "getIdentityResolver", generateGetIdentityResolver(),
-                        "helpers", generateHelpers()
+                        "helpers", generateHelpers(),
+                        "experimentalSerdeProtocolFields", ctx.settings().useExperimentalSerde()
+                                ? generateExperimentalSerdeProtocolFields()
+                                : emptyGoTemplate()
                 ));
+    }
+
+    private Writable generateExperimentalSerdeProtocolFields() {
+        ensureSupportedProtocol();
+        return goTemplate("""
+                $D
+                Protocol smithyhttp.ClientProtocol
+                """, SmithyGoDependency.SMITHY_HTTP_TRANSPORT);
     }
 
     private Writable generateProtocolTypes() {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -15,13 +15,10 @@
 
 package software.amazon.smithy.go.codegen;
 
-import static java.util.stream.Collectors.toSet;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -38,22 +35,31 @@ import software.amazon.smithy.go.codegen.GoSettings.ArtifactType;
 import software.amazon.smithy.go.codegen.integration.GoIntegration;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.go.codegen.integration.RuntimeClientPlugin;
+import software.amazon.smithy.go.codegen.serde2.ListDeserializer;
+import software.amazon.smithy.go.codegen.serde2.ListSerializer;
+import software.amazon.smithy.go.codegen.serde2.MapDeserializer;
+import software.amazon.smithy.go.codegen.serde2.MapSerializer;
+import software.amazon.smithy.go.codegen.serde2.Serde2DeserializeResponseMiddleware;
+import software.amazon.smithy.go.codegen.serde2.Serde2SerializeRequestMiddleware;
+import software.amazon.smithy.go.codegen.serde2.UnionDeserializer;
+import software.amazon.smithy.go.codegen.serde2.UnionSerializer;
+import software.amazon.smithy.go.codegen.util.ShapeUtil;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.neighbor.Walker;
 import software.amazon.smithy.model.shapes.IntEnumShape;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.ShapeVisitor;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.EnumTrait;
-import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.transform.ModelTransformer;
 import software.amazon.smithy.utils.OptionalUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -223,6 +229,10 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
         TopDownIndex.of(model).getContainedOperations(service)
                 .forEach(eventStreamGenerator::generateOperationEventStreamStructure);
 
+        // All of these things will completely go away when serde2 is done.
+        //
+        // There is a block further down after the serde2 stuff that also uses the protocol generator, but that all will
+        // have to be pulled out of ProtocolGenerator and just be generic.
         if (!settings.useExperimentalSerde() && protocolGenerator != null) {
             LOGGER.info("Generating serde for protocol " + protocolGenerator.getProtocol() + " on " + service.getId());
             ProtocolGenerator.GenerationContext.Builder contextBuilder = ProtocolGenerator.GenerationContext.builder()
@@ -255,43 +265,73 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
                 });
             }
 
-            LOGGER.info("Generating protocol " + protocolGenerator.getProtocol()
-                    + " unit tests for " + service.getId());
-            writers.useFileWriter("protocol_test.go", settings.getModuleName(), writer -> {
-                protocolGenerator.generateProtocolTests(contextBuilder.writer(writer).build());
-            });
-
             protocolDocumentGenerator.generateInternalDocumentTypes(protocolGenerator, contextBuilder.build());
         }
 
+        LOGGER.info("Generating protocol tests for " + service.getId());
+        ProtocolUtils.generateHttpProtocolTests(ctx);
+
         if (settings.useExperimentalSerde()) {
-            var walker = new Walker(model);
-            var operations = TopDownIndex.of(model).getContainedOperations(service);
+            protocolDocumentGenerator.generateLegacyInternalDocumentTypes(ctx);
 
-            var shapes = new HashSet<Shape>();
-            shapes.addAll(operations.stream()
-                    .map(it -> model.expectShape(it.getInputShape()))
-                    .flatMap(it -> walker.walkShapes(it).stream())
-                    .collect(toSet()));
-            shapes.addAll(operations.stream()
-                    .map(it -> model.expectShape(it.getOutputShape()))
-                    .flatMap(it -> walker.walkShapes(it).stream())
-                    .collect(toSet()));
-            shapes.addAll(model.getStructureShapesWithTrait(ErrorTrait.class).stream()
-                    .flatMap(it -> walker.walkShapes(it).stream())
-                    .collect(toSet()));
+            var shapes = new ArrayList<>(ctx.serdeShapes());
+            shapes.add(ShapeUtil.UNIT); // targeted by enum members, just generate a blank schema for it
 
-            var sortedShapes = new ArrayList<>(shapes.stream()
-                    .sorted()
-                    .filter(it -> it.getType() != ShapeType.MEMBER)
-                    .toList());
+            ctx.writerDelegator().useFileWriter("type_registry.go", settings.getModuleName(), new TypeRegistry(ctx));
 
-            sortedShapes.add(StructureShape.builder().id("smithy.api#Unit").build());
+            ctx.writerDelegator().useFileWriter("schemas/schemas.go", settings.getModuleName() + "/schemas", writer -> {
+                for (Shape shape : shapes) {
+                    new SchemaGenerator(ctx, shape).accept(writer);
+                }
 
-            ctx.writerDelegator().useFileWriter("schemas/schemas.go", settings.getModuleName() + "/schemas",
-                    Writable.map(sortedShapes, it -> new SchemaGenerator(ctx, it), true));
+                writer.write("");
+                writer.writeDocs("Initialize schema members after all schemas are declared to avoid initialization cycles");
+                writer.openBlock("func init() {", "}", () -> {
+                    for (Shape shape : shapes) {
+                        new SchemaGenerator(ctx, shape).acceptMembersInit(writer);
+                    }
+                });
+            });
+
+            var lists = ctx.serdeShapes(ListShape.class);
+            var maps = ctx.serdeShapes(MapShape.class);
+            var unionSerdes = ctx.serdeShapes(UnionShape.class);
+
+            // unfortunately since we have input/output in the top-level package and nested shapes in types/ we have to
+            // generate these twice since we don't want to export them
+            //
+            // also rn we don't check for what's actually used in either package at all but DCE should take care of that
+
+            ctx.writerDelegator().useFileWriter("common_serde.go", settings.getModuleName(),
+                    Writable.map(unionSerdes, it -> new UnionSerializer(ctx, it), true));
+            ctx.writerDelegator().useFileWriter("types/common_serde.go", settings.getModuleName() + "/types",
+                    Writable.map(unionSerdes, it -> new UnionSerializer(ctx, it), true));
+            ctx.writerDelegator().useFileWriter("common_serde.go", settings.getModuleName(),
+                    Writable.map(unionSerdes, it -> new UnionDeserializer(ctx, it), true));
+            ctx.writerDelegator().useFileWriter("types/common_serde.go", settings.getModuleName() + "/types",
+                    Writable.map(unionSerdes, it -> new UnionDeserializer(ctx, it), true));
+
+            ctx.writerDelegator().useFileWriter("common_serde.go", settings.getModuleName(),
+                    Writable.map(lists, it -> new ListSerializer(ctx, it), true));
+            ctx.writerDelegator().useFileWriter("types/common_serde.go", settings.getModuleName() + "/types",
+                    Writable.map(lists, it -> new ListSerializer(ctx, it), true));
+            ctx.writerDelegator().useFileWriter("common_serde.go", settings.getModuleName(),
+                    Writable.map(lists, it -> new ListDeserializer(ctx, it), true));
+            ctx.writerDelegator().useFileWriter("types/common_serde.go", settings.getModuleName() + "/types",
+                    Writable.map(lists, it -> new ListDeserializer(ctx, it), true));
+
+            ctx.writerDelegator().useFileWriter("common_serde.go", settings.getModuleName(),
+                    Writable.map(maps, it -> new MapSerializer(ctx, it), true));
+            ctx.writerDelegator().useFileWriter("types/common_serde.go", settings.getModuleName() + "/types",
+                    Writable.map(maps, it -> new MapSerializer(ctx, it), true));
+            ctx.writerDelegator().useFileWriter("common_serde.go", settings.getModuleName(),
+                    Writable.map(maps, it -> new MapDeserializer(ctx, it), true));
+            ctx.writerDelegator().useFileWriter("types/common_serde.go", settings.getModuleName() + "/types",
+                    Writable.map(maps, it -> new MapDeserializer(ctx, it), true));
         }
 
+        // This is all stuff that we'll still need to do but it DEPENDS on ProtocolGenerator right now
+        //
         // TODO: With serde/schema decoupling, protocol generators are going away. Endpoint/auth resolution is going to
         //       need to be decoupled from that and I don't really know how yet. Probably just separate integrations /
         //       integration hooks.
@@ -318,11 +358,6 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
                 ProtocolGenerator.GenerationContext context = contextBuilder.writer(writer).build();
                 protocolGenerator.generateEndpointResolutionTests(context);
             });
-
-            LOGGER.info("Generating protocol tests for " + service.getId());
-            ProtocolUtils.generateHttpProtocolTests(ctx);
-
-            protocolDocumentGenerator.generateInternalDocumentTypes(protocolGenerator, contextBuilder.build());
         }
 
         LOGGER.fine("Flushing go writers");
@@ -366,9 +401,13 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
     @Override
     public Void unionShape(UnionShape shape) {
-        UnionGenerator generator = new UnionGenerator(model, symbolProvider, shape);
+        UnionGenerator generator = new UnionGenerator(ctx, model, symbolProvider, shape);
         writers.useShapeWriter(shape, generator::generateUnion);
         writers.useShapeExportedTestWriter(shape, generator::generateUnionExamples);
+
+        if (settings.useExperimentalSerde()) {
+            // TODO schema probably
+        }
         return null;
     }
 
@@ -419,7 +458,12 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
             }
         });
 
-        var clientOptions = new ClientOptions(context, protocol);
+        if (ctx.settings().useExperimentalSerde()) {
+            writers.useShapeWriter(shape, new Serde2SerializeRequestMiddleware());
+            writers.useShapeWriter(shape, new Serde2DeserializeResponseMiddleware());
+        }
+
+        var clientOptions = new ClientOptions(ctx, context, protocol);
         writers.useFileWriter("options.go", settings.getModuleName(), clientOptions);
         return null;
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -15,10 +15,13 @@
 
 package software.amazon.smithy.go.codegen;
 
+import static java.util.stream.Collectors.toSet;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -29,7 +32,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.build.PluginContext;
-import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.go.codegen.GoSettings.ArtifactType;
@@ -45,11 +47,13 @@ import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.ShapeVisitor;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.transform.ModelTransformer;
 import software.amazon.smithy.utils.OptionalUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -219,7 +223,7 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
         TopDownIndex.of(model).getContainedOperations(service)
                 .forEach(eventStreamGenerator::generateOperationEventStreamStructure);
 
-        if (protocolGenerator != null) {
+        if (!settings.useExperimentalSerde() && protocolGenerator != null) {
             LOGGER.info("Generating serde for protocol " + protocolGenerator.getProtocol() + " on " + service.getId());
             ProtocolGenerator.GenerationContext.Builder contextBuilder = ProtocolGenerator.GenerationContext.builder()
                     .protocolName(protocolGenerator.getProtocolName())
@@ -251,6 +255,55 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
                 });
             }
 
+            LOGGER.info("Generating protocol " + protocolGenerator.getProtocol()
+                    + " unit tests for " + service.getId());
+            writers.useFileWriter("protocol_test.go", settings.getModuleName(), writer -> {
+                protocolGenerator.generateProtocolTests(contextBuilder.writer(writer).build());
+            });
+
+            protocolDocumentGenerator.generateInternalDocumentTypes(protocolGenerator, contextBuilder.build());
+        }
+
+        if (settings.useExperimentalSerde()) {
+            var walker = new Walker(model);
+            var operations = TopDownIndex.of(model).getContainedOperations(service);
+
+            var shapes = new HashSet<Shape>();
+            shapes.addAll(operations.stream()
+                    .map(it -> model.expectShape(it.getInputShape()))
+                    .flatMap(it -> walker.walkShapes(it).stream())
+                    .collect(toSet()));
+            shapes.addAll(operations.stream()
+                    .map(it -> model.expectShape(it.getOutputShape()))
+                    .flatMap(it -> walker.walkShapes(it).stream())
+                    .collect(toSet()));
+            shapes.addAll(model.getStructureShapesWithTrait(ErrorTrait.class).stream()
+                    .flatMap(it -> walker.walkShapes(it).stream())
+                    .collect(toSet()));
+
+            var sortedShapes = new ArrayList<>(shapes.stream()
+                    .sorted()
+                    .filter(it -> it.getType() != ShapeType.MEMBER)
+                    .toList());
+
+            sortedShapes.add(StructureShape.builder().id("smithy.api#Unit").build());
+
+            ctx.writerDelegator().useFileWriter("schemas/schemas.go", settings.getModuleName() + "/schemas",
+                    Writable.map(sortedShapes, it -> new SchemaGenerator(ctx, it), true));
+        }
+
+        // TODO: With serde/schema decoupling, protocol generators are going away. Endpoint/auth resolution is going to
+        //       need to be decoupled from that and I don't really know how yet. Probably just separate integrations /
+        //       integration hooks.
+        if (protocolGenerator != null) {
+            ProtocolGenerator.GenerationContext.Builder contextBuilder = ProtocolGenerator.GenerationContext.builder()
+                    .protocolName(protocolGenerator.getProtocolName())
+                    .integrations(integrations)
+                    .model(model)
+                    .service(service)
+                    .settings(settings)
+                    .symbolProvider(symbolProvider)
+                    .delegator(writers);
             writers.useFileWriter("endpoints.go", settings.getModuleName(), writer -> {
                 ProtocolGenerator.GenerationContext context = contextBuilder.writer(writer).build();
                 protocolGenerator.generateEndpointResolution(context);
@@ -297,9 +350,9 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
         if (shape.getId().getNamespace().equals(CodegenUtils.getSyntheticTypeNamespace())) {
             return null;
         }
-        Symbol symbol = symbolProvider.toSymbol(shape);
-        writers.useShapeWriter(shape, writer -> new StructureGenerator(
-                model, symbolProvider, writer, service, shape, symbol, protocolGenerator).run());
+        writers.useShapeWriter(shape, writer ->
+                new StructureGenerator(ctx, writer, shape, protocolGenerator).run());
+
         return null;
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/DefaultTraitGenerators.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/DefaultTraitGenerators.java
@@ -1,0 +1,86 @@
+package software.amazon.smithy.go.codegen;
+
+import static software.amazon.smithy.go.codegen.SmithyGoDependency.SMITHY_TRAITS;
+
+import java.util.HashMap;
+import java.util.Map;
+import software.amazon.smithy.aws.traits.protocols.AwsQueryErrorTrait;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.EventHeaderTrait;
+import software.amazon.smithy.model.traits.EventPayloadTrait;
+import software.amazon.smithy.model.traits.HostLabelTrait;
+import software.amazon.smithy.model.traits.HttpErrorTrait;
+import software.amazon.smithy.model.traits.HttpHeaderTrait;
+import software.amazon.smithy.model.traits.HttpLabelTrait;
+import software.amazon.smithy.model.traits.HttpPayloadTrait;
+import software.amazon.smithy.model.traits.HttpPrefixHeadersTrait;
+import software.amazon.smithy.model.traits.HttpQueryParamsTrait;
+import software.amazon.smithy.model.traits.HttpQueryTrait;
+import software.amazon.smithy.model.traits.HttpResponseCodeTrait;
+import software.amazon.smithy.model.traits.JsonNameTrait;
+import software.amazon.smithy.model.traits.MediaTypeTrait;
+import software.amazon.smithy.model.traits.SensitiveTrait;
+import software.amazon.smithy.model.traits.StreamingTrait;
+import software.amazon.smithy.model.traits.TimestampFormatTrait;
+import software.amazon.smithy.model.traits.XmlAttributeTrait;
+import software.amazon.smithy.model.traits.XmlFlattenedTrait;
+import software.amazon.smithy.model.traits.XmlNameTrait;
+import software.amazon.smithy.model.traits.XmlNamespaceTrait;
+import software.amazon.smithy.rulesengine.traits.ContextParamTrait;
+
+public class DefaultTraitGenerators {
+    private static final Map<ShapeId, TraitGenerator> GENERATORS = new HashMap<>();
+
+    static {
+        // Documentation traits
+        GENERATORS.put(SensitiveTrait.ID, new SimpleTraitGenerator<SensitiveTrait>(SMITHY_TRAITS.struct("Sensitive")));
+
+        // Serialization and Protocol traits
+        GENERATORS.put(JsonNameTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("JSONName"),
+                "Name", JsonNameTrait::getValue));
+        GENERATORS.put(MediaTypeTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("MediaType"),
+                "Type", MediaTypeTrait::getValue));
+        GENERATORS.put(TimestampFormatTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("TimestampFormat"),
+                "Format", TimestampFormatTrait::getValue));
+        GENERATORS.put(XmlAttributeTrait.ID, new SimpleTraitGenerator<XmlAttributeTrait>(SMITHY_TRAITS.struct("XMLAttribute")));
+        GENERATORS.put(XmlFlattenedTrait.ID, new SimpleTraitGenerator<XmlFlattenedTrait>(SMITHY_TRAITS.struct("XMLFlattened")));
+        GENERATORS.put(XmlNameTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("XMLName"),
+                "Name", XmlNameTrait::getValue));
+        GENERATORS.put(XmlNamespaceTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("XMLNamespace"),
+                "URI", XmlNamespaceTrait::getUri,
+                "Prefix", XmlNamespaceTrait::getPrefix));
+
+        // Streaming
+        GENERATORS.put(EventHeaderTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("EventHeader")));
+        GENERATORS.put(EventPayloadTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("EventPayload")));
+        GENERATORS.put(StreamingTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("Streaming")));
+
+        // HTTP bindings
+        GENERATORS.put(HttpHeaderTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("HTTPHeader"),
+                "Name", HttpHeaderTrait::getValue));
+        GENERATORS.put(HttpLabelTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("HTTPLabel")));
+        GENERATORS.put(HttpPayloadTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("HTTPPayload")));
+        GENERATORS.put(HttpPrefixHeadersTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("HTTPPrefixHeaders"),
+                "Prefix", HttpPrefixHeadersTrait::getValue));
+        GENERATORS.put(HttpQueryTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("HTTPQuery"),
+                "Name", HttpQueryTrait::getValue));
+        GENERATORS.put(HttpQueryParamsTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("HTTPQueryParams")));
+        GENERATORS.put(HttpResponseCodeTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("HTTPResponseCode")));
+
+        // Endpoint Traits
+        GENERATORS.put(HostLabelTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("HostLabel")));
+
+        // Other traits
+        GENERATORS.put(ContextParamTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("ContextParam")));
+        GENERATORS.put(AwsQueryErrorTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("AWSQueryError"),
+                "ErrorCode", AwsQueryErrorTrait::getCode,
+                "StatusCode", AwsQueryErrorTrait::getHttpResponseCode));
+    }
+
+    public static TraitGenerator forTrait(ShapeId id) {
+        return GENERATORS.get(id);
+    }
+
+    private DefaultTraitGenerators() {
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoCodegenContext.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoCodegenContext.java
@@ -15,6 +15,9 @@
 
 package software.amazon.smithy.go.codegen;
 
+import static java.util.stream.Collectors.toSet;
+
+import java.util.HashSet;
 import java.util.List;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.codegen.core.CodegenContext;
@@ -22,7 +25,12 @@ import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.codegen.core.WriterDelegator;
 import software.amazon.smithy.go.codegen.integration.GoIntegration;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.neighbor.Walker;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
@@ -36,5 +44,39 @@ public record GoCodegenContext(
 ) implements CodegenContext<GoSettings, GoWriter, GoIntegration> {
     public ServiceShape service() {
         return settings.getService(model);
+    }
+
+    /**
+     * Return all **non-member** shapes in the (de)serialization tree of the service. That is, every shape in the tree
+     * of the input/outputs of all operations, plus all structures with @error.
+     */
+    public List<Shape> serdeShapes() {
+        var walker = new Walker(model);
+        var operations = TopDownIndex.of(model).getContainedOperations(service());
+
+        var shapes = new HashSet<Shape>();
+        shapes.addAll(operations.stream()
+                .map(it -> model.expectShape(it.getInputShape()))
+                .flatMap(it -> walker.walkShapes(it).stream())
+                .collect(toSet()));
+        shapes.addAll(operations.stream()
+                .map(it -> model.expectShape(it.getOutputShape()))
+                .flatMap(it -> walker.walkShapes(it).stream())
+                .collect(toSet()));
+        shapes.addAll(model.getStructureShapesWithTrait(ErrorTrait.class).stream()
+                .flatMap(it -> walker.walkShapes(it).stream())
+                .collect(toSet()));
+
+        return shapes.stream()
+                .sorted()
+                .filter(it -> it.getType() != ShapeType.MEMBER)
+                .toList();
+    }
+
+    public <T extends Shape> List<T> serdeShapes(Class<T> clazz) {
+        return serdeShapes().stream()
+                .filter(clazz::isInstance)
+                .map(clazz::cast)
+                .toList();
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoCodegenContext.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoCodegenContext.java
@@ -22,6 +22,7 @@ import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.codegen.core.WriterDelegator;
 import software.amazon.smithy.go.codegen.integration.GoIntegration;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
@@ -32,4 +33,8 @@ public record GoCodegenContext(
         FileManifest fileManifest,
         WriterDelegator<GoWriter> writerDelegator,
         List<GoIntegration> integrations
-) implements CodegenContext<GoSettings, GoWriter, GoIntegration> {}
+) implements CodegenContext<GoSettings, GoWriter, GoIntegration> {
+    public ServiceShape service() {
+        return settings.getService(model);
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoSettings.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoSettings.java
@@ -55,6 +55,7 @@ public final class GoSettings {
     private static final String MODULE_DESCRIPTION = "moduleDescription";
     private static final String MODULE_VERSION = "moduleVersion";
     private static final String GENERATE_GO_MOD = "generateGoMod";
+    private static final String USE_EXPERIMENTAL_SERDE = "useExperimentalSerde";
     private static final String GO_DIRECTIVE = "goDirective";
 
     private ShapeId service;
@@ -62,6 +63,7 @@ public final class GoSettings {
     private String moduleDescription = "";
     private String moduleVersion;
     private Boolean generateGoMod = false;
+    private Boolean useExperimentalSerde = false;
     private String goDirective = GoModuleInfo.DEFAULT_GO_DIRECTIVE;
     private ShapeId protocol;
     private ArtifactType artifactType;
@@ -86,7 +88,7 @@ public final class GoSettings {
     public static GoSettings from(ObjectNode config, ArtifactType artifactType) {
         GoSettings settings = new GoSettings();
         config.warnIfAdditionalProperties(
-            Arrays.asList(SERVICE, MODULE_NAME, MODULE_DESCRIPTION, MODULE_VERSION, GENERATE_GO_MOD, GO_DIRECTIVE));
+            Arrays.asList(SERVICE, MODULE_NAME, MODULE_DESCRIPTION, MODULE_VERSION, GENERATE_GO_MOD, USE_EXPERIMENTAL_SERDE, GO_DIRECTIVE));
         settings.setArtifactType(artifactType);
         settings.setService(config.expectStringMember(SERVICE).expectShapeId());
         settings.setModuleName(config.expectStringMember(MODULE_NAME).getValue());
@@ -94,6 +96,7 @@ public final class GoSettings {
                 MODULE_DESCRIPTION, settings.getModuleName() + " client"));
         settings.setModuleVersion(config.getStringMemberOrDefault(MODULE_VERSION, null));
         settings.setGenerateGoMod(config.getBooleanMemberOrDefault(GENERATE_GO_MOD, false));
+        settings.setUseExperimentalSerde(config.getBooleanMemberOrDefault(USE_EXPERIMENTAL_SERDE, false));
         settings.setGoDirective(config.getStringMemberOrDefault(GO_DIRECTIVE, GoModuleInfo.DEFAULT_GO_DIRECTIVE));
         return settings;
     }
@@ -215,6 +218,14 @@ public final class GoSettings {
      */
     public void setGenerateGoMod(Boolean generateGoMod) {
         this.generateGoMod = Objects.requireNonNull(generateGoMod);
+    }
+
+    public Boolean useExperimentalSerde() {
+        return useExperimentalSerde;
+    }
+
+    public void setUseExperimentalSerde(Boolean value) {
+        this.useExperimentalSerde = Objects.requireNonNull(value);
     }
 
     /**

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
@@ -24,6 +24,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolContainer;
@@ -997,5 +998,4 @@ public final class GoWriter extends SymbolWriter<GoWriter, ImportDeclarations> {
             return "";
         }
     }
-
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/LegacyJsonProtocolDocumentUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/LegacyJsonProtocolDocumentUtils.java
@@ -1,0 +1,49 @@
+package software.amazon.smithy.go.codegen;
+
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
+
+// This is copied almost entirely as-is from JsonProtocolDocumentUtils. It is used for schema-serde to preserve the
+// legacy APIs and behavior of documents, which at the time of migration, only supported JSON. Clients using
+// schema-based serde don't use these, instead they use Value() and UnmarshalDocument() for requests and responses.
+public final class LegacyJsonProtocolDocumentUtils {
+    public static void generateProtocolDocumentMarshalerUnmarshalDocument(GoCodegenContext context, GoWriter writer) {
+        writer.write("mBytes, err := m.$L()", ProtocolDocumentGenerator.MARSHAL_SMITHY_DOCUMENT_METHOD);
+        writer.write("if err != nil { return err }").write("");
+        writer.write("jDecoder := $T($T(mBytes))", SymbolUtils.createValueSymbolBuilder("NewDecoder",
+                SmithyGoDependency.JSON).build(), SymbolUtils.createValueSymbolBuilder("NewReader",
+                SmithyGoDependency.BYTES).build());
+        writer.write("jDecoder.UseNumber()").write("");
+
+        writer.write("var jv interface{}");
+        writer.openBlock("if err := jDecoder.Decode(&v); err != nil {", "}", () -> writer.write("return err"))
+                .write("");
+
+        Symbol newUnmarshaler = ProtocolDocumentGenerator.Utilities.getInternalDocumentSymbolBuilder(
+                        context.settings(), ProtocolDocumentGenerator.INTERNAL_NEW_DOCUMENT_UNMARSHALER_FUNC)
+                .build();
+
+        writer.write("return $T(v).$L(&jv)", newUnmarshaler,
+                ProtocolDocumentGenerator.UNMARSHAL_SMITHY_DOCUMENT_METHOD);
+    }
+
+    public static void generateProtocolDocumentMarshalerMarshalDocument(GoCodegenContext context, GoWriter writer) {
+        Symbol newEncoder = SymbolUtils.createValueSymbolBuilder("NewEncoder", SmithyGoDependency.SMITHY_DOCUMENT_JSON)
+                .build();
+
+        writer.write("return $T().Encode(m.value)", newEncoder);
+    }
+
+    public static void generateProtocolDocumentUnmarshalerUnmarshalDocument(GoCodegenContext context, GoWriter writer) {
+        Symbol newDecoder = SymbolUtils.createValueSymbolBuilder("NewDecoder", SmithyGoDependency.SMITHY_DOCUMENT_JSON)
+                .build();
+
+        writer.write("decoder := $T()", newDecoder);
+        writer.write("return decoder.DecodeJSONInterface(m.value, v)");
+    }
+
+    public static void generateProtocolDocumentUnmarshalerMarshalDocument(GoCodegenContext context, GoWriter writer) {
+        writer.write("return $T(m.value)",
+                SymbolUtils.createValueSymbolBuilder("Marshal", SmithyGoDependency.JSON).build());
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -133,9 +133,8 @@ public final class OperationGenerator implements Runnable {
 
         // Write out the input and output structures. These are written out here to prevent naming conflicts with other
         // shapes in the model.
-        new StructureGenerator(model, symbolProvider, writer, service, inputShape, inputSymbol, protocolGenerator)
-                .renderStructure(() -> {
-                }, true);
+        new StructureGenerator(ctx, writer, inputShape, protocolGenerator)
+                .renderStructure(() -> {}, true);
 
         var rulesTrait = service.getTrait(EndpointRuleSetTrait.class);
         var bddTrait = service.getTrait(EndpointBddTrait.class);
@@ -149,17 +148,14 @@ public final class OperationGenerator implements Runnable {
                 .build();
 
         StructureShape structOutputShape;
-        Symbol structOutputSymbol;
-        
+
         if (EventStreamGenerator.isV2EventStream(model, operation)) {
             List<MemberShape> onlyEventStreamMembers = outputShape.members().stream().filter(member -> StreamingTrait.isEventStream(model, member)).toList();
             structOutputShape = buildShape(onlyEventStreamMembers);
-            structOutputSymbol = symbolProvider.toSymbol(outputShape);
         } else {
             structOutputShape = outputShape;
-            structOutputSymbol = outputSymbol;
         }
-        new StructureGenerator(model, symbolProvider, writer, service, structOutputShape, structOutputSymbol, protocolGenerator)
+        new StructureGenerator(ctx, writer, structOutputShape, protocolGenerator)
                 .renderStructure(() -> {
                     if (outputShape.getMemberNames().size() != 0) {
                         writer.write("");
@@ -278,17 +274,21 @@ public final class OperationGenerator implements Runnable {
                     return err
                 }""");
 
-        // Add request serializer middleware
-        String serializerMiddlewareName = ProtocolGenerator.getSerializeMiddlewareName(
-                operation.getId(), service, protocolGenerator.getProtocolName());
-        writer.write("err = stack.Serialize.Add(&$L{}, middleware.After)", serializerMiddlewareName);
-        writer.write("if err != nil { return err }");
+        if (!ctx.settings().useExperimentalSerde()) {
+            // Add request serializer middleware
+            String serializerMiddlewareName = ProtocolGenerator.getSerializeMiddlewareName(
+                    operation.getId(), service, protocolGenerator.getProtocolName());
+            writer.write("err = stack.Serialize.Add(&$L{}, middleware.After)", serializerMiddlewareName);
+            writer.write("if err != nil { return err }");
 
-        // Adds response deserializer middleware
-        String deserializerMiddlewareName = ProtocolGenerator.getDeserializeMiddlewareName(
-                operation.getId(), service, protocolGenerator.getProtocolName());
-        writer.write("err = stack.Deserialize.Add(&$L{}, middleware.After)", deserializerMiddlewareName);
-        writer.write("if err != nil { return err }");
+            // Adds response deserializer middleware
+            String deserializerMiddlewareName = ProtocolGenerator.getDeserializeMiddlewareName(
+                    operation.getId(), service, protocolGenerator.getProtocolName());
+            writer.write("err = stack.Deserialize.Add(&$L{}, middleware.After)", deserializerMiddlewareName);
+            writer.write("if err != nil { return err }");
+        } else {
+            // TODO
+        }
 
         // FUTURE: retry middleware should be at the front of finalize, right now it's added by the SDK
         writer.write("""

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -155,7 +155,7 @@ public final class OperationGenerator implements Runnable {
         } else {
             structOutputShape = outputShape;
         }
-        new StructureGenerator(ctx, writer, structOutputShape, protocolGenerator)
+        new StructureGenerator(ctx, writer, structOutputShape, protocolGenerator, symbolProvider.toSymbol(outputShape))
                 .renderStructure(() -> {
                     if (outputShape.getMemberNames().size() != 0) {
                         writer.write("");
@@ -187,7 +187,7 @@ public final class OperationGenerator implements Runnable {
                 var nonStreamingOutput = outputShape.members().stream().filter(member -> !StreamingTrait.isEventStream(model, member)).toList();
                 StructureShape initialReplyStruct = outputShape.toBuilder().clearMembers().members(nonStreamingOutput).build();
 
-                new StructureGenerator(model, symbolProvider, writer, service, initialReplyStruct, initialReply, protocolGenerator)
+                new StructureGenerator(ctx, writer, initialReplyStruct, protocolGenerator, initialReply)
                     .renderStructure(() -> {
                         writer.writeDocs("Metadata pertaining to the operation's result.");
                         writer.write("ResultMetadata $T", metadataSymbol);

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -54,6 +54,8 @@ public final class OperationGenerator implements Runnable {
     private final Symbol operationSymbol;
     private final ProtocolGenerator protocolGenerator;
     private final List<RuntimeClientPlugin> runtimeClientPlugins;
+    private final StructureShape input;
+    private final StructureShape output;
 
     OperationGenerator(
             GoCodegenContext ctx,
@@ -71,6 +73,8 @@ public final class OperationGenerator implements Runnable {
         this.operationSymbol = ctx.symbolProvider().toSymbol(operation);
         this.protocolGenerator = protocolGenerator;
         this.runtimeClientPlugins = runtimeClientPlugins;
+        this.input = ctx.model().expectShape(operation.getInputShape(), StructureShape.class);
+        this.output = ctx.model().expectShape(operation.getOutputShape(), StructureShape.class);
     }
 
     @Override
@@ -287,7 +291,14 @@ public final class OperationGenerator implements Runnable {
             writer.write("err = stack.Deserialize.Add(&$L{}, middleware.After)", deserializerMiddlewareName);
             writer.write("if err != nil { return err }");
         } else {
-            // TODO
+            writer.write("""
+                if err := stack.Serialize.Add(&serializeRequestMiddleware{options: &options}, middleware.After); err != nil {
+                    return err
+                }""");
+            writer.write("""
+                if err := stack.Deserialize.Add(&deserializeResponseMiddleware{options: &options, output: &$T{}}, middleware.After); err != nil {
+                    return err
+                }""", symbolProvider.toSymbol(output));
         }
 
         // FUTURE: retry middleware should be at the front of finalize, right now it's added by the SDK

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ProtocolDocumentGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ProtocolDocumentGenerator.java
@@ -353,6 +353,62 @@ public final class ProtocolDocumentGenerator {
         });
     }
 
+    // Used for schema-serde, generates legacy JSON-based document support to preserve existing APIs/behavior.
+    // Copied from above generateInternalDocumentTypes which will eventually be deleted when schema-serde is complete.
+    public void generateLegacyInternalDocumentTypes(GoCodegenContext ctx) {
+        if (!this.hasDocumentShapes) {
+            return;
+        }
+
+        writeInternalDocumentPackage("document.go", writer -> {
+            Symbol marshalerSymbol = getInternalDocumentSymbol("documentMarshaler",
+                    true);
+            Symbol unmarshalerSymbol = getInternalDocumentSymbol("documentUnmarshaler", true);
+
+            Symbol isDocumentInterface = getInternalDocumentSymbol(INTERNAL_IS_DOCUMENT_INTERFACE);
+
+            writeInternalDocumentImplementation(
+                    writer,
+                    marshalerSymbol,
+                    () -> LegacyJsonProtocolDocumentUtils.generateProtocolDocumentMarshalerUnmarshalDocument(ctx, writer),
+                    () -> LegacyJsonProtocolDocumentUtils.generateProtocolDocumentMarshalerMarshalDocument(ctx, writer));
+            writeInternalDocumentImplementation(writer,
+                    unmarshalerSymbol,
+                    () -> LegacyJsonProtocolDocumentUtils.generateProtocolDocumentUnmarshalerUnmarshalDocument(ctx, writer),
+                    () -> LegacyJsonProtocolDocumentUtils.generateProtocolDocumentUnmarshalerMarshalDocument(ctx, writer));
+
+            Symbol documentInterfaceSymbol = getInternalDocumentSymbol(DOCUMENT_INTERFACE_NAME);
+
+            writer.writeDocs(String.format("%s creates a new document marshaler for the given input type",
+                    INTERNAL_NEW_DOCUMENT_MARSHALER_FUNC));
+            writer.openBlock("func $L(v interface{}) $T {", "}", INTERNAL_NEW_DOCUMENT_MARSHALER_FUNC,
+                    documentInterfaceSymbol, () -> {
+                        writer.openBlock("return &$T{", "}", marshalerSymbol, () -> {
+                            writer.write("value: v,");
+                        });
+                    }).write("");
+
+            writer.writeDocs(String.format("%s creates a new document unmarshaler for the given service response",
+                    INTERNAL_NEW_DOCUMENT_UNMARSHALER_FUNC));
+            writer.openBlock("func $L(v interface{}) $T {", "}", INTERNAL_NEW_DOCUMENT_UNMARSHALER_FUNC,
+                    documentInterfaceSymbol, () -> {
+                        writer.openBlock("return &$T{", "}", unmarshalerSymbol, () -> {
+                            writer.write("value: v,");
+                        });
+                    }).write("");
+
+            writer.writeDocs(String.format("%s returns whether the given Interface implementation is"
+                    + " a valid client implementation", isDocumentInterface));
+            writer.openBlock("func $T(v Interface) (ok bool) {", "}", isDocumentInterface, () -> {
+                writer.openBlock("defer func() {", "}()", () -> {
+                    writer.openBlock("if err := recover(); err != nil {", "}", () -> writer.write("ok = false"));
+                });
+                writer.write("v.$L()", IS_SMITHY_DOCUMENT_METHOD);
+                writer.write("return true");
+            }).write("");
+        });
+    }
+
     private void writeInternalDocumentImplementation(
             GoWriter writer,
             Symbol typeSymbol,
@@ -364,10 +420,11 @@ public final class ProtocolDocumentGenerator {
         });
         writer.write("");
 
+        // for schema-serde (if the service doesn't do that yet then this is just unused for now)
+        writer.write("func (m $P) Value() any { return m.value }", typeSymbol);
+
         writer.openBlock("func (m $P) $L(v interface{}) error {", "}", typeSymbol, UNMARSHAL_SMITHY_DOCUMENT_METHOD,
                 unmarshalMethodDefinition);
-        writer.write("");
-
         writer.openBlock("func (m $P) $L() ([]byte, error) {", "}", typeSymbol, MARSHAL_SMITHY_DOCUMENT_METHOD,
                 marshalMethodDefinition);
         writer.write("");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SchemaGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SchemaGenerator.java
@@ -1,0 +1,87 @@
+package software.amazon.smithy.go.codegen;
+
+import static software.amazon.smithy.go.codegen.GoWriter.emptyGoTemplate;
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+
+import java.util.Map;
+import software.amazon.smithy.go.codegen.util.ShapeUtil;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.utils.SmithyInternalApi;
+import software.amazon.smithy.utils.StringUtils;
+
+@SmithyInternalApi
+public class SchemaGenerator implements Writable {
+    private final GoCodegenContext ctx;
+    private final Shape shape;
+
+    public SchemaGenerator(GoCodegenContext ctx, Shape shape) {
+        this.ctx = ctx;
+        this.shape = shape;
+    }
+
+    public static String getSchemaName(Shape shape) {
+        var name = shape.getId().getName();
+        return ShapeUtil.isExported(shape)
+                ? name
+                : "_" + name;
+    }
+
+    public static String getMemberSchemaName(Shape shape, MemberShape member) {
+        return String.format("%s_%s", getSchemaName(shape), member.getMemberName());
+    }
+
+    @Override
+    public void accept(GoWriter writer) {
+        writer.addUseImports(SmithyGoDependency.SMITHY);
+        writer.writeGoTemplate("""
+                        var $ident:L = smithy.NewSchema($id:S, smithy.ShapeType$type:L,
+                                $memberOpts:W
+                                smithy.WithTraits(
+                                    $traitOpts:W
+                                ),
+                            )
+                        $members:W
+                        """,
+                Map.of(
+                        "ident", getSchemaName(shape),
+                        "id", shape.getId().toString(),
+                        "type", StringUtils.capitalize(shape.getType().toString()),
+                        "members", Writable.map(shape.members(), this::renderMemberIdent),
+                        "memberOpts", Writable.map(shape.members(), this::renderMemberOpt),
+                        "traitOpts", Writable.map(shape.getAllTraits().values(), this::renderTraitOpt, true)
+                ));
+    }
+
+    private Writable renderMemberIdent(MemberShape member) {
+        var memberName = member.getMemberName();
+        return goTemplate("""
+                        var $ident:L = $schema:L.Member($name:S)
+                        """,
+                Map.of(
+                        "ident", getMemberSchemaName(shape, member),
+                        "schema", getSchemaName(shape),
+                        "name", memberName
+                ));
+    }
+
+    private Writable renderMemberOpt(MemberShape member) {
+        var target = ctx.model().expectShape(member.getTarget());
+
+        return goTemplate("smithy.WithMember($name:S, $target:L, $traits:W),",
+                Map.of(
+                        "name", member.getMemberName(),
+                        "target", getSchemaName(target),
+                        "traits", Writable.map(member.getAllTraits().values(), this::renderTraitOpt)
+                ));
+    }
+
+    private Writable renderTraitOpt(Trait trait) {
+        // FUTURE: load additional generators through GoIntegration
+        var generator = DefaultTraitGenerators.forTrait(trait.toShapeId());
+        return generator != null
+                ? goTemplate("$W,", generator.render(trait))
+                : emptyGoTemplate();
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SchemaGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SchemaGenerator.java
@@ -36,74 +36,63 @@ public class SchemaGenerator implements Writable {
     public void accept(GoWriter writer) {
         writer.addUseImports(SmithyGoDependency.SMITHY);
         writer.writeGoTemplate("""
-                        var $ident:L = &smithy.Schema{
-                            ID: smithy.ShapeID{
-                                Namespace: $namespace:S,
-                                Name: $name:S,
-                            },
-                            Type: smithy.ShapeType$type:L,
-                            $members:W
-                            $traits:W
-                        }
-                        $memberVars:W
+                        var $ident:L = smithy.NewSchema(smithy.ShapeID{
+                            Namespace: $namespace:S,
+                            Name: $name:S,
+                        }, smithy.ShapeType$type:L, $numMembers:L$traits:W)
+                        $memberVarDecls:W
                         """,
                 Map.of(
                         "ident", getSchemaName(shape),
                         "namespace", shape.getId().getNamespace(),
                         "name", shape.getId().getName(),
                         "type", StringUtils.capitalize(shape.getType().toString()),
-                        "members", renderMembers(),
-                        "traits", renderTraits(),
-                        "memberVars", Writable.map(shape.members(), this::renderMemberIdent, true)
+                        "numMembers", shape.members().size(),
+                        "traits", renderVariadicTraits(shape.getAllTraits().values()),
+                        "memberVarDecls", Writable.map(shape.members(), this::renderMemberVarDecl, true)
                 ));
     }
 
-    private Writable renderMembers() {
+    public void acceptMembersInit(GoWriter writer) {
         if (shape.members().isEmpty()) {
-            return emptyGoTemplate();
+            return;
         }
-        return goTemplate("""
-                Members: map[string]*smithy.Schema{
-                    $W
-                },""", Writable.map(shape.members(), this::renderMemberMapEntry));
-    }
-
-    private Writable renderTraits() {
-        if (shape.getAllTraits().isEmpty()) {
-            return emptyGoTemplate();
-        }
-        return goTemplate("""
-                Traits: map[string]smithy.Trait{
-                    $W
-                },""", Writable.map(shape.getAllTraits().values(), this::renderTraitMapEntry));
-    }
-
-    private Writable renderMemberIdent(MemberShape member) {
-        var memberName = member.getMemberName();
-        return goTemplate("""
-                        var $ident:L = $schema:L.Members[$name:S]
+        writer.writeGoTemplate("""
+                        $memberAddAndAssign:W
                         """,
                 Map.of(
-                        "ident", getMemberSchemaName(shape, member),
-                        "schema", getSchemaName(shape),
-                        "name", memberName
+                        "memberAddAndAssign", Writable.map(shape.members(), this::renderMemberAddAndAssign, true)
                 ));
     }
 
-    private Writable renderMemberMapEntry(MemberShape member) {
+    private Writable renderMemberVarDecl(MemberShape member) {
+        return goTemplate("""
+                        var $ident:L *smithy.Schema
+                        """,
+                Map.of("ident", getMemberSchemaName(shape, member)));
+    }
+
+    private Writable renderMemberAddAndAssign(MemberShape member) {
         var target = ctx.model().expectShape(member.getTarget());
         var memberTraits = member.getAllTraits().values();
 
         return goTemplate("""
-                        $name:S: smithy.NewMember($name:S, $target:L$traits:W),
+                        $ident:L = $schema:L.AddMember($name:S, $target:L$traits:W)
                         """,
                 Map.of(
+                        "ident", getMemberSchemaName(shape, member),
+                        "schema", getSchemaName(shape),
                         "name", member.getMemberName(),
                         "target", getSchemaName(target),
-                        "traits", memberTraits.isEmpty()
-                                ? emptyGoTemplate()
-                                : goTemplate(", $W", Writable.map(memberTraits, this::renderVariadicTrait))
+                        "traits", renderVariadicTraits(memberTraits)
                 ));
+    }
+
+    private Writable renderVariadicTraits(java.util.Collection<Trait> traits) {
+        if (traits.isEmpty()) {
+            return emptyGoTemplate();
+        }
+        return goTemplate(", $W", Writable.map(traits, this::renderVariadicTrait));
     }
 
     private Writable renderTraitMapEntry(Trait trait) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -134,7 +134,8 @@ final class ServiceGenerator implements Runnable {
         return goTemplate("""
                 const ServiceID = $S
                 const ServiceAPIVersion = $S
-                """, serviceId, service.getVersion());
+                const serviceName = $S
+                """, serviceId, service.getVersion(), service.getId().getName());
     }
 
     private Writable generateClient() {
@@ -196,6 +197,8 @@ final class ServiceGenerator implements Runnable {
 
                     $protocolResolvers:W
 
+                    $experimentalSerdeResolvers:W
+
                     for _, fn := range optFns {
                         fn(&options)
                     }
@@ -243,8 +246,15 @@ final class ServiceGenerator implements Runnable {
                                         .flatMap(it -> it.getClientMemberResolvers().stream())
                                         .map(this::generateClientMemberResolver)
                                         .toList()
-                        ).compose()
+                        ).compose(),
+                    "experimentalSerdeResolvers", settings.useExperimentalSerde()? generateExperimentalSerdeResolvers() : emptyGoTemplate()
                 ));
+    }
+
+    private Writable generateExperimentalSerdeResolvers() {
+        ensureSupportedProtocol();
+        // TODO(serde2) dynamically resolve a symbol based on traits
+        return goTemplate("options.Protocol = $T()", SmithyGoDependency.SMITHY_AWS_PROTOCOLS_JSON10.func("New"));
     }
 
     private Writable generateGetOptions() {
@@ -353,6 +363,7 @@ final class ServiceGenerator implements Runnable {
                 ) {
                     ctx = middleware.ClearStackValues(ctx)
                     ctx = middleware.WithServiceID(ctx, ServiceID)
+                    ctx = middleware.WithServiceName(ctx, serviceName)
                     ctx = middleware.WithOperationName(ctx, opID)
 
                     $newStack:W

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SimpleTraitGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SimpleTraitGenerator.java
@@ -1,0 +1,48 @@
+package software.amazon.smithy.go.codegen;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.model.traits.Trait;
+
+class SimpleTraitGenerator<T extends Trait> implements TraitGenerator {
+    private final Symbol symbol;
+    private final Map<String, Function<T, Object>> mappings = new LinkedHashMap<>();
+
+    public SimpleTraitGenerator(Symbol symbol) {
+        this.symbol = symbol;
+    }
+
+    public SimpleTraitGenerator(Symbol symbol,
+                                String k1, Function<T, Object> v1) {
+        this.symbol = symbol;
+
+        mappings.put(k1, v1);
+    }
+
+    public SimpleTraitGenerator(Symbol symbol,
+                                String k1, Function<T, Object> v1,
+                                String k2, Function<T, Object> v2) {
+        this.symbol = symbol;
+
+        mappings.put(k1, v1);
+        mappings.put(k2, v2);
+    }
+
+    @Override
+    public Writable render(Trait trait) {
+        return goTemplate("&$T{$W}", symbol, Writable.map(mappings.entrySet(), entry -> {
+            var value = entry.getValue().apply((T) trait);
+            return goTemplate("$L: $L,", entry.getKey(), formatValue(value));
+        }));
+    }
+
+    private String formatValue(Object value) {
+        return value instanceof String
+                ? "\"" + value + "\""
+                : value.toString();
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -52,6 +52,7 @@ public final class SmithyGoDependency {
     public static final GoDependency SLICES = stdlib("slices");
 
     public static final GoDependency SMITHY = smithy(null, "smithy");
+    public static final GoDependency SMITHY_TRAITS = smithy("traits", "smithytraits");
     public static final GoDependency SMITHY_TRANSPORT = smithy("transport", "smithytransport");
     public static final GoDependency SMITHY_HTTP_TRANSPORT = smithy("transport/http", "smithyhttp");
     public static final GoDependency SMITHY_MIDDLEWARE = smithy("middleware");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -82,6 +82,9 @@ public final class SmithyGoDependency {
     public static final GoDependency SMITHY_TRACING = smithy("tracing");
     public static final GoDependency SMITHY_METRICS = smithy("metrics");
 
+    public static final GoDependency SMITHY_AWS_PROTOCOLS = relativePackage( "github.com/aws/smithy-go/aws-protocols", null, "v1.0.0", null);
+    public static final GoDependency SMITHY_AWS_PROTOCOLS_JSON10 = relativePackage( "github.com/aws/smithy-go/aws-protocols", "awsjson10", "v1.0.0", null);
+
     public static final GoDependency MATH = stdlib("math");
 
     private static final String SMITHY_SOURCE_PATH = "github.com/aws/smithy-go";

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
@@ -52,7 +52,7 @@ public final class StructureGenerator implements Runnable {
     private final SymbolProvider symbolProvider;
     private final GoWriter writer;
     private final StructureShape shape;
-    private final Symbol symbol;
+    private Symbol symbol;
     private final ServiceShape service;
     private final ProtocolGenerator protocolGenerator;
     private final boolean useExperimentalSerde;
@@ -75,6 +75,17 @@ public final class StructureGenerator implements Runnable {
         this.protocolGenerator = protocolGenerator;
         this.useExperimentalSerde = ctx.settings().useExperimentalSerde();
         this.nilIndex = GoPointableIndex.of(model);
+    }
+
+    public StructureGenerator(
+            GoCodegenContext ctx,
+            GoWriter writer,
+            StructureShape shape,
+            ProtocolGenerator protocolGenerator,
+            Symbol symbolOverride
+    ) {
+        this(ctx, writer, shape, protocolGenerator);
+        this.symbol = symbolOverride;
     }
 
     @Override

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/StructureGenerator.java
@@ -15,22 +15,20 @@
 
 package software.amazon.smithy.go.codegen;
 
-import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
-import software.amazon.smithy.go.codegen.knowledge.GoPointableIndex;
-import software.amazon.smithy.go.codegen.util.ShapeUtil;
+import software.amazon.smithy.go.codegen.serde2.StructureDeserializer;
+import software.amazon.smithy.go.codegen.serde2.StructureSerializer;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.shapes.CollectionShape;
-import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.InputTrait;
+import software.amazon.smithy.model.traits.OutputTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SetUtils;
@@ -57,7 +55,6 @@ public final class StructureGenerator implements Runnable {
     private final ProtocolGenerator protocolGenerator;
     private final boolean useExperimentalSerde;
     private final GoCodegenContext ctx;
-    private final GoPointableIndex nilIndex;
 
     public StructureGenerator(
             GoCodegenContext ctx,
@@ -74,7 +71,6 @@ public final class StructureGenerator implements Runnable {
         this.symbol = ctx.symbolProvider().toSymbol(shape);
         this.protocolGenerator = protocolGenerator;
         this.useExperimentalSerde = ctx.settings().useExperimentalSerde();
-        this.nilIndex = GoPointableIndex.of(model);
     }
 
     public StructureGenerator(
@@ -151,7 +147,14 @@ public final class StructureGenerator implements Runnable {
         writer.closeBlock("}").write("");
 
         if (useExperimentalSerde) {
-            // TODO generateSerializers();
+            if (shape.hasTrait(InputTrait.class)) {
+                writer.write(new StructureSerializer(ctx, shape));
+            } else if (shape.hasTrait(OutputTrait.class)) {
+                writer.write(new StructureDeserializer(ctx, shape));
+            } else {
+                writer.write(new StructureSerializer(ctx, shape));
+                writer.write(new StructureDeserializer(ctx, shape));
+            }
         }
     }
 
@@ -214,5 +217,9 @@ public final class StructureGenerator implements Runnable {
             fault = "smithy.FaultServer";
         }
         writer.write("func (e *$L) ErrorFault() smithy.ErrorFault { return $L }", structureSymbol.getName(), fault);
+
+        if (useExperimentalSerde) {
+            writer.write(new StructureDeserializer(ctx, shape));
+        }
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/TraitGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/TraitGenerator.java
@@ -1,0 +1,7 @@
+package software.amazon.smithy.go.codegen;
+
+import software.amazon.smithy.model.traits.Trait;
+
+public interface TraitGenerator {
+    Writable render(Trait trait);
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/TypeRegistry.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/TypeRegistry.java
@@ -1,0 +1,38 @@
+package software.amazon.smithy.go.codegen;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+
+import java.util.Map;
+import software.amazon.smithy.model.shapes.StructureShape;
+
+public class TypeRegistry implements Writable {
+    private final GoCodegenContext ctx;
+
+    public TypeRegistry(GoCodegenContext ctx) {
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void accept(GoWriter writer) {
+        var shapes = ctx.serdeShapes(StructureShape.class).stream().toList();
+
+        writer.addUseImports(SmithyGoDependency.SMITHY);
+        writer.addImport(ctx.settings().getModuleName() + "/schemas", "schemas");
+        writer.writeGoTemplate("""
+                // TypeRegistry is the type registry for this service.
+                var TypeRegistry = &smithy.TypeRegistry{
+                    Entries: map[string]*smithy.TypeRegistryEntry{
+                        $entries:W
+                    },
+                }
+                """, Map.of("entries", Writable.map(shapes, this::renderEntry)));
+    }
+
+    private Writable renderEntry(StructureShape shape) {
+        return goTemplate("""
+                $S: &smithy.TypeRegistryEntry{
+                    Schema: schemas.$L,
+                    New: func() any { return &$T{} },
+                },""", shape.getId().toString(), SchemaGenerator.getSchemaName(shape), ctx.symbolProvider().toSymbol(shape));
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/UnionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/UnionGenerator.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
@@ -38,12 +39,14 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 public class UnionGenerator {
     public static final String UNKNOWN_MEMBER_NAME = "UnknownUnionMember";
 
+    private final GoCodegenContext ctx;
     private final Model model;
     private final SymbolProvider symbolProvider;
     private final UnionShape shape;
     private final boolean isEventStream;
 
-    public UnionGenerator(Model model, SymbolProvider symbolProvider, UnionShape shape) {
+    public UnionGenerator(GoCodegenContext ctx, Model model, SymbolProvider symbolProvider, UnionShape shape) {
+        this.ctx = ctx;
         this.model = model;
         this.symbolProvider = symbolProvider;
         this.shape = shape;
@@ -99,7 +102,74 @@ public class UnionGenerator {
             });
 
             writer.write("func (*$L) is$L() {}", exportedMemberName, symbol.getName());
+
+            if (ctx.settings().useExperimentalSerde()) {
+                generateMemberSerializer(writer, member, exportedMemberName, target);
+                generateMemberDeserializer(writer, member, exportedMemberName, target);
+            }
         }
+    }
+    
+    private void generateMemberSerializer(GoWriter writer, MemberShape member, String memberName, Shape target) {
+        writer.addUseImports(SmithyGoDependency.SMITHY);
+        writer.addImport(ctx.settings().getModuleName() + "/schemas", "schemas");
+        var schemaName = "schemas." + SchemaGenerator.getMemberSchemaName(shape, member);
+        writer.openBlock("func (v *$L) Serialize(s smithy.ShapeSerializer) {", "}", memberName, () -> {
+            switch (target.getType()) {
+                case BYTE -> writer.write("s.WriteInt8($L, v.Value)", schemaName);
+                case SHORT -> writer.write("s.WriteInt16($L, v.Value)", schemaName);
+                case INTEGER -> writer.write("s.WriteInt32($L, v.Value)", schemaName);
+                case LONG -> writer.write("s.WriteInt64($L, v.Value)", schemaName);
+                case FLOAT -> writer.write("s.WriteFloat32($L, v.Value)", schemaName);
+                case DOUBLE -> writer.write("s.WriteFloat64($L, v.Value)", schemaName);
+                case BOOLEAN -> writer.write("s.WriteBool($L, v.Value)", schemaName);
+                case STRING -> writer.write("s.WriteString($L, v.Value)", schemaName);
+                case BLOB -> writer.write("s.WriteBlob($L, v.Value)", schemaName);
+                case TIMESTAMP -> writer.write("s.WriteTime($L, v.Value)", schemaName);
+                case ENUM -> writer.write("s.WriteString($L, string(v.Value))", schemaName);
+                case INT_ENUM -> writer.write("s.WriteInt32($L, int32(v.Value))", schemaName);
+                case BIG_INTEGER -> writer.write("s.WriteBigInteger($L, v.Value)", schemaName);
+                case BIG_DECIMAL -> writer.write("s.WriteBigDecimal($L, v.Value)", schemaName);
+                case STRUCTURE -> writer.write("s.WriteStruct($L, &v.Value)", schemaName); // struct variants are value types
+                case LIST, SET, MAP -> writer.write("serialize$L(s, $L, v.Value)", target.getId().getName(), schemaName);
+                case MEMBER, SERVICE, RESOURCE, OPERATION -> throw new CodegenException("invalid shape type " + target.getType());
+            }
+        });
+    }
+
+    private void generateMemberDeserializer(GoWriter writer, MemberShape member, String memberName, Shape target) {
+        writer.addUseImports(SmithyGoDependency.SMITHY);
+        writer.addImport(ctx.settings().getModuleName() + "/schemas", "schemas");
+        var schemaName = "schemas." + SchemaGenerator.getMemberSchemaName(shape, member);
+        writer.openBlock("func (v *$L) Deserialize(d smithy.ShapeDeserializer) error {", "}", memberName, () -> {
+            switch (target.getType()) {
+                case BYTE -> writer.write("return d.ReadInt8($L, &v.Value)", schemaName);
+                case SHORT -> writer.write("return d.ReadInt16($L, &v.Value)", schemaName);
+                case INTEGER -> writer.write("return d.ReadInt32($L, &v.Value)", schemaName);
+                case LONG -> writer.write("return d.ReadInt64($L, &v.Value)", schemaName);
+                case FLOAT -> writer.write("return d.ReadFloat32($L, &v.Value)", schemaName);
+                case DOUBLE -> writer.write("return d.ReadFloat64($L, &v.Value)", schemaName);
+                case BOOLEAN -> writer.write("return d.ReadBool($L, &v.Value)", schemaName);
+                case STRING -> writer.write("return d.ReadString($L, &v.Value)", schemaName);
+                case BLOB -> writer.write("return d.ReadBlob($L, &v.Value)", schemaName);
+                case TIMESTAMP -> writer.write("return d.ReadTime($L, &v.Value)", schemaName);
+                case ENUM -> {
+                    writer.write("var s string");
+                    writer.write("if err := d.ReadString($L, &s); err != nil { return err }", schemaName);
+                    writer.write("v.Value = $T(s)", symbolProvider.toSymbol(target));
+                    writer.write("return nil");
+                }
+                case INT_ENUM -> {
+                    writer.write("var i int32");
+                    writer.write("if err := d.ReadInt32($L, &i); err != nil { return err }", schemaName);
+                    writer.write("v.Value = $T(i)", symbolProvider.toSymbol(target));
+                    writer.write("return nil");
+                }
+                case STRUCTURE -> writer.write("return v.Value.Deserialize(d)");
+                case LIST, MAP, UNION -> writer.write("return deserialize$L(d, $L, &v.Value)", target.getId().getName(), schemaName);
+                case MEMBER, SERVICE, RESOURCE, OPERATION -> throw new CodegenException("invalid shape type " + target.getType());
+            }
+        });
     }
 
     private boolean isEventStreamErrorMember(MemberShape memberShape) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/UnsupportedShapeException.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/UnsupportedShapeException.java
@@ -1,0 +1,10 @@
+package software.amazon.smithy.go.codegen;
+
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.model.shapes.ShapeType;
+
+public class UnsupportedShapeException extends CodegenException {
+    public UnsupportedShapeException(ShapeType type) {
+        super("unsupported shape type: " + type);
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/Writable.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/Writable.java
@@ -1,6 +1,18 @@
 package software.amazon.smithy.go.codegen;
 
+import java.util.Collection;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 public interface Writable extends Consumer<GoWriter> {
+    static <T> Writable map(Collection<T> items, Function<T, Writable> mapper, boolean writeNewlines) {
+        return ChainWritable.of(items.stream()
+                .map(mapper)
+                .toList()
+        ).compose(writeNewlines);
+    }
+
+    static <T> Writable map(Collection<T> items, Function<T, Writable> mapper) {
+        return map(items, mapper, false);
+    }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde/SerdeUtil.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde/SerdeUtil.java
@@ -36,6 +36,9 @@ import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
+/**
+ * WARNING 1/29/26: AVOID any new usages of these.
+ */
 @SmithyInternalApi
 public final class SerdeUtil {
     private SerdeUtil() {}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/ListDeserializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/ListDeserializer.java
@@ -1,0 +1,154 @@
+package software.amazon.smithy.go.codegen.serde2;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+
+import java.util.Map;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.go.codegen.GoCodegenContext;
+import software.amazon.smithy.go.codegen.GoUniverseTypes;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.Writable;
+import software.amazon.smithy.go.codegen.util.ShapeUtil;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.SparseTrait;
+
+public class ListDeserializer implements Writable {
+    private final GoCodegenContext ctx;
+    private final ListShape shape;
+    private final Shape member;
+
+    public ListDeserializer(GoCodegenContext ctx, ListShape shape) {
+        this.ctx = ctx;
+        this.shape = shape;
+        this.member = ShapeUtil.expectMember(ctx.model(), shape);
+    }
+
+    @Override
+    public void accept(GoWriter writer) {
+        writer.addUseImports(SmithyGoDependency.SMITHY);
+        if (member.hasTrait(SparseTrait.class)) {
+            renderSparse(writer);
+        } else {
+            renderDense(writer);
+        }
+    }
+
+    private void renderDense(GoWriter writer) {
+        writer.writeGoTemplate("""
+                func deserialize$shapeName:L(d smithy.ShapeDeserializer, s *smithy.Schema, v *$symbol:T) error {
+                    return smithy.ReadList(d, s, func() error {
+                        var vv $memberSymbol:T
+                        if err := $deserializeMember:W; err != nil {
+                            return err
+                        }
+
+                        *v = append(*v, $cast:W)
+                        return nil
+                    })
+                }
+                """, Map.of(
+                "shapeName", shape.getId().getName(),
+                "symbol", ctx.symbolProvider().toSymbol(shape),
+                "memberSymbol", switch (member.getType()) {
+                    case ENUM -> GoUniverseTypes.String;
+                    case INT_ENUM -> GoUniverseTypes.Int32;
+                    default -> ctx.symbolProvider().toSymbol(member);
+                },
+                "deserializeMember", renderDeserializeMember(),
+                "cast", switch (member.getType()) {
+                    case ENUM, INT_ENUM -> goTemplate("$T(vv)", ctx.symbolProvider().toSymbol(member));
+                    default -> goTemplate("vv");
+                }
+        ));
+    }
+
+    private void renderSparse(GoWriter writer) {
+        writer.writeGoTemplate("""
+                func deserialize$shapeName:L(d smithy.ShapeDeserializer, s *smithy.Schema, v *$symbol:T) error {
+                    return smithy.ReadList(d, s, func() error {
+                        if isNil, err := d.ReadNil(s.ListMember()); err != nil {
+                            return err
+                        } else if isNil {
+                            *v = append(*v, nil)
+                            return nil
+                        }
+
+                        var vv $memberSymbol:T
+                        if err := $deserializeMember:W; err != nil {
+                            return err
+                        }
+
+                        *v = append(*v, $cast:W)
+                        return nil
+                    })
+                }
+                """, Map.of(
+                "shapeName", shape.getId().getName(),
+                "symbol", ctx.symbolProvider().toSymbol(shape),
+                "memberSymbol", switch (member.getType()) {
+                    case ENUM -> GoUniverseTypes.String;
+                    case INT_ENUM -> GoUniverseTypes.Int32;
+                    default -> ctx.symbolProvider().toSymbol(member);
+                },
+                "deserializeMember", renderDeserializeMember(),
+                "cast", renderSparseCast()
+        ));
+    }
+
+    private Writable renderSparseCast() {
+        return switch (member.getType()) {
+            case ENUM, INT_ENUM -> goTemplate("""
+                    func() $T {
+                        ev := $T(vv)
+                        return &ev
+                    }()""", ctx.symbolProvider().toSymbol(member));
+
+            // don't need the address-of
+            case BLOB, LIST, SET, MAP, UNION, DOCUMENT ->
+                    goTemplate("vv");
+
+            default -> goTemplate("&vv");
+        };
+    }
+
+    private Writable renderDeserializeMember() {
+        return switch (member.getType()) {
+            case BYTE ->
+                    goTemplate("d.ReadInt8(s.ListMember(), &vv)");
+            case SHORT ->
+                    goTemplate("d.ReadInt16(s.ListMember(), &vv)");
+            case INTEGER, INT_ENUM ->
+                    goTemplate("d.ReadInt32(s.ListMember(), &vv)");
+            case LONG ->
+                    goTemplate("d.ReadInt64(s.ListMember(), &vv)");
+
+            case FLOAT ->
+                    goTemplate("d.ReadFloat32(s.ListMember(), &vv)");
+            case DOUBLE ->
+                    goTemplate("d.ReadFloat64(s.ListMember(), &vv)");
+
+            case STRING, ENUM ->
+                    goTemplate("d.ReadString(s.ListMember(), &vv)");
+            case BOOLEAN ->
+                    goTemplate("d.ReadBool(s.ListMember(), &vv)");
+            case TIMESTAMP ->
+                    goTemplate("d.ReadTimestamp(s.ListMember(), &vv)");
+            case BLOB ->
+                    goTemplate("d.ReadBlob(s.ListMember(), &vv)");
+
+            case LIST, SET, MAP, UNION ->
+                    goTemplate("deserialize$L(d, s.ListMember(), &vv)", member.getId().getName());
+            case STRUCTURE ->
+                    goTemplate("vv.Deserialize(d)");
+            case DOCUMENT ->
+                    goTemplate("d.ReadDocument(s.ListMember(), &vv)");
+
+            case BIG_INTEGER, BIG_DECIMAL ->
+                    throw new CodegenException("big integer / big decimal unsupported");
+            case MEMBER, OPERATION, RESOURCE, SERVICE ->
+                    throw new CodegenException("invalid shape type " + shape.getType());
+        };
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/ListSerializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/ListSerializer.java
@@ -1,0 +1,142 @@
+package software.amazon.smithy.go.codegen.serde2;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+
+import java.util.Map;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.go.codegen.GoCodegenContext;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.Writable;
+import software.amazon.smithy.go.codegen.util.ShapeUtil;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.SparseTrait;
+
+public class ListSerializer implements Writable {
+    private final GoCodegenContext ctx;
+    private final ListShape shape;
+    private final Shape member;
+
+    public ListSerializer(GoCodegenContext ctx, ListShape shape) {
+        this.ctx = ctx;
+        this.shape = shape;
+        this.member = ShapeUtil.expectMember(ctx.model(), shape);
+    }
+
+    @Override
+    public void accept(GoWriter writer) {
+        writer.addUseImports(SmithyGoDependency.SMITHY);
+        writer.writeGoTemplate("""
+                func serialize$shapeName:L(s smithy.ShapeSerializer, schema *smithy.Schema, v $symbol:T) {
+                    s.WriteList(schema)
+                    for _, vv := range v {
+                        $serializeValue:W
+                    }
+                    s.CloseList()
+                }
+                """, Map.of(
+                "shapeName", shape.getId().getName(),
+                "symbol", ctx.symbolProvider().toSymbol(shape),
+                "serializeValue", renderSerializeValue()
+        ));
+    }
+
+    private Writable renderSerializeValue() {
+        if (shape.hasTrait(SparseTrait.class)) {
+            return renderSparseSerializeValue();
+        }
+        return renderDenseSerializeValue();
+    }
+
+    private Writable wrapNilCheck(Writable inner) {
+        return goTemplate("""
+                if vv != nil {
+                    $W
+                } else {
+                    s.WriteNil(schema.ListMember())
+                }""", inner);
+    }
+
+    private Writable renderSparseSerializeValue() {
+        return switch (member.getType()) {
+            case BYTE ->
+                    wrapNilCheck(goTemplate("s.WriteInt8(schema.ListMember(), *vv)"));
+            case SHORT ->
+                    wrapNilCheck(goTemplate("s.WriteInt16(schema.ListMember(), *vv)"));
+            case INTEGER ->
+                    wrapNilCheck(goTemplate("s.WriteInt32(schema.ListMember(), *vv)"));
+            case INT_ENUM ->
+                    wrapNilCheck(goTemplate("s.WriteInt32(schema.ListMember(), int32(*vv))"));
+            case LONG ->
+                    wrapNilCheck(goTemplate("s.WriteInt64(schema.ListMember(), *vv)"));
+
+            case FLOAT ->
+                    wrapNilCheck(goTemplate("s.WriteFloat32(schema.ListMember(), *vv)"));
+            case DOUBLE ->
+                    wrapNilCheck(goTemplate("s.WriteFloat64(schema.ListMember(), *vv)"));
+
+            case STRING ->
+                    wrapNilCheck(goTemplate("s.WriteString(schema.ListMember(), *vv)"));
+            case ENUM ->
+                    wrapNilCheck(goTemplate("s.WriteString(schema.ListMember(), string(*vv))"));
+            case BOOLEAN ->
+                    wrapNilCheck(goTemplate("s.WriteBool(schema.ListMember(), *vv)"));
+            case TIMESTAMP ->
+                    wrapNilCheck(goTemplate("s.WriteTime(schema.ListMember(), *vv)"));
+            case BLOB ->
+                    wrapNilCheck(goTemplate("s.WriteBlob(schema.ListMember(), vv)"));
+
+            case LIST, SET, MAP, UNION ->
+                    wrapNilCheck(goTemplate("serialize$L(s, schema.ListMember(), vv)", member.getId().getName()));
+            case STRUCTURE ->
+                    wrapNilCheck(goTemplate("vv.Serialize(s)"));
+            case DOCUMENT ->
+                    wrapNilCheck(goTemplate("s.WriteDocument(schema.ListMember(), vv)"));
+
+            case BIG_INTEGER, BIG_DECIMAL ->
+                    throw new CodegenException("big integer / big decimal unsupported");
+            case MEMBER, OPERATION, RESOURCE, SERVICE ->
+                    throw new CodegenException("invalid shape type " + member.getType());
+        };
+    }
+
+    private Writable renderDenseSerializeValue() {
+        return switch (member.getType()) {
+            case BYTE ->
+                    goTemplate("s.WriteInt8(schema.ListMember(), vv)");
+            case SHORT ->
+                    goTemplate("s.WriteInt16(schema.ListMember(), vv)");
+            case INTEGER, INT_ENUM ->
+                    goTemplate("s.WriteInt32(schema.ListMember(), int32(vv))");
+            case LONG ->
+                    goTemplate("s.WriteInt64(schema.ListMember(), vv)");
+
+            case FLOAT ->
+                    goTemplate("s.WriteFloat32(schema.ListMember(), vv)");
+            case DOUBLE ->
+                    goTemplate("s.WriteFloat64(schema.ListMember(), vv)");
+
+            case STRING, ENUM ->
+                    goTemplate("s.WriteString(schema.ListMember(), string(vv))");
+            case BOOLEAN ->
+                    goTemplate("s.WriteBool(schema.ListMember(), vv)");
+            case TIMESTAMP ->
+                    goTemplate("s.WriteTime(schema.ListMember(), vv)");
+            case BLOB ->
+                    goTemplate("s.WriteBlob(schema.ListMember(), vv)");
+
+            case LIST, SET, MAP, UNION ->
+                    goTemplate("serialize$L(s, schema.ListMember(), vv)", member.getId().getName());
+            case STRUCTURE ->
+                    goTemplate("vv.Serialize(s)");
+            case DOCUMENT ->
+                    goTemplate("s.WriteDocument(schema.ListMember(), vv)");
+
+            case BIG_INTEGER, BIG_DECIMAL ->
+                    throw new CodegenException("big integer / big decimal unsupported");
+            case MEMBER, OPERATION, RESOURCE, SERVICE ->
+                    throw new CodegenException("invalid shape type " + member.getType());
+        };
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/MapDeserializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/MapDeserializer.java
@@ -1,0 +1,156 @@
+package software.amazon.smithy.go.codegen.serde2;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+
+import java.util.Map;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.go.codegen.GoCodegenContext;
+import software.amazon.smithy.go.codegen.GoUniverseTypes;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.Writable;
+import software.amazon.smithy.go.codegen.util.ShapeUtil;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.SparseTrait;
+
+public class MapDeserializer implements Writable {
+    private final GoCodegenContext ctx;
+    private final MapShape shape;
+    private final Shape value;
+
+    public MapDeserializer(GoCodegenContext ctx, MapShape shape) {
+        this.ctx = ctx;
+        this.shape = shape;
+        this.value = ShapeUtil.expectMember(ctx.model(), shape);
+    }
+
+    @Override
+    public void accept(GoWriter writer) {
+        writer.addUseImports(SmithyGoDependency.SMITHY);
+        if (shape.hasTrait(SparseTrait.class)) {
+            renderSparse(writer);
+        } else {
+            renderDense(writer);
+        }
+    }
+
+    private void renderDense(GoWriter writer) {
+        writer.writeGoTemplate("""
+                func deserialize$shapeName:L(d smithy.ShapeDeserializer, s *smithy.Schema, v *$symbol:T) error {
+                    *v = make($symbol:T)
+                    return smithy.ReadMap(d, s, func(k string) error {
+                        var vv $valueSymbol:T
+                        if err := $deserializeValue:W; err != nil {
+                            return err
+                        }
+
+                        (*v)[k] = $cast:W
+                        return nil
+                    })
+                }
+                """, Map.of(
+                "shapeName", shape.getId().getName(),
+                "symbol", ctx.symbolProvider().toSymbol(shape),
+                "valueSymbol", switch (value.getType()) {
+                    case ENUM -> GoUniverseTypes.String;
+                    case INT_ENUM -> GoUniverseTypes.Int32;
+                    default -> ctx.symbolProvider().toSymbol(value);
+                },
+                "deserializeValue", renderDeserializeValue(),
+                "cast", switch (value.getType()) {
+                    case ENUM, INT_ENUM -> goTemplate("$T(vv)", ctx.symbolProvider().toSymbol(value));
+                    default -> goTemplate("vv");
+                }
+        ));
+    }
+
+    private void renderSparse(GoWriter writer) {
+        writer.writeGoTemplate("""
+                func deserialize$shapeName:L(d smithy.ShapeDeserializer, s *smithy.Schema, v *$symbol:T) error {
+                    *v = make($symbol:T)
+                    return smithy.ReadMap(d, s, func(k string) error {
+                        if isNil, err := d.ReadNil(s.MapValue()); err != nil {
+                            return err
+                        } else if isNil {
+                            (*v)[k] = nil
+                            return nil
+                        }
+
+                        var vv $valueSymbol:T
+                        if err := $deserializeValue:W; err != nil {
+                            return err
+                        }
+
+                        (*v)[k] = $cast:W
+                        return nil
+                    })
+                }
+                """, Map.of(
+                "shapeName", shape.getId().getName(),
+                "symbol", ctx.symbolProvider().toSymbol(shape),
+                "valueSymbol", switch (value.getType()) {
+                    case ENUM -> GoUniverseTypes.String;
+                    case INT_ENUM -> GoUniverseTypes.Int32;
+                    default -> ctx.symbolProvider().toSymbol(value);
+                },
+                "deserializeValue", renderDeserializeValue(),
+                "cast", renderSparseCast()
+        ));
+    }
+
+    private Writable renderSparseCast() {
+        return switch (value.getType()) {
+            case ENUM, INT_ENUM -> goTemplate("""
+                    func() $T {
+                        ev := $T(vv)
+                        return &ev
+                    }()""", ctx.symbolProvider().toSymbol(value));
+
+            // don't need the address-of
+            case BLOB, LIST, SET, MAP, UNION, DOCUMENT ->
+                    goTemplate("vv");
+
+            default -> goTemplate("&vv");
+        };
+    }
+
+    private Writable renderDeserializeValue() {
+        return switch (value.getType()) {
+            case BYTE ->
+                    goTemplate("d.ReadInt8(s.MapValue(), &vv)");
+            case SHORT ->
+                    goTemplate("d.ReadInt16(s.MapValue(), &vv)");
+            case INTEGER, INT_ENUM ->
+                    goTemplate("d.ReadInt32(s.MapValue(), &vv)");
+            case LONG ->
+                    goTemplate("d.ReadInt64(s.MapValue(), &vv)");
+
+            case FLOAT ->
+                    goTemplate("d.ReadFloat32(s.MapValue(), &vv)");
+            case DOUBLE ->
+                    goTemplate("d.ReadFloat64(s.MapValue(), &vv)");
+
+            case STRING, ENUM ->
+                    goTemplate("d.ReadString(s.MapValue(), &vv)");
+            case BOOLEAN ->
+                    goTemplate("d.ReadBool(s.MapValue(), &vv)");
+            case TIMESTAMP ->
+                    goTemplate("d.ReadTime(s.MapValue(), &vv)");
+            case BLOB ->
+                    goTemplate("d.ReadBlob(s.MapValue(), &vv)");
+
+            case LIST, SET, MAP, UNION ->
+                    goTemplate("deserialize$L(d, s.MapValue(), &vv)", value.getId().getName());
+            case STRUCTURE ->
+                    goTemplate("vv.Deserialize(d)");
+            case DOCUMENT ->
+                    goTemplate("d.ReadDocument(s.MapValue(), &vv)");
+
+            case BIG_INTEGER, BIG_DECIMAL ->
+                    throw new CodegenException("big integer / big decimal unsupported");
+            case MEMBER, OPERATION, RESOURCE, SERVICE ->
+                    throw new CodegenException("invalid shape type " + value.getType());
+        };
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/MapSerializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/MapSerializer.java
@@ -1,0 +1,143 @@
+package software.amazon.smithy.go.codegen.serde2;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+
+import java.util.Map;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.go.codegen.GoCodegenContext;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.Writable;
+import software.amazon.smithy.go.codegen.util.ShapeUtil;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.SparseTrait;
+
+public class MapSerializer implements Writable {
+    private final GoCodegenContext ctx;
+    private final MapShape shape;
+    private final Shape value;
+
+    public MapSerializer(GoCodegenContext ctx, MapShape shape) {
+        this.ctx = ctx;
+        this.shape = shape;
+        this.value = ShapeUtil.expectMember(ctx.model(), shape);
+    }
+
+    @Override
+    public void accept(GoWriter writer) {
+        writer.addUseImports(SmithyGoDependency.SMITHY);
+        writer.writeGoTemplate("""
+                func serialize$shapeName:L(s smithy.ShapeSerializer, schema *smithy.Schema, v $symbol:T) {
+                    s.WriteMap(schema)
+                    for k, vv := range v {
+                        s.WriteKey(schema.MapKey(), k)
+                        $serializeValue:W
+                    }
+                    s.CloseMap()
+                }
+                """, Map.of(
+                "shapeName", shape.getId().getName(),
+                "symbol", ctx.symbolProvider().toSymbol(shape),
+                "serializeValue", renderSerializeValue()
+        ));
+    }
+
+    private Writable renderSerializeValue() {
+        if (shape.hasTrait(SparseTrait.class)) {
+            return renderSparseSerializeValue();
+        }
+        return renderDenseSerializeValue();
+    }
+
+    private Writable wrapNilCheck(Writable inner) {
+        return goTemplate("""
+                if vv != nil {
+                    $W
+                } else {
+                    s.WriteNil(schema.MapValue())
+                }""", inner);
+    }
+
+    private Writable renderSparseSerializeValue() {
+        return switch (value.getType()) {
+            case BYTE ->
+                    wrapNilCheck(goTemplate("s.WriteInt8(schema.MapValue(), *vv)"));
+            case SHORT ->
+                    wrapNilCheck(goTemplate("s.WriteInt16(schema.MapValue(), *vv)"));
+            case INTEGER ->
+                    wrapNilCheck(goTemplate("s.WriteInt32(schema.MapValue(), *vv)"));
+            case INT_ENUM ->
+                    wrapNilCheck(goTemplate("s.WriteInt32(schema.MapValue(), int32(*vv))"));
+            case LONG ->
+                    wrapNilCheck(goTemplate("s.WriteInt64(schema.MapValue(), *vv)"));
+
+            case FLOAT ->
+                    wrapNilCheck(goTemplate("s.WriteFloat32(schema.MapValue(), *vv)"));
+            case DOUBLE ->
+                    wrapNilCheck(goTemplate("s.WriteFloat64(schema.MapValue(), *vv)"));
+
+            case STRING ->
+                    wrapNilCheck(goTemplate("s.WriteString(schema.MapValue(), *vv)"));
+            case ENUM ->
+                    wrapNilCheck(goTemplate("s.WriteString(schema.MapValue(), string(*vv))"));
+            case BOOLEAN ->
+                    wrapNilCheck(goTemplate("s.WriteBool(schema.MapValue(), *vv)"));
+            case TIMESTAMP ->
+                    wrapNilCheck(goTemplate("s.WriteTime(schema.MapValue(), *vv)"));
+            case BLOB ->
+                    wrapNilCheck(goTemplate("s.WriteBlob(schema.MapValue(), vv)"));
+
+            case LIST, SET, MAP, UNION ->
+                    wrapNilCheck(goTemplate("serialize$L(s, schema.MapValue(), vv)", value.getId().getName()));
+            case STRUCTURE ->
+                    wrapNilCheck(goTemplate("vv.Serialize(s)"));
+            case DOCUMENT ->
+                    wrapNilCheck(goTemplate("s.WriteDocument(schema.MapValue(), vv)"));
+
+            case BIG_INTEGER, BIG_DECIMAL ->
+                    throw new CodegenException("big integer / big decimal unsupported");
+            case MEMBER, OPERATION, RESOURCE, SERVICE ->
+                    throw new CodegenException("invalid shape type " + value.getType());
+        };
+    }
+
+    private Writable renderDenseSerializeValue() {
+        return switch (value.getType()) {
+            case BYTE ->
+                    goTemplate("s.WriteInt8(schema.MapValue(), vv)");
+            case SHORT ->
+                    goTemplate("s.WriteInt16(schema.MapValue(), vv)");
+            case INTEGER, INT_ENUM ->
+                    goTemplate("s.WriteInt32(schema.MapValue(), int32(vv))");
+            case LONG ->
+                    goTemplate("s.WriteInt64(schema.MapValue(), vv)");
+
+            case FLOAT ->
+                    goTemplate("s.WriteFloat32(schema.MapValue(), vv)");
+            case DOUBLE ->
+                    goTemplate("s.WriteFloat64(schema.MapValue(), vv)");
+
+            case STRING, ENUM ->
+                    goTemplate("s.WriteString(schema.MapValue(), string(vv))");
+            case BOOLEAN ->
+                    goTemplate("s.WriteBool(schema.MapValue(), vv)");
+            case TIMESTAMP ->
+                    goTemplate("s.WriteTime(schema.MapValue(), vv)");
+            case BLOB ->
+                    goTemplate("s.WriteBlob(schema.MapValue(), vv)");
+
+            case LIST, SET, MAP, UNION ->
+                    goTemplate("serialize$L(s, schema.MapValue(), vv)", value.getId().getName());
+            case STRUCTURE ->
+                    goTemplate("vv.Serialize(s)");
+            case DOCUMENT ->
+                    goTemplate("s.WriteDocument(schema.MapValue(), vv)");
+
+            case BIG_INTEGER, BIG_DECIMAL ->
+                    throw new CodegenException("big integer / big decimal unsupported");
+            case MEMBER, OPERATION, RESOURCE, SERVICE ->
+                    throw new CodegenException("invalid shape type " + value.getType());
+        };
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/Serde2DeserializeResponseMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/Serde2DeserializeResponseMiddleware.java
@@ -1,0 +1,57 @@
+package software.amazon.smithy.go.codegen.serde2;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+import static software.amazon.smithy.go.codegen.SymbolUtils.buildPackageSymbol;
+import static software.amazon.smithy.go.codegen.SymbolUtils.pointerTo;
+
+import java.util.Map;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.Writable;
+import software.amazon.smithy.go.codegen.middleware.DeserializeStepMiddleware;
+
+public class Serde2DeserializeResponseMiddleware extends DeserializeStepMiddleware {
+    @Override
+    public String getStructName() {
+        return "deserializeResponseMiddleware";
+    }
+
+    @Override
+    public String getId() {
+        return "OperationDeserializer";
+    }
+
+    @Override
+    public Map<String, Symbol> getFields() {
+        return Map.of(
+                "options", pointerTo(buildPackageSymbol("Options")),
+                "output", SmithyGoDependency.SMITHY.interfaceSymbol("Deserializable")
+        );
+    }
+
+    @Override
+    public Writable getFuncBody() {
+        return goTemplate("""
+                out, md, err := next.HandleDeserialize(ctx, in)
+                if err != nil {
+                    return out, md, err
+                }
+
+                resp, ok := out.RawResponse.(*smithyhttp.Response)
+                if !ok {
+                    return out, md, &smithy.DeserializationError{Err: fmt.Errorf("unknown transport type %T", out.RawResponse)}
+                }
+
+                _, span := tracing.StartSpan(ctx, "OperationDeserializer")
+                endTimer := startMetricTimer(ctx, "client.call.deserialization_duration")
+
+                err = m.options.Protocol.DeserializeResponse(ctx, TypeRegistry, resp, m.output)
+                out.Result = m.output
+
+                endTimer()
+                span.End()
+
+                return out, md, err
+                """);
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/Serde2SerializeRequestMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/Serde2SerializeRequestMiddleware.java
@@ -1,0 +1,61 @@
+package software.amazon.smithy.go.codegen.serde2;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+import static software.amazon.smithy.go.codegen.SymbolUtils.buildPackageSymbol;
+import static software.amazon.smithy.go.codegen.SymbolUtils.pointerTo;
+
+import java.util.Map;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.Writable;
+import software.amazon.smithy.go.codegen.middleware.SerializeStepMiddleware;
+
+public class Serde2SerializeRequestMiddleware extends SerializeStepMiddleware {
+    @Override
+    public String getStructName() {
+        return "serializeRequestMiddleware";
+    }
+
+    @Override
+    public String getId() {
+        return "OperationSerializer";
+    }
+
+    @Override
+    public Map<String, Symbol> getFields() {
+        return Map.of(
+                "options", pointerTo(buildPackageSymbol("Options"))
+        );
+    }
+
+    @Override
+    public Writable getFuncBody() {
+        return GoWriter.goTemplate("""
+                $D
+                req, ok := in.Request.(*smithyhttp.Request)
+                if !ok {
+                    return middleware.SerializeOutput{}, middleware.Metadata{}, fmt.Errorf("unexpected transport type %T", in.Request)
+                }
+
+                input, ok := in.Parameters.(smithy.Serializable)
+                if !ok {
+                    return middleware.SerializeOutput{}, middleware.Metadata{}, fmt.Errorf("input %T is not Serializable", in.Request)
+                }
+
+                _, span := tracing.StartSpan(ctx, "OperationSerializer")
+                endTimer := startMetricTimer(ctx, "client.call.serialization_duration")
+
+                err := m.options.Protocol.SerializeRequest(ctx, input, req)
+
+                endTimer()
+                span.End()
+
+                if err != nil {
+                    return middleware.SerializeOutput{}, middleware.Metadata{}, err
+                }
+
+                return next.HandleSerialize(ctx, in)
+                """, SmithyGoDependency.SMITHY_TRACING);
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/StructureDeserializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/StructureDeserializer.java
@@ -1,0 +1,127 @@
+package software.amazon.smithy.go.codegen.serde2;
+
+import java.util.Comparator;
+import software.amazon.smithy.go.codegen.GoCodegenContext;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.ProtocolDocumentGenerator;
+import software.amazon.smithy.go.codegen.SchemaGenerator;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.SmithyGoTypes;
+import software.amazon.smithy.go.codegen.UnsupportedShapeException;
+import software.amazon.smithy.go.codegen.Writable;
+import software.amazon.smithy.go.codegen.knowledge.GoPointableIndex;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.StructureShape;
+
+public class StructureDeserializer implements Writable {
+    private final GoCodegenContext ctx;
+    private final StructureShape shape;
+    private final GoPointableIndex nilIndex;
+
+    public StructureDeserializer(GoCodegenContext ctx, StructureShape shape) {
+        this.ctx = ctx;
+        this.shape = shape;
+
+        this.nilIndex = GoPointableIndex.of(ctx.model());
+    }
+
+    @Override
+    public void accept(GoWriter writer) {
+        writer.addImport(ctx.settings().getModuleName() + "/schemas", "schemas");
+        writer.addUseImports(SmithyGoDependency.SMITHY);
+
+        var symbol = ctx.symbolProvider().toSymbol(shape);
+        var members = shape.members().stream()
+                .sorted(Comparator.comparing(MemberShape::getMemberName))
+                .toList();
+        writer.openBlock("func (v *$L) Deserialize(d smithy.ShapeDeserializer) error {", "}", symbol.getName(), () -> {
+            writer.openBlock("return smithy.ReadStruct(d, schemas.$L, func(s *smithy.Schema) error {", "})", SchemaGenerator.getSchemaName(shape), () -> {
+                writer.openBlock("switch s {", "}", () -> {
+                    for (var member : members) {
+                        writer.write("case schemas.$L:", SchemaGenerator.getMemberSchemaName(shape, member));
+                        renderMember(writer, member, ctx.model().expectShape(member.getTarget()), "v." + ctx.symbolProvider().toMemberName(member));
+                    }
+                });
+                writer.write("return nil");
+            });
+        });
+    }
+
+    private void renderMember(GoWriter writer, MemberShape member, Shape target, String ident) {
+        var schemaName = SchemaGenerator.getMemberSchemaName(shape, member);
+        var ptrSuffix = nilIndex.isNillable(member) ? "Ptr" : "";
+        switch (target.getType()) {
+            case BYTE ->
+                    writer.write("return d.ReadInt8$L(schemas.$L, &$L)", ptrSuffix, schemaName, ident);
+            case SHORT ->
+                    writer.write("return d.ReadInt16$L(schemas.$L, &$L)", ptrSuffix, schemaName, ident);
+            case INTEGER ->
+                    writer.write("return d.ReadInt32$L(schemas.$L, &$L)", ptrSuffix, schemaName, ident);
+            case LONG ->
+                    writer.write("return d.ReadInt64$L(schemas.$L, &$L)", ptrSuffix, schemaName, ident);
+
+            case FLOAT ->
+                    writer.write("return d.ReadFloat32$L(schemas.$L, &$L)", ptrSuffix, schemaName, ident);
+            case DOUBLE ->
+                    writer.write("return d.ReadFloat64$L(schemas.$L, &$L)", ptrSuffix, schemaName, ident);
+
+            case STRING ->
+                    writer.write("return d.ReadString$L(schemas.$L, &$L)", ptrSuffix, schemaName, ident);
+            case ENUM ->
+                    writer.write("""
+                            var ev string
+                            if err := d.ReadString(schemas.$1L, &ev); err != nil {
+                                return err
+                            }
+                            $2L = $3T(ev)
+                            return nil""", schemaName, ident, ctx.symbolProvider().toSymbol(target));
+            case INT_ENUM ->
+                    writer.write("""
+                            var ev int32
+                            if err := d.ReadInt32(schemas.$1L, &ev); err != nil {
+                                return err
+                            }
+                            $2L = $3T(ev)
+                            return nil""", schemaName, ident, ctx.symbolProvider().toSymbol(target));
+            case BOOLEAN ->
+                    writer.write("return d.ReadBool$L(schemas.$L, &$L)", ptrSuffix, schemaName, ident);
+            case TIMESTAMP ->
+                    writer.write("return d.ReadTime$L(schemas.$L, &$L)", ptrSuffix, schemaName, ident);
+            case BLOB ->
+                    writer.write("return d.ReadBlob(schemas.$L, &$L)", schemaName, ident);
+
+            case LIST, SET, MAP, UNION ->
+                    writer.write("return deserialize$L(d, schemas.$L, &$L)", target.getId().getName(), schemaName, ident);
+            case STRUCTURE -> {
+                if (nilIndex.isNillable(member)) {
+                    writer.write("""
+                            $1L = &$2T{}
+                            return $1L.Deserialize(d)""", ident, ctx.symbolProvider().toSymbol(target));
+                } else {
+                    writer.write("return $L.Deserialize(d)", ident);
+                }
+            }
+            case DOCUMENT -> {
+                var unmarshaler = ProtocolDocumentGenerator.Utilities.getInternalDocumentSymbolBuilder(
+                        ctx.settings(), ProtocolDocumentGenerator.INTERNAL_NEW_DOCUMENT_UNMARSHALER_FUNC).build();
+                writer.addUseImports(SmithyGoDependency.SMITHY_DOCUMENT);
+                writer.write("""
+                        var dv smithydocument.Value
+                        if err := d.ReadDocument(schemas.$L, &dv); err != nil {
+                            return err
+                        }
+                        if ov, ok := dv.(smithydocument.Opaque); ok {
+                            $L = $T(ov.Value)
+                        }
+                        return nil""", schemaName, ident, unmarshaler);
+            }
+
+            // FUTURE(602)
+            case BIG_INTEGER, BIG_DECIMAL -> throw new UnsupportedShapeException(target.getType());
+
+            // invalid in this context
+            case MEMBER, SERVICE, RESOURCE, OPERATION -> throw new UnsupportedShapeException(target.getType());
+        }
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/StructureSerializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/StructureSerializer.java
@@ -1,0 +1,99 @@
+package software.amazon.smithy.go.codegen.serde2;
+
+import java.util.Comparator;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.go.codegen.GoCodegenContext;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SchemaGenerator;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.UnsupportedShapeException;
+import software.amazon.smithy.go.codegen.Writable;
+import software.amazon.smithy.go.codegen.knowledge.GoPointableIndex;
+import software.amazon.smithy.go.codegen.util.ShapeUtil;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class StructureSerializer implements Writable {
+    private final GoCodegenContext ctx;
+    private final StructureShape shape;
+    private final GoPointableIndex nilIndex;
+
+    public StructureSerializer(GoCodegenContext ctx, StructureShape shape) {
+        this.ctx = ctx;
+        this.shape = shape;
+
+        this.nilIndex = GoPointableIndex.of(ctx.model());
+    }
+
+    @Override
+    public void accept(GoWriter writer) {
+        writer.addImport(ctx.settings().getModuleName() + "/schemas", "schemas");
+
+        var symbol = ctx.symbolProvider().toSymbol(shape);
+        var members = shape.members().stream()
+                .sorted(Comparator.comparing(MemberShape::getMemberName))
+                .toList();
+        writer.addUseImports(SmithyGoDependency.SMITHY);
+        writer.openBlock("func (v *$L) Serialize(s smithy.ShapeSerializer) {", "}", symbol.getName(), () -> {
+            writer.write("s.WriteMap(schemas.$L)", SchemaGenerator.getSchemaName(shape));
+            for (var member : members) {
+                var target = ShapeUtil.expectMember(ctx.model(), shape, member.getMemberName());
+                var ident = String.format("v.%s", ctx.symbolProvider().toMemberName(member));
+                generateSerializeMember(writer, member, target, ident);
+            }
+            writer.write("s.CloseMap()");
+        });
+        writer.write("");
+    }
+
+    private void generateSerializeMember(GoWriter writer, MemberShape member, Shape target, String ident) {
+        var schemaName = "schemas." + SchemaGenerator.getMemberSchemaName(shape, member);
+        var ptrSuffix = nilIndex.isNillable(member) ? "Ptr" : "";
+        switch (target.getType()) {
+            case BYTE ->
+                    writer.write("s.WriteInt8$L($L, $L)", ptrSuffix, schemaName, ident);
+            case SHORT ->
+                    writer.write("s.WriteInt16$L($L, $L)", ptrSuffix, schemaName, ident);
+            case INTEGER ->
+                    writer.write("s.WriteInt32$L($L, $L)", ptrSuffix, schemaName, ident);
+            case LONG ->
+                    writer.write("s.WriteInt64$L($L, $L)", ptrSuffix, schemaName, ident);
+
+            case FLOAT ->
+                    writer.write("s.WriteFloat32$L($L, $L)", ptrSuffix, schemaName, ident);
+            case DOUBLE ->
+                    writer.write("s.WriteFloat64$L($L, $L)", ptrSuffix, schemaName, ident);
+
+            case STRING ->
+                    writer.write("s.WriteString$L($L, $L)", ptrSuffix, schemaName, ident);
+            case ENUM ->
+                    writer.write("s.WriteString($L, string($L))", schemaName, ident);
+            case INT_ENUM ->
+                    writer.write("s.WriteInt32($L, int32($L))", schemaName, ident);
+            case BOOLEAN ->
+                    writer.write("s.WriteBool$L($L, $L)", ptrSuffix, schemaName, ident);
+            case TIMESTAMP ->
+                    writer.write("s.WriteTime$L($L, $L)", ptrSuffix, schemaName, ident);
+            case BLOB ->
+                    writer.write("s.WriteBlob($L, $L)", schemaName, ident);
+
+            case LIST, SET, MAP, UNION ->
+                    writer.write("serialize$L(s, $L, $L)", target.getId().getName(), schemaName, ident);
+            case STRUCTURE ->
+                    writer.write("if ($2L != nil) { s.WriteStruct($1L, $2L) }", schemaName, ident);
+            case DOCUMENT -> {
+                writer.addUseImports(SmithyGoDependency.SMITHY_DOCUMENT);
+                writer.write("s.WriteDocument($L, &smithydocument.Opaque{Value: $L})", schemaName, ident);
+            }
+
+            // FUTURE(602)
+            case BIG_INTEGER, BIG_DECIMAL -> throw new UnsupportedShapeException(target.getType());
+
+            // invalid in this context
+            case MEMBER, SERVICE, RESOURCE, OPERATION -> throw new CodegenException("invalid shape " + target.getType());
+        }
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/UnionDeserializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/UnionDeserializer.java
@@ -1,0 +1,73 @@
+package software.amazon.smithy.go.codegen.serde2;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+
+import java.util.Comparator;
+import java.util.Map;
+import software.amazon.smithy.go.codegen.GoCodegenContext;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SchemaGenerator;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.Writable;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+
+public class UnionDeserializer implements Writable {
+    private final GoCodegenContext ctx;
+    private final UnionShape shape;
+
+    public UnionDeserializer(GoCodegenContext ctx, UnionShape shape) {
+        this.ctx = ctx;
+        this.shape = shape;
+    }
+
+    @Override
+    public void accept(GoWriter writer) {
+        writer.addUseImports(SmithyGoDependency.SMITHY);
+        writer.addImport(ctx.settings().getModuleName() + "/schemas", "schemas");
+
+        var symbol = ctx.symbolProvider().toSymbol(shape);
+        var members = shape.members().stream()
+                .sorted(Comparator.comparing(MemberShape::getMemberName))
+                .toList();
+
+        writer.writeGoTemplate("""
+                func deserialize$shapeName:L(d smithy.ShapeDeserializer, s *smithy.Schema, v *$symbol:T) error {
+                    ms, err := d.ReadUnion(s)
+                    if err != nil {
+                        return err
+                    }
+
+                    switch ms {
+                    $cases:W
+                    }
+                    return nil
+                }
+                """, Map.of(
+                "shapeName", shape.getId().getName(),
+                "symbol", symbol,
+                "cases", renderCases(members)
+        ));
+    }
+
+    private Writable renderCases(java.util.List<MemberShape> members) {
+        return (GoWriter w) -> {
+            var unionSymbol = ctx.symbolProvider().toSymbol(shape);
+            for (var member : members) {
+                var memberName = ctx.symbolProvider().toMemberName(member);
+                var variantSchema = SchemaGenerator.getMemberSchemaName(shape, member);
+                
+                var memberSymbol = unionSymbol.toBuilder()
+                        .name(memberName)
+                        .build();
+                
+                w.write("case schemas.$L:", variantSchema);
+                w.indent();
+                w.write("vv := &$T{}", memberSymbol);
+                w.write("*v = vv");
+                w.write("return vv.Deserialize(d)");
+                w.dedent();
+            }
+        };
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/UnionDeserializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/UnionDeserializer.java
@@ -41,7 +41,8 @@ public class UnionDeserializer implements Writable {
                     switch ms {
                     $cases:W
                     }
-                    return nil
+
+                    return d.CloseUnion(s)
                 }
                 """, Map.of(
                 "shapeName", shape.getId().getName(),

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/UnionSerializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/UnionSerializer.java
@@ -1,0 +1,62 @@
+package software.amazon.smithy.go.codegen.serde2;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.GoCodegenContext;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SchemaGenerator;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.Writable;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+
+public class UnionSerializer implements Writable {
+    private final GoCodegenContext ctx;
+    private final UnionShape shape;
+
+    public UnionSerializer(GoCodegenContext ctx, UnionShape shape) {
+        this.ctx = ctx;
+        this.shape = shape;
+    }
+
+    @Override
+    public void accept(GoWriter writer) {
+        writer.addUseImports(SmithyGoDependency.SMITHY);
+        writer.addImport(ctx.settings().getModuleName() + "/schemas", "schemas");
+
+        var symbol = ctx.symbolProvider().toSymbol(shape);
+        var members = shape.members().stream()
+                .sorted(Comparator.comparing(MemberShape::getMemberName))
+                .toList();
+
+        writer.writeGoTemplate("""
+                func serialize$shapeName:L(s smithy.ShapeSerializer, schema *smithy.Schema, v $symbol:T) {
+                    switch vv := v.(type) {
+                        $cases:W
+                    }
+                }
+                """, Map.of(
+                "shapeName", shape.getId().getName(),
+                "symbol", symbol,
+                "cases", renderCases(members)
+        ));
+    }
+
+    private Writable renderCases(List<MemberShape> members) {
+        return (GoWriter w) -> {
+            for (var member : members) {
+                var variantSymbol = Symbol.builder()
+                        .name(ctx.symbolProvider().toMemberName(member))
+                        .namespace(ctx.settings().getModuleName() + "/types", ".")
+                        .build();
+                var variantSchema = SchemaGenerator.getMemberSchemaName(shape, member);
+                w.write("case *$T:", variantSymbol);
+                w.write("    s.WriteUnion(schema, schemas.$L, vv)", variantSchema);
+            }
+        };
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/util/ShapeUtil.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/util/ShapeUtil.java
@@ -28,6 +28,7 @@ import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
 
 public final class ShapeUtil {
     public static final StringShape STRING_SHAPE = StringShape.builder()
@@ -40,6 +41,10 @@ public final class ShapeUtil {
 
     public static final BooleanShape BOOL_SHAPE = BooleanShape.builder()
             .id("smithy.api#PrimitiveBoolean")
+            .build();
+
+    public static final StructureShape UNIT = StructureShape.builder()
+            .id("smithy.api#Unit")
             .build();
 
     private ShapeUtil() {}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/util/ShapeUtil.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/util/ShapeUtil.java
@@ -15,14 +15,18 @@
 
 package software.amazon.smithy.go.codegen.util;
 
+import java.util.Set;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.neighbor.Walker;
 import software.amazon.smithy.model.shapes.BooleanShape;
 import software.amazon.smithy.model.shapes.CollectionShape;
 import software.amazon.smithy.model.shapes.IntegerShape;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.StringShape;
 
 public final class ShapeUtil {
@@ -39,6 +43,13 @@ public final class ShapeUtil {
             .build();
 
     private ShapeUtil() {}
+
+    public static boolean isExported(Shape shape) {
+        return switch (shape.getType()) {
+            case STRUCTURE, UNION, ENUM -> true;
+            default -> false;
+        };
+    }
 
     public static ListShape listOf(Shape member) {
         return ListShape.builder()

--- a/document/document.go
+++ b/document/document.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
+	"time"
 )
 
 // Marshaler is an interface for a type that marshals a document to its protocol-specific byte representation and
@@ -15,26 +16,26 @@ import (
 // When defining struct types. the `document` struct tag can be used to control how the value will be
 // marshaled into the resulting protocol document.
 //
-//		// Field is ignored
-//		Field int `document:"-"`
+//	// Field is ignored
+//	Field int `document:"-"`
 //
-//		// Field object of key "myName"
-//		Field int `document:"myName"`
+//	// Field object of key "myName"
+//	Field int `document:"myName"`
 //
-//		// Field object key of key "myName", and
-//		// Field is omitted if the field is a zero value for the type.
-//		Field int `document:"myName,omitempty"`
+//	// Field object key of key "myName", and
+//	// Field is omitted if the field is a zero value for the type.
+//	Field int `document:"myName,omitempty"`
 //
-//		// Field object key of "Field", and
-//		// Field is omitted if the field is a zero value for the type.
-//		Field int `document:",omitempty"`
+//	// Field object key of "Field", and
+//	// Field is omitted if the field is a zero value for the type.
+//	Field int `document:",omitempty"`
 //
 // All struct fields, including anonymous fields, are marshaled unless the
 // any of the following conditions are meet.
 //
-//		- the field is not exported
-//		- document field tag is "-"
-//		- document field tag specifies "omitempty", and is a zero value.
+//   - the field is not exported
+//   - document field tag is "-"
+//   - document field tag specifies "omitempty", and is a zero value.
 //
 // Pointer and interface values are encoded as the value pointed to or
 // contained in the interface. A nil value encodes as a null
@@ -50,6 +51,13 @@ import (
 //
 // Marshal cannot represent cyclic data structures and will not handle them.
 // Passing cyclic structures to Marshal will result in an infinite recursion.
+//
+// Marshaler is not used in schema-serde based services (which are currently
+// being rolled out) since having an implementation of Marshaler locks a
+// document into support for a specific serial format. Existing implementations
+// of Marshaler will continue to encode to JSON as that is effectively the only
+// serial format supported for Document prior to the introduction of
+// schema-serde. In schema-serde services it is replaced by [Value].
 type Marshaler interface {
 	MarshalSmithyDocument() ([]byte, error)
 }
@@ -63,17 +71,93 @@ type Marshaler interface {
 //
 // Both generic interface{} and concrete types are valid unmarshal destination types. When unmarshaling a document
 // into an empty interface the Unmarshaler will store one of these values:
-//   bool,                   for boolean values
-//   document.Number,        for arbitrary-precision numbers (int64, float64, big.Int, big.Float)
-//   string,                 for string values
-//   []interface{},          for array values
-//   map[string]interface{}, for objects
-//   nil,                    for null values
+//
+//	bool,                   for boolean values
+//	document.Number,        for arbitrary-precision numbers (int64, float64, big.Int, big.Float)
+//	string,                 for string values
+//	[]interface{},          for array values
+//	map[string]interface{}, for objects
+//	nil,                    for null values
 //
 // When unmarshaling, any error that occurs will halt the unmarshal and return the error.
 type Unmarshaler interface {
 	UnmarshalSmithyDocument(v interface{}) error
 }
+
+// Value is a sealed type representing a Smithy document value. It covers the
+// full Smithy data model including blob and timestamp.
+//
+// The following types implement Value:
+//   - [Null]
+//   - [Boolean]
+//   - [Number]
+//   - [String]
+//   - [Blob]
+//   - [Timestamp]
+//   - [List]
+//   - [Map]
+//   - [Structure]
+//   - [Opaque]
+type Value interface {
+	isValue()
+}
+
+// Null is a document null value.
+type Null struct{}
+
+func (Null) isValue() {}
+
+// Boolean is a document boolean value.
+type Boolean bool
+
+func (Boolean) isValue() {}
+
+// String is a document string value.
+type String string
+
+func (String) isValue() {}
+
+// Blob is a document blob value.
+type Blob []byte
+
+func (Blob) isValue() {}
+
+// Timestamp is a document timestamp value.
+type Timestamp time.Time
+
+func (Timestamp) isValue() {}
+
+// List is a document list value.
+type List []Value
+
+func (List) isValue() {}
+
+// Map is a document map value with string keys.
+type Map map[string]Value
+
+func (Map) isValue() {}
+
+// Structure is a document structure value with an optional discriminator
+// identifying the shape it represents.
+type Structure struct {
+	// Discriminator is the absolute shape ID (e.g.
+	// "com.example#MyShape") of the concrete type this structure
+	// represents. It may be empty if the type is unknown.
+	Discriminator string
+
+	// Members maps member names to their document values.
+	Members map[string]Value
+}
+
+func (Structure) isValue() {}
+
+// Opaque wraps an arbitrary Go value for backward compatibility with the
+// legacy reflection-based document serialization path.
+type Opaque struct {
+	Value any
+}
+
+func (Opaque) isValue() {}
 
 type noSerde interface {
 	noSmithyDocumentSerde()
@@ -95,6 +179,8 @@ func IsNoSerde(x interface{}) bool {
 
 // Number is an arbitrary precision numerical value
 type Number string
+
+func (Number) isValue() {}
 
 // Int64 returns the number as a string.
 func (n Number) String() string {

--- a/middleware/context.go
+++ b/middleware/context.go
@@ -5,6 +5,7 @@ import "context"
 type (
 	serviceIDKey     struct{}
 	operationNameKey struct{}
+	serviceNameKey   struct{}
 )
 
 // WithServiceID adds a service ID to the context, scoped to middleware stack
@@ -37,5 +38,21 @@ func WithOperationName(parent context.Context, id string) context.Context {
 // typically the operation shape's name from its Smithy model.
 func GetOperationName(ctx context.Context) string {
 	name, _ := GetStackValue(ctx, operationNameKey{}).(string)
+	return name
+}
+
+// WithServiceName adds the service name to the context, scoped to middleware
+// stack values.
+//
+// This API is called in the client runtime when bootstrapping an operation and
+// should not typically be used directly.
+func WithServiceName(parent context.Context, id string) context.Context {
+	return WithStackValue(parent, serviceNameKey{}, id)
+}
+
+// GetServiceName retrieves the service name from the context. This is
+// ALWAYS the service shape's name from its Smithy model.
+func GetServiceName(ctx context.Context) string {
+	name, _ := GetStackValue(ctx, serviceNameKey{}).(string)
 	return name
 }

--- a/schema.go
+++ b/schema.go
@@ -1,0 +1,156 @@
+package smithy
+
+import (
+	"maps"
+	"strings"
+)
+
+// ShapeType is a type of Smithy shape.
+// See https://smithy.io/2.0/spec/idl.html#defining-shapes.
+type ShapeType int
+
+// Enumerates ShapeType per the Smithy IDL.
+const (
+	ShapeTypeBlob ShapeType = iota
+	ShapeTypeBoolean
+	ShapeTypeString
+	ShapeTypeTimestamp
+	ShapeTypeByte
+	ShapeTypeShort
+	ShapeTypeInteger
+	ShapeTypeLong
+	ShapeTypeFloat
+	ShapeTypeDocument
+	ShapeTypeDouble
+	ShapeTypeBigDecimal
+	ShapeTypeBigInteger
+	ShapeTypeEnum
+	ShapeTypeIntEnum
+	ShapeTypeList
+	ShapeTypeSet
+	ShapeTypeMap
+	ShapeTypeStructure
+	ShapeTypeUnion
+	ShapeTypeMember
+	ShapeTypeService
+	ShapeTypeResource
+	ShapeTypeOperation
+)
+
+// ShapeID fields of a Smithy shape ID.
+type ShapeID struct {
+	Namespace, Name, Member string
+}
+
+func stoid(s string) ShapeID {
+	ns, n, _ := strings.Cut(s, "#")
+	n, m, _ := strings.Cut(n, "$")
+	return ShapeID{ns, n, m}
+}
+
+// Schema encodes information about a shape from a Smithy model.
+//
+// Generated clients use schemas at runtime to dynamically (de)serialize
+// request/responses.
+type Schema struct {
+	id  ShapeID
+	typ ShapeType
+
+	members map[string]*Schema // member name -> schema
+	traits  map[string]Trait   // trait ID -> trait
+}
+
+// SchemaOptions configures a new Schema.
+type SchemaOptions struct {
+	members []*Schema
+	traits  []Trait
+}
+
+// WithMember adds a member targeting the given Schema.
+//
+// Traits provided for the member here override any traits on the target if
+// there is collision.
+func WithMember(name string, target *Schema, traits ...Trait) func(*SchemaOptions) {
+	return func(o *SchemaOptions) {
+		m := &Schema{
+			id:      ShapeID{Member: name},
+			typ:     target.typ,
+			members: target.members,
+			traits:  maps.Clone(target.traits),
+		}
+
+		for _, t := range traits {
+			m.traits[t.TraitID()] = t
+		}
+
+		o.members = append(o.members, m)
+	}
+}
+
+// WithTraits adds traits to the Schema.
+func WithTraits(traits ...Trait) func(*SchemaOptions) {
+	return func(o *SchemaOptions) {
+		o.traits = append(o.traits, traits...)
+	}
+}
+
+// NewSchema returns a schema with the provided members and traits.
+//
+// Generated clients include schemas for every shape that needs to be
+// (de)serialized as part of a service operation in a schemas/ package.
+func NewSchema(id string, typ ShapeType, opts ...func(*SchemaOptions)) *Schema {
+	var o SchemaOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	sid := stoid(id)
+	members := make(map[string]*Schema, len(o.members))
+	for _, m := range o.members {
+		m.id.Namespace = sid.Namespace
+		m.id.Name = sid.Name
+		members[m.id.Member] = m
+	}
+
+	traits := make(map[string]Trait, len(o.traits))
+	for _, t := range o.traits {
+		traits[t.TraitID()] = t
+	}
+
+	return &Schema{
+		id:      sid,
+		typ:     typ,
+		members: members,
+		traits:  traits,
+	}
+}
+
+// ID returns the shape ID for this schema as it appears in the original
+// Smithy model.
+func (s *Schema) ID() ShapeID {
+	return s.id
+}
+
+// Type returns the schema's type.
+func (s *Schema) Type() ShapeType {
+	return s.typ
+}
+
+// Member returns the named member from the schema.
+func (s *Schema) Member(name string) *Schema {
+	m, _ := s.members[name]
+	return m
+}
+
+// Trait returns the target trait on the schema if it exists.
+func SchemaTrait[T Trait](s *Schema) (T, bool) {
+	var trait T
+
+	opaque, ok := s.traits[trait.TraitID()]
+	if !ok {
+		return trait, false
+	}
+
+	tt, ok := opaque.(T)
+	return tt, ok
+}

--- a/schema.go
+++ b/schema.go
@@ -1,6 +1,7 @@
 package smithy
 
 import (
+	"fmt"
 	"maps"
 	"strings"
 )
@@ -42,6 +43,14 @@ type ShapeID struct {
 	Namespace, Name, Member string
 }
 
+// String returns the IDL microformat for the shape ID.
+func (s *ShapeID) String() string {
+	if s.Member == "" {
+		return fmt.Sprintf("%s#%s", s.Namespace, s.Name)
+	}
+	return fmt.Sprintf("%s#%s$%s", s.Namespace, s.Name, s.Member)
+}
+
 func stoid(s string) ShapeID {
 	ns, n, _ := strings.Cut(s, "#")
 	n, m, _ := strings.Cut(n, "$")
@@ -53,36 +62,93 @@ func stoid(s string) ShapeID {
 // Generated clients use schemas at runtime to dynamically (de)serialize
 // request/responses.
 type Schema struct {
-	ID      ShapeID
-	Type    ShapeType
-	Members map[string]*Schema // member name -> schema
-	Traits  map[string]Trait   // trait ID -> trait
+	id      ShapeID
+	typ     ShapeType
+	members map[string]*Schema // member name -> schema
+	traits  map[string]Trait   // trait ID -> trait
+
+	listMember       *Schema
+	mapKey, mapValue *Schema
 }
 
-// NewMember creates a member schema from a target schema, overriding traits.
-//
-// Traits provided for the member override any traits on the target if there
-// is collision.
-func NewMember(name string, target *Schema, traits ...Trait) *Schema {
-	m := &Schema{
-		ID:      ShapeID{Member: name},
-		Type:    target.Type,
-		Members: target.Members,
-		Traits:  maps.Clone(target.Traits),
-	}
-
+// NewSchema creates a new Schema with the given shape ID and traits.
+func NewSchema(id ShapeID, typ ShapeType, numMembers int, traits ...Trait) *Schema {
+	traitMap := make(map[string]Trait, len(traits))
 	for _, t := range traits {
-		m.Traits[t.TraitID()] = t
+		traitMap[t.TraitID()] = t
+	}
+	return &Schema{
+		id:      id,
+		typ:     typ,
+		members: make(map[string]*Schema, numMembers),
+		traits:  traitMap,
+	}
+}
+
+// AddMember adds a member to the schema derived from the target, with
+// optional trait overrides. The member schema is returned for caller
+// reference.
+func (s *Schema) AddMember(name string, target *Schema, traits ...Trait) *Schema {
+	m := &Schema{
+		id:      ShapeID{Member: name},
+		typ:     target.typ,
+		members: target.members,
+		traits:  maps.Clone(target.traits),
 	}
 
+	if len(m.traits) == 0 && len(traits) != 0 {
+		m.traits = map[string]Trait{}
+	}
+	for _, t := range traits {
+		m.traits[t.TraitID()] = t
+	}
+
+	s.members[name] = m
+	switch name {
+	case "member":
+		s.listMember = m
+	case "key":
+		s.mapKey = m
+	case "value":
+		s.mapValue = m
+	}
 	return m
+}
+
+// ListMember returns the "member" schema for list types.
+func (s *Schema) ListMember() *Schema {
+	return s.listMember
+}
+
+// MapKey returns the "key" schema for map types.
+func (s *Schema) MapKey() *Schema {
+	return s.mapKey
+}
+
+// MapValue returns the "value" schema for map types.
+func (s *Schema) MapValue() *Schema {
+	return s.mapValue
+}
+
+// MemberName returns the member component of the schema's shape ID.
+func (s *Schema) MemberName() string {
+	return s.id.Member
+}
+
+// Member returns the member schema for the given name, or nil.
+func (s *Schema) Member(name string) *Schema {
+	return s.members[name]
 }
 
 // Trait returns the target trait on the schema if it exists.
 func SchemaTrait[T Trait](s *Schema) (T, bool) {
 	var trait T
 
-	opaque, ok := s.Traits[trait.TraitID()]
+	if s == nil {
+		return trait, false
+	}
+
+	opaque, ok := s.traits[trait.TraitID()]
 	if !ok {
 		return trait, false
 	}

--- a/serde.go
+++ b/serde.go
@@ -1,0 +1,220 @@
+package smithy
+
+import (
+	"math/big"
+	"time"
+
+	"github.com/aws/smithy-go/document"
+)
+
+// Codec provides implementations of Serializer and ShapeDeserializer to be
+// used by a Protocol.
+type Codec interface {
+	Serializer() ShapeSerializer
+	Deserializer([]byte) ShapeDeserializer
+}
+
+// ShapeSerializer implements the marshaling of an in-code representation of a
+// shape to an unspecified data format, which is determined by the
+// implementation.
+type ShapeSerializer interface {
+	Bytes() []byte
+
+	WriteInt8(*Schema, int8)
+	WriteInt16(*Schema, int16)
+	WriteInt32(*Schema, int32)
+	WriteInt64(*Schema, int64)
+	WriteInt8Ptr(*Schema, *int8)
+	WriteInt16Ptr(*Schema, *int16)
+	WriteInt32Ptr(*Schema, *int32)
+	WriteInt64Ptr(*Schema, *int64)
+
+	WriteFloat32(*Schema, float32)
+	WriteFloat64(*Schema, float64)
+	WriteFloat32Ptr(*Schema, *float32)
+	WriteFloat64Ptr(*Schema, *float64)
+
+	WriteBool(*Schema, bool)
+	WriteBoolPtr(*Schema, *bool)
+
+	WriteString(*Schema, string)
+	WriteStringPtr(*Schema, *string)
+
+	WriteBigInteger(*Schema, big.Int)
+	WriteBigDecimal(*Schema, big.Float)
+	WriteBlob(*Schema, []byte)
+	WriteTime(*Schema, time.Time)
+	WriteTimePtr(*Schema, *time.Time)
+
+	WriteStruct(*Schema, Serializable)
+
+	WriteUnion(schema, variant *Schema, v Serializable)
+
+	WriteNil(*Schema)
+
+	WriteList(*Schema)
+	CloseList()
+
+	WriteMap(*Schema)
+	WriteKey(*Schema, string)
+	CloseMap()
+
+	WriteDocument(*Schema, document.Value)
+}
+
+// ShapeDeserializer implements the unmarshaling from some unspecified data
+// format to an in-code representation of a shape, which is determined by the
+// implementation.
+type ShapeDeserializer interface {
+	ReadInt8(*Schema, *int8) error
+	ReadInt16(*Schema, *int16) error
+	ReadInt32(*Schema, *int32) error
+	ReadInt64(*Schema, *int64) error
+
+	ReadInt8Ptr(*Schema, **int8) error
+	ReadInt16Ptr(*Schema, **int16) error
+	ReadInt32Ptr(*Schema, **int32) error
+	ReadInt64Ptr(*Schema, **int64) error
+
+	ReadFloat32(*Schema, *float32) error
+	ReadFloat64(*Schema, *float64) error
+
+	ReadFloat32Ptr(*Schema, **float32) error
+	ReadFloat64Ptr(*Schema, **float64) error
+
+	ReadBool(*Schema, *bool) error
+	ReadBoolPtr(*Schema, **bool) error
+
+	ReadString(*Schema, *string) error
+	ReadStringPtr(*Schema, **string) error
+
+	ReadTime(*Schema, *time.Time) error
+	ReadTimePtr(*Schema, **time.Time) error
+
+	ReadBlob(*Schema, *[]byte) error
+
+	ReadList(*Schema) error
+	// returns true if there's another item in the list, false at the end and
+	// an error if a decode error is encountered. use other deserializer
+	// methods to read the expected type from the deserializer
+	ReadListItem(*Schema) (hasMoreElements bool, err error)
+
+	ReadMap(*Schema) error
+	// the bool will be true if there's another key in the list and the string
+	// will have the value of that key, with any decode error in the error. use
+	// other deserializer methods to read the expected type.
+	ReadMapKey(*Schema) (key string, hasMoreElements bool, err error)
+
+	ReadStruct(*Schema) error
+	// returns the member schema for the given struct, nil when there are no
+	// more members, with any decode error in the error. use other deserializer
+	// methods to read the expected type.
+	ReadStructMember() (*Schema, error)
+
+	// returns the schema for the variant that the union is
+	ReadUnion(*Schema) (*Schema, error)
+
+	// returns true if the next value is null (and consumes it)
+	ReadNil(*Schema) (bool, error)
+
+	ReadDocument(*Schema, *document.Value) error
+}
+
+// Serializable is an entity that can describe itself to a ShapeSerializer to
+// be encoded to some format.
+//
+// Unlike the standard library marshaler interfaces, which idiomatically encode
+// to []byte, the output format and data type here is not specified at all.
+// This is because Smithy shapes need to encode to a variety of formats or data
+// carriers. For example, HTTP-binding JSON protocols need to serialize some
+// members to bytes (the HTTP request body) and others directly to fields on
+// the HTTP request itself (e.g. headers).
+type Serializable interface {
+	Serialize(ShapeSerializer)
+}
+
+// Deserializable is an entity that can unmarshal itself from a
+// ShapeDeserializer.
+type Deserializable interface {
+	Deserialize(ShapeDeserializer) error
+}
+
+// DeserializableError is implemented by modeled error types for a service.
+type DeserializableError interface {
+	Deserializable
+	error
+}
+
+// ReadStruct is a utility API for generated clients.
+func ReadStruct(d ShapeDeserializer, schema *Schema, memberFn func(*Schema) error) error {
+	if err := d.ReadStruct(schema); err != nil {
+		return err
+	}
+
+	for {
+		ms, err := d.ReadStructMember()
+		if ms == nil {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if err := memberFn(ms); err != nil {
+			return err
+		}
+	}
+}
+
+// ReadList is a utility API for generated clients.
+func ReadList(d ShapeDeserializer, schema *Schema, memberFn func() error) error {
+	if err := d.ReadList(schema); err != nil {
+		return err
+	}
+
+	var memberSchema *Schema
+	if schema != nil {
+		memberSchema = schema.ListMember()
+	}
+
+	for {
+		ok, err := d.ReadListItem(memberSchema)
+		if !ok {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		if err := memberFn(); err != nil {
+			return err
+		}
+	}
+}
+
+// ReadMap is a utility API for generated clients.
+func ReadMap(d ShapeDeserializer, schema *Schema, memberFn func(string) error) error {
+	if err := d.ReadMap(schema); err != nil {
+		return err
+	}
+
+	var keySchema *Schema
+	if schema != nil {
+		keySchema = schema.MapKey()
+	}
+
+	for {
+		k, ok, err := d.ReadMapKey(keySchema)
+		if !ok {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		if err := memberFn(k); err != nil {
+			return err
+		}
+	}
+}

--- a/serde.go
+++ b/serde.go
@@ -113,6 +113,7 @@ type ShapeDeserializer interface {
 
 	// returns the schema for the variant that the union is
 	ReadUnion(*Schema) (*Schema, error)
+	CloseUnion(*Schema) error
 
 	// returns true if the next value is null (and consumes it)
 	ReadNil(*Schema) (bool, error)

--- a/trait.go
+++ b/trait.go
@@ -1,0 +1,8 @@
+package smithy
+
+// Trait represents a trait applied to a shape in a Smithy model. Traits
+// related to (de)serialization are included in code-generated Schemas for the
+// client.
+type Trait interface {
+	TraitID() string
+}

--- a/traits/http.go
+++ b/traits/http.go
@@ -1,0 +1,49 @@
+package traits
+
+// HTTPHeader represents smithy.api#httpHeader.
+type HTTPHeader struct {
+	Name string
+}
+
+// TraitID identifies the trait.
+func (*HTTPHeader) TraitID() string { return "smithy.api#httpHeader" }
+
+// HTTPLabel represents smithy.api#httpLabel.
+type HTTPLabel struct{}
+
+// TraitID identifies the trait.
+func (*HTTPLabel) TraitID() string { return "smithy.api#httpLabel" }
+
+// HTTPPayload represents smithy.api#httpPayload.
+type HTTPPayload struct{}
+
+// TraitID identifies the trait.
+func (*HTTPPayload) TraitID() string { return "smithy.api#httpPayload" }
+
+// HTTPPrefixHeaders represents smithy.api#httpPrefixHeaders.
+type HTTPPrefixHeaders struct {
+	Prefix string
+}
+
+// TraitID identifies the trait.
+func (*HTTPPrefixHeaders) TraitID() string { return "smithy.api#httpPrefixHeaders" }
+
+// HTTPQuery represents smithy.api#httpQuery.
+type HTTPQuery struct {
+	Name string
+}
+
+// TraitID identifies the trait.
+func (*HTTPQuery) TraitID() string { return "smithy.api#httpQuery" }
+
+// HTTPQueryParams represents smithy.api#httpQueryParams.
+type HTTPQueryParams struct{}
+
+// TraitID identifies the trait.
+func (*HTTPQueryParams) TraitID() string { return "smithy.api#httpQueryParams" }
+
+// HTTPResponseCode represents smithy.api#httpResponseCode.
+type HTTPResponseCode struct{}
+
+// TraitID identifies the trait.
+func (*HTTPResponseCode) TraitID() string { return "smithy.api#httpResponseCode" }

--- a/traits/serde.go
+++ b/traits/serde.go
@@ -1,0 +1,54 @@
+package traits
+
+// JSONName represents smithy.api#jsonName.
+type JSONName struct {
+	Name string
+}
+
+// TraitID identifies the trait.
+func (*JSONName) TraitID() string { return "smithy.api#jsonName" }
+
+// MediaType represents smithy.api#mediaType.
+type MediaType struct {
+	Type string
+}
+
+// TraitID identifies the trait.
+func (*MediaType) TraitID() string { return "smithy.api#mediaType" }
+
+// TimestampFormat represents smithy.api#timestampFormat.
+type TimestampFormat struct {
+	Format string
+}
+
+// TraitID identifies the trait.
+func (*TimestampFormat) TraitID() string { return "smithy.api#timestampFormat" }
+
+// XMLAttribute represents smithy.api#xmlAttribute.
+type XMLAttribute struct{}
+
+// TraitID identifies the trait.
+func (*XMLAttribute) TraitID() string { return "smithy.api#xmlAttribute" }
+
+// XMLFlattened represents smithy.api#xmlFlattened.
+type XMLFlattened struct{}
+
+// TraitID identifies the trait.
+func (*XMLFlattened) TraitID() string { return "smithy.api#xmlFlattened" }
+
+// XMLName represents smithy.api#xmlName.
+type XMLName struct {
+	Name string
+}
+
+// TraitID identifies the trait.
+func (*XMLName) TraitID() string { return "smithy.api#xmlName" }
+
+// XMLNamespace represents smithy.api#xmlNamespace.
+type XMLNamespace struct {
+	URI    string
+	Prefix string
+}
+
+// TraitID identifies the trait.
+func (*XMLNamespace) TraitID() string { return "smithy.api#xmlNamespace" }

--- a/traits/traits.go
+++ b/traits/traits.go
@@ -1,0 +1,48 @@
+// Package traits defines representations of Smithy IDL traits that appear in
+// code-generated schemas.
+package traits
+
+// Sensitive represents smithy.api#sensitive.
+type Sensitive struct{}
+
+// TraitID identifies the trait.
+func (*Sensitive) TraitID() string { return "smithy.api#sensitive" }
+
+// EventHeader represents smithy.api#eventHeader.
+type EventHeader struct{}
+
+// TraitID identifies the trait.
+func (*EventHeader) TraitID() string { return "smithy.api#eventHeader" }
+
+// EventPayload represents smithy.api#eventPayload.
+type EventPayload struct{}
+
+// TraitID identifies the trait.
+func (*EventPayload) TraitID() string { return "smithy.api#eventPayload" }
+
+// Streaming represents smithy.api#streaming.
+type Streaming struct{}
+
+// TraitID identifies the trait.
+func (*Streaming) TraitID() string { return "smithy.api#streaming" }
+
+// HostLabel represents smithy.api#hostLabel.
+type HostLabel struct{}
+
+// TraitID identifies the trait.
+func (*HostLabel) TraitID() string { return "smithy.api#hostLabel" }
+
+// ContextParam represents smithy.rules#contextParam.
+type ContextParam struct{}
+
+// TraitID identifies the trait.
+func (*ContextParam) TraitID() string { return "smithy.rules#contextParam" }
+
+// AWSQueryError represents aws.protocols#awsQueryError.
+type AWSQueryError struct {
+	ErrorCode  string
+	StatusCode int
+}
+
+// TraitID identifies the trait.
+func (*AWSQueryError) TraitID() string { return "aws.protocols#awsQueryError" }

--- a/transport/http/protocol.go
+++ b/transport/http/protocol.go
@@ -1,0 +1,19 @@
+package http
+
+import (
+	"context"
+
+	"github.com/aws/smithy-go"
+)
+
+// ClientProtocol defines the interface through which client-side operation
+// request/responses are (de)serialized across the wire.
+//
+// While a caller CAN define their own protocol, it is almost never necessary
+// to do so. In practice, a generated client will utilize one of the predefined
+// protocols implemented as part of the Smithy client runtime.
+type ClientProtocol interface {
+	ID() string
+	SerializeRequest(context.Context, smithy.Serializable, *Request) error
+	DeserializeResponse(ctx context.Context, types *smithy.TypeRegistry, resp *Response, out smithy.Deserializable) error
+}

--- a/type_registry.go
+++ b/type_registry.go
@@ -1,0 +1,61 @@
+package smithy
+
+import (
+	"strings"
+)
+
+// TypeRegistry creates an instance of a type based on its Smithy IDL shape ID.
+//
+// Generated clients have an exported package-level registry (named
+// TypeRegistry) that holds all structure types for the service.
+type TypeRegistry struct {
+	Entries map[string]*TypeRegistryEntry
+}
+
+// RegistryEntry creates a type registry entry.
+func RegistryEntry[T any](schema *Schema) *TypeRegistryEntry {
+	return &TypeRegistryEntry{
+		Schema: schema,
+		New: func() any {
+			return new(T)
+		},
+	}
+}
+
+// DeserializableError provides an instance of a deserializable error structure
+// for a given shape ID.
+//
+// The ID is given as a string here since this will be called in a context where
+// a shape ID is a discriminator read in from some wire payload.
+func (t *TypeRegistry) DeserializableError(id string) (DeserializableError, bool) {
+	return typeRegistryLookup[DeserializableError](t, id)
+}
+
+// TypeRegistryEntry holds the schema and constructor for a registered shape.
+type TypeRegistryEntry struct {
+	Schema *Schema
+	New    func() any
+}
+
+func (t *TypeRegistry) lookupShortName(id string) (*TypeRegistryEntry, bool) {
+	for key, e := range t.Entries {
+		if idx := strings.Index(key, "#"); idx != -1 && key[idx+1:] == id {
+			return e, true
+		}
+	}
+	return nil, false
+}
+
+func typeRegistryLookup[T any](t *TypeRegistry, id string) (T, bool) {
+	entry, ok := t.Entries[id]
+	if !ok {
+		entry, ok = t.lookupShortName(id)
+	}
+	if !ok {
+		var v T
+		return v, false
+	}
+
+	v, ok := entry.New().(T)
+	return v, ok
+}


### PR DESCRIPTION
I had benchmarked this after merging it and the old (new old) deserializer performance was pretty bad, basically because of json.Token being an interface. It was some odd ~15% allocation increase across the board.

Thus we're just going to toss that and roll our own.

Dave Cheney has a pretty in-depth article about fast json parsing https://dave.cheney.net/paste/gophercon-sg-2023.html which I've largely followed for this. I didn't make every single optimization that he did though.

Running this against the deserialize stuff in jsonrpc10 we're now at a slight performance boost over the old static version across the board, I've made results available at https://gist.github.com/lucix-aws/ba3ca20113b23752144ad25e0f237a58.