### PR TITLE
implement rpcv2cbor

### DIFF
--- a/aws-protocols/awsjson10/awsjson10.go
+++ b/aws-protocols/awsjson10/awsjson10.go
@@ -30,6 +30,7 @@ func New() *Protocol {
 // New11 returns an instance of the awsJson 1.1 protocol.
 //
 // TODO(serde2): figure out how we want to organize awsjson10 vs 11
+// TODO(serde2): this doesn't do query compatible yet
 func New11() *Protocol {
 	return &Protocol{
 		version: "1.1",

--- a/aws-protocols/internal/json/shape_deserializer.go
+++ b/aws-protocols/internal/json/shape_deserializer.go
@@ -453,22 +453,48 @@ func (d *ShapeDeserializer) ReadStructMember() (*smithy.Schema, error) {
 	return member, nil
 }
 
+type unionCtx struct {
+	schema *smithy.Schema
+}
+
 // ReadUnion implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadUnion(s *smithy.Schema) (*smithy.Schema, error) {
-	// Decode the entire union object to find the non-null member.
-	var raw map[string]json.RawMessage
-	if err := d.dec.Decode(&raw); err != nil {
-		return nil, fmt.Errorf("decode union: %w", err)
+	if _, ok := d.head.Top().(*unionCtx); !ok {
+		if isNil, err := d.ReadNil(s); isNil || err != nil {
+			return nil, err
+		}
+
+		tok, err := d.token()
+		if err != nil {
+			return nil, err
+		}
+		delim, ok := tok.(json.Delim)
+		if !ok || delim != '{' {
+			return nil, fmt.Errorf("expected '{', got %v", tok)
+		}
+		d.head.Push(&unionCtx{schema: s})
 	}
 
-	for key, val := range raw {
-		if string(val) == "null" {
+	for d.more() {
+		tok, err := d.token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := tok.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected string key, got %T", tok)
+		}
+
+		// skip null values
+		if isNil, err := d.ReadNil(nil); isNil || err != nil {
+			if err != nil {
+				return nil, err
+			}
 			continue
 		}
 
 		member := s.Member(key)
 		if member == nil && d.opts.UseJSONName {
-			// Try matching by jsonName trait
 			for _, m := range s.Members() {
 				if jn, ok := smithy.SchemaTrait[*traits.JSONName](m); ok && jn.Name == key {
 					member = m
@@ -477,17 +503,17 @@ func (d *ShapeDeserializer) ReadUnion(s *smithy.Schema) (*smithy.Schema, error) 
 			}
 		}
 		if member == nil {
+			if err := d.skip(); err != nil {
+				return nil, err
+			}
 			continue
 		}
 
-		// Replace the decoder with one that reads just this value
-		dec := json.NewDecoder(bytes.NewReader(val))
-		dec.UseNumber()
-		d.dec = dec
 		return member, nil
 	}
 
-	return nil, nil
+	d.head.Pop()
+	return nil, d.expectDelim('}')
 }
 
 // used to skip over a struct member that we didn't have a schema for, though

--- a/aws-protocols/internal/json/shape_deserializer.go
+++ b/aws-protocols/internal/json/shape_deserializer.go
@@ -486,7 +486,12 @@ func (d *ShapeDeserializer) ReadUnion(s *smithy.Schema) (*smithy.Schema, error) 
 		}
 
 		// skip null values
-		if isNil, err := d.ReadNil(nil); isNil || err != nil {
+		isNil, err := d.ReadNil(nil)
+		if err != nil {
+		    return nil, err
+		} else {
+		    continue
+		}
 			if err != nil {
 				return nil, err
 			}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -301,13 +302,13 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
                     // members initialized before they are used as targets in
                     // AddMember calls. This ensures MapKey(), MapValue(), and
                     // ListMember() are non-nil when the member schema is created.
-                    var shapeIds = new java.util.HashSet<software.amazon.smithy.model.shapes.ShapeId>();
-                   shapes.stream().map(s -> s.getId()).collect(collectors.toSet())
+                    var shapeIds = new HashSet<ShapeId>();
+                    for (Shape s : shapes) {
                         shapeIds.add(s.getId());
                     }
 
-                    var sorted = new java.util.ArrayList<Shape>();
-                    var visited = new java.util.HashSet<software.amazon.smithy.model.shapes.ShapeId>();
+                    var sorted = new ArrayList<Shape>();
+                    var visited = new HashSet<ShapeId>();
                     for (Shape s : shapes) {
                         topoVisit(s, model, shapeIds, visited, sorted);
                     }
@@ -516,9 +517,9 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
     private static void topoVisit(
             Shape shape,
             Model model,
-            java.util.Set<ShapeId> inSet,
-            java.util.Set<ShapeId> visited,
-            java.util.List<Shape> result
+            Set<ShapeId> inSet,
+            Set<ShapeId> visited,
+            List<Shape> result
     ) {
         if (visited.contains(shape.getId())) {
             return;

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -302,7 +302,7 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
                     // AddMember calls. This ensures MapKey(), MapValue(), and
                     // ListMember() are non-nil when the member schema is created.
                     var shapeIds = new java.util.HashSet<software.amazon.smithy.model.shapes.ShapeId>();
-                    for (Shape s : shapes) {
+                   shapes.stream().map(s -> s.getId()).collect(collectors.toSet())
                         shapeIds.add(s.getId());
                     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -297,7 +297,22 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
                 writer.write("");
                 writer.writeDocs("Initialize schema members after all schemas are declared to avoid initialization cycles");
                 writer.openBlock("func init() {", "}", () -> {
-                    for (Shape shape : shapes) {
+                    // Topologically sort shapes so that target schemas have their
+                    // members initialized before they are used as targets in
+                    // AddMember calls. This ensures MapKey(), MapValue(), and
+                    // ListMember() are non-nil when the member schema is created.
+                    var shapeIds = new java.util.HashSet<software.amazon.smithy.model.shapes.ShapeId>();
+                    for (Shape s : shapes) {
+                        shapeIds.add(s.getId());
+                    }
+
+                    var sorted = new java.util.ArrayList<Shape>();
+                    var visited = new java.util.HashSet<software.amazon.smithy.model.shapes.ShapeId>();
+                    for (Shape s : shapes) {
+                        topoVisit(s, model, shapeIds, visited, sorted);
+                    }
+
+                    for (Shape shape : sorted) {
                         new SchemaGenerator(ctx, shape).acceptMembersInit(writer);
                     }
                 });
@@ -496,5 +511,25 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
     public Void intEnumShape(IntEnumShape shape) {
         writers.useShapeWriter(shape, writer -> new IntEnumGenerator(symbolProvider, writer, shape).run());
         return null;
+    }
+
+    private static void topoVisit(
+            Shape shape,
+            Model model,
+            java.util.Set<ShapeId> inSet,
+            java.util.Set<ShapeId> visited,
+            java.util.List<Shape> result
+    ) {
+        if (visited.contains(shape.getId())) {
+            return;
+        }
+        visited.add(shape.getId());
+        for (var member : shape.members()) {
+            var targetId = member.getTarget();
+            if (inSet.contains(targetId)) {
+                topoVisit(model.expectShape(targetId), model, inSet, visited, result);
+            }
+        }
+        result.add(shape);
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/DefaultTraitGenerators.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/DefaultTraitGenerators.java
@@ -5,6 +5,7 @@ import static software.amazon.smithy.go.codegen.SmithyGoDependency.SMITHY_TRAITS
 import java.util.HashMap;
 import java.util.Map;
 import software.amazon.smithy.aws.traits.protocols.AwsQueryErrorTrait;
+import software.amazon.smithy.go.codegen.trait.BackfilledInputOutputTrait;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.EventHeaderTrait;
 import software.amazon.smithy.model.traits.EventPayloadTrait;
@@ -82,6 +83,9 @@ public class DefaultTraitGenerators {
         GENERATORS.put(AwsQueryErrorTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("AWSQueryError"),
                 "ErrorCode", AwsQueryErrorTrait::getCode,
                 "StatusCode", AwsQueryErrorTrait::getHttpResponseCode));
+
+        // Codegen-internal traits
+        GENERATORS.put(BackfilledInputOutputTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("UnitShape")));
     }
 
     public static TraitGenerator forTrait(ShapeId id) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import software.amazon.smithy.aws.traits.protocols.AwsJson1_0Trait;
 import software.amazon.smithy.aws.traits.protocols.AwsJson1_1Trait;
+import software.amazon.smithy.aws.traits.protocols.AwsQueryCompatibleTrait;
 import software.amazon.smithy.aws.traits.protocols.RestJson1Trait;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -46,12 +47,12 @@ import software.amazon.smithy.go.codegen.integration.ConfigFieldResolver;
 import software.amazon.smithy.go.codegen.integration.GoIntegration;
 import software.amazon.smithy.go.codegen.integration.OperationMetricsStruct;
 import software.amazon.smithy.go.codegen.integration.RuntimeClientPlugin;
-import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.protocol.traits.Rpcv2CborTrait;
 import software.amazon.smithy.utils.MapUtils;
 
 /**
@@ -261,10 +262,10 @@ final class ServiceGenerator implements Runnable {
     private Writable generateExperimentalSerdeResolvers() {
         ensureSupportedProtocol();
         // TODO(serde2) dynamically resolve a symbol based on traits
-        return goTemplate("options.Protocol = $T()", resolveDefaultProtocol());
+        return goTemplate("options.Protocol = $W", resolveDefaultProtocol());
     }
 
-    private Symbol resolveDefaultProtocol() {
+    private Writable resolveDefaultProtocol() {
         Set<ShapeId> protocols = ServiceIndex.of(model).getProtocols(service).keySet();
         var preferred = PROTOCOLS_BY_PRIORITY.stream()
                 .filter(protocols::contains)
@@ -272,11 +273,18 @@ final class ServiceGenerator implements Runnable {
                 .get();
 
         if (preferred.equals(AwsJson1_0Trait.ID)) {
-            return SmithyGoDependency.SMITHY_AWS_PROTOCOLS_JSON10.func("New");
+            return goTemplate("$T()", SmithyGoDependency.SMITHY_AWS_PROTOCOLS_JSON10.func("New"));
         } else if (preferred.equals(AwsJson1_1Trait.ID)) {
-            return SmithyGoDependency.SMITHY_AWS_PROTOCOLS_JSON10.func("New11");
+            return goTemplate("$T()", SmithyGoDependency.SMITHY_AWS_PROTOCOLS_JSON10.func("New11"));
         } else if (preferred.equals(RestJson1Trait.ID)) {
-            return SmithyGoDependency.SMITHY_AWS_PROTOCOLS_RESTJSON1.func("New");
+            return goTemplate("$T()", SmithyGoDependency.SMITHY_AWS_PROTOCOLS_RESTJSON1.func("New"));
+        } else if (preferred.equals(Rpcv2CborTrait.ID)) {
+            return goTemplate("$T($W)",
+                    SmithyGoDependency.SMITHY_HTTP_PROTOCOLS_RPCV2.func("NewCBOR"),
+                    service.hasTrait(AwsQueryCompatibleTrait.class)
+                            ? goTemplate("$T", SmithyGoDependency.SMITHY_HTTP_PROTOCOLS_RPCV2.valueSymbol("UseQueryCompatible"))
+                            : emptyGoTemplate()
+            );
         } else {
             throw new CodegenException("unsupported schema-serde protocol " + preferred);
         }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -86,6 +86,9 @@ public final class SmithyGoDependency {
     public static final GoDependency SMITHY_AWS_PROTOCOLS_JSON10 = relativePackage( "github.com/aws/smithy-go/aws-protocols", "awsjson10", "v1.0.0", null);
     public static final GoDependency SMITHY_AWS_PROTOCOLS_RESTJSON1 = relativePackage( "github.com/aws/smithy-go/aws-protocols", "restjson1", "v1.0.0", null);
 
+    public static final GoDependency SMITHY_HTTP_PROTOCOLS = relativePackage( "github.com/aws/smithy-go/smithy-http-protocols", null, "v1.0.0", null);
+    public static final GoDependency SMITHY_HTTP_PROTOCOLS_RPCV2 = relativePackage( "github.com/aws/smithy-go/smithy-http-protocols", "rpcv2", "v1.0.0", null);
+
     public static final GoDependency MATH = stdlib("math");
 
     private static final String SMITHY_SOURCE_PATH = "github.com/aws/smithy-go";

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/UnionDeserializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/UnionDeserializer.java
@@ -33,15 +33,12 @@ public class UnionDeserializer implements Writable {
 
         writer.writeGoTemplate("""
                 func deserialize$shapeName:L(d smithy.ShapeDeserializer, s *smithy.Schema, v *$symbol:T) error {
-                    ms, err := d.ReadUnion(s)
-                    if err != nil {
-                        return err
-                    }
-
-                    switch ms {
-                    $cases:W
-                    }
-                    return nil
+                    return smithy.ReadUnion(d, s, func(ms *smithy.Schema) error {
+                        switch ms {
+                        $cases:W
+                        }
+                        return nil
+                    })
                 }
                 """, Map.of(
                 "shapeName", shape.getId().getName(),

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,56 @@
+package errors
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/aws/smithy-go"
+)
+
+// SetErrorCodeOverride sets the ErrorCodeOverride field on err if present.
+//
+// This is used by protocols in awsquery-compatible mode that need to override
+// the error code on a deserialized error.
+func SetErrorCodeOverride(err error, code string) {
+	// yes it's reflection but i don't really view errors as a hot path so i
+	// think it's fine
+	v := reflect.ValueOf(err)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return
+	}
+
+	f := v.FieldByName("ErrorCodeOverride")
+	if !f.IsValid() || !f.CanSet() || f.Type() != reflect.TypeOf((*string)(nil)) {
+		return
+	}
+
+	f.Set(reflect.ValueOf(&code))
+}
+
+// SanitizeErrorCode strips namespace prefixes and colon suffixes from protocol
+// error codes.
+func SanitizeErrorCode(code string) string {
+	_, noprefix, ok := strings.Cut(code, "#")
+	if !ok {
+		noprefix = code // If sep does not appear in s, cut returns s, "", false.
+	}
+
+	code, _, _ = strings.Cut(noprefix, ":")
+	return code
+}
+
+// ParseQueryError extracts the error code and fault from X-Amzn-Query-Error.
+func ParseQueryError(header string) (string, smithy.ErrorFault) {
+	code, fault, _ := strings.Cut(header, ";")
+	switch fault {
+	case "Sender":
+		return code, smithy.FaultClient
+	case "Receiver":
+		return code, smithy.FaultServer
+	default:
+		return code, smithy.FaultUnknown
+	}
+}

--- a/serde.go
+++ b/serde.go
@@ -1,6 +1,7 @@
 package smithy
 
 import (
+	"fmt"
 	"io"
 	"math/big"
 	"time"
@@ -156,6 +157,31 @@ type Deserializable interface {
 type DeserializableError interface {
 	Deserializable
 	error
+}
+
+// ReadUnion is a utility API for generated clients.
+func ReadUnion(d ShapeDeserializer, schema *Schema, memberFn func(*Schema) error) error {
+	ms, err := d.ReadUnion(schema)
+	if err != nil {
+		return err
+	}
+
+	if ms != nil {
+		if err := memberFn(ms); err != nil {
+			return err
+		}
+	}
+
+	for {
+		ms, err = d.ReadUnion(schema)
+		if err != nil {
+			return err
+		}
+		if ms == nil {
+			return nil
+		}
+		return fmt.Errorf("union has more than one non-nil member: %s", ms.MemberName())
+	}
 }
 
 // ReadStruct is a utility API for generated clients.

--- a/smithy-http-protocols/go.mod
+++ b/smithy-http-protocols/go.mod
@@ -1,0 +1,7 @@
+module github.com/aws/smithy-go/smithy-http-protocols
+
+go 1.24
+
+require github.com/aws/smithy-go v1.24.0
+
+replace github.com/aws/smithy-go => ../

--- a/smithy-http-protocols/internal/cbor/codec.go
+++ b/smithy-http-protocols/internal/cbor/codec.go
@@ -1,0 +1,20 @@
+package cbor
+
+import (
+	"github.com/aws/smithy-go"
+)
+
+// Codec is a CBOR codec.
+type Codec struct{}
+
+var _ smithy.Codec = (*Codec)(nil)
+
+// Serializer returns a CBOR shape serializer.
+func (c *Codec) Serializer() smithy.ShapeSerializer {
+	return NewShapeSerializer()
+}
+
+// Deserializer returns a CBOR shape deserializer.
+func (c *Codec) Deserializer(p []byte) smithy.ShapeDeserializer {
+	return NewShapeDeserializer(p)
+}

--- a/smithy-http-protocols/internal/cbor/float16.go
+++ b/smithy-http-protocols/internal/cbor/float16.go
@@ -1,0 +1,45 @@
+package cbor
+
+func float16to32(f uint16) uint32 {
+	sign, exp, mant := splitf16(f)
+	if exp == 0x1f {
+		return sign | 0xff<<23 | mant // infinity/NaN
+	}
+
+	if exp == 0 { // subnormal
+		if mant == 0 {
+			return sign
+		}
+		return normalize(sign, mant)
+	}
+
+	return sign | (exp+127-15)<<23 | mant // rebias exp by the difference between the two
+}
+
+func splitf16(f uint16) (sign, exp, mantissa uint32) {
+	const smask = 0x1 << 15  // put sign in float32 position
+	const emask = 0x1f << 10 // pull exponent as a number (for bias shift)
+	const mmask = 0x3ff      // put mantissa in float32 position
+
+	return uint32(f&smask) << 16, uint32(f&emask) >> 10, uint32(f&mmask) << 13
+}
+
+// moves a float16 normal into normal float32 space
+// to do this we must re-express the float16 mantissa in terms of a normal
+// float32 where the hidden bit is 1, e.g.
+//
+// f16: 0    00000              0001010000 = 0.000101 * 2^(-14), which is equal to
+// f32: 0 01101101 01000000000000000000000 =     1.01 * 2^(-18)
+//
+// this is achieved by shifting the mantissa to the right until the leading bit
+// that == 1 reaches position 24, then the number of positions shifted over is
+// equal to the offset from the subnormal exponent
+func normalize(sign, mant uint32) uint32 {
+	exp := uint32(-14 + 127) // f16 subnormal exp, with f32 bias
+	for mant&0x800000 == 0 { // repeat until bit 24 ("hidden" mantissa) is 1
+		mant <<= 1
+		exp-- // tracking the offset
+	}
+	mant &= 0x7fffff // remask to 23bit
+	return sign | exp<<23 | mant
+}

--- a/smithy-http-protocols/internal/cbor/shape_deserializer.go
+++ b/smithy-http-protocols/internal/cbor/shape_deserializer.go
@@ -1,0 +1,785 @@
+package cbor
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/document"
+	smithycbor "github.com/aws/smithy-go/encoding/cbor"
+)
+
+var errUnexpectedEOF = errors.New("unexpected end of CBOR data")
+
+// ShapeDeserializer implements unmarshaling of CBOR into Smithy shapes.
+type ShapeDeserializer struct {
+	p    []byte
+	off  int
+	head deserStack
+	opts ShapeDeserializerOptions
+}
+
+type deserCtxKind byte
+
+const (
+	deserCtxList deserCtxKind = iota
+	deserCtxMap
+	deserCtxStruct
+	deserCtxUnion
+)
+
+type deserCtx struct {
+	kind      deserCtxKind
+	schema    *smithy.Schema
+	remaining int
+}
+
+type deserStack struct {
+	values []deserCtx
+}
+
+func (s *deserStack) top() *deserCtx {
+	if len(s.values) == 0 {
+		return nil
+	}
+	return &s.values[len(s.values)-1]
+}
+
+func (s *deserStack) push(v deserCtx) {
+	s.values = append(s.values, v)
+}
+
+func (s *deserStack) pop() {
+	s.values = s.values[:len(s.values)-1]
+}
+
+// ShapeDeserializerOptions configures ShapeDeserializer.
+type ShapeDeserializerOptions struct{}
+
+var _ smithy.ShapeDeserializer = (*ShapeDeserializer)(nil)
+
+// NewShapeDeserializer creates a new ShapeDeserializer.
+func NewShapeDeserializer(p []byte, opts ...func(*ShapeDeserializerOptions)) *ShapeDeserializer {
+	o := ShapeDeserializerOptions{}
+	for _, fn := range opts {
+		fn(&o)
+	}
+	return &ShapeDeserializer{p: p, opts: o}
+}
+
+func (d *ShapeDeserializer) eof() bool {
+	return d.off >= len(d.p)
+}
+
+func (d *ShapeDeserializer) peekMajor() majorType {
+	return majorType(d.p[d.off] & 0xe0 >> 5)
+}
+
+func (d *ShapeDeserializer) peekMinor() byte {
+	return d.p[d.off] & 0x1f
+}
+
+func (d *ShapeDeserializer) readArg() (uint64, error) {
+	if d.eof() {
+		return 0, errUnexpectedEOF
+	}
+
+	minor := d.peekMinor()
+	if minor < minorArg1 {
+		d.off++
+		return uint64(minor), nil
+	}
+
+	idx := int(minor - minorArg1)
+	if idx < 0 || idx >= len(argSizes) {
+		return 0, fmt.Errorf("unexpected minor value %d", minor)
+	}
+
+	n := argSizes[idx]
+	if d.off+1+n > len(d.p) {
+		return 0, errUnexpectedEOF
+	}
+
+	buf := d.p[d.off+1 : d.off+1+n]
+	d.off += 1 + n
+
+	switch n {
+	case 1:
+		return uint64(buf[0]), nil
+	case 2:
+		return uint64(binary.BigEndian.Uint16(buf)), nil
+	case 4:
+		return uint64(binary.BigEndian.Uint32(buf)), nil
+	default:
+		return binary.BigEndian.Uint64(buf), nil
+	}
+}
+
+func (d *ShapeDeserializer) readInt64() (int64, error) {
+	if d.eof() {
+		return 0, errUnexpectedEOF
+	}
+
+	major := d.peekMajor()
+	switch major {
+	case majorTypeUint:
+		v, err := d.readArg()
+		if err != nil {
+			return 0, err
+		}
+		if v > math.MaxInt64 {
+			return 0, fmt.Errorf("cbor uint %d exceeds max int64", v)
+		}
+		return int64(v), nil
+	case majorTypeNegInt:
+		v, err := d.readArg()
+		if err != nil {
+			return 0, err
+		}
+		// CBOR negint: actual value is -1 - v
+		if v > math.MaxInt64 {
+			return 0, fmt.Errorf("cbor negint exceeds min int64")
+		}
+		return -1 - int64(v), nil
+	default:
+		return 0, fmt.Errorf("expected integer, got major type %d", major)
+	}
+}
+
+func (d *ShapeDeserializer) readFloat64() (float64, error) {
+	if d.eof() {
+		return 0, errUnexpectedEOF
+	}
+
+	major := d.peekMajor()
+	switch major {
+	case majorType7:
+		minor := d.peekMinor()
+		switch minor {
+		case major7Float16:
+			if d.off+3 > len(d.p) {
+				return 0, errUnexpectedEOF
+			}
+			bits := binary.BigEndian.Uint16(d.p[d.off+1 : d.off+3])
+			d.off += 3
+			return float64(math.Float32frombits(float16to32(bits))), nil
+		case major7Float32:
+			if d.off+5 > len(d.p) {
+				return 0, errUnexpectedEOF
+			}
+			bits := binary.BigEndian.Uint32(d.p[d.off+1 : d.off+5])
+			d.off += 5
+			return float64(math.Float32frombits(bits)), nil
+		case major7Float64:
+			if d.off+9 > len(d.p) {
+				return 0, errUnexpectedEOF
+			}
+			bits := binary.BigEndian.Uint64(d.p[d.off+1 : d.off+9])
+			d.off += 9
+			return math.Float64frombits(bits), nil
+		default:
+			return 0, fmt.Errorf("expected float, got minor %d", minor)
+		}
+	case majorTypeUint:
+		v, err := d.readArg()
+		if err != nil {
+			return 0, err
+		}
+		return float64(v), nil
+	case majorTypeNegInt:
+		v, err := d.readArg()
+		if err != nil {
+			return 0, err
+		}
+		return -1 - float64(v), nil
+	default:
+		return 0, fmt.Errorf("expected float, got major type %d", major)
+	}
+}
+
+// ReadNil implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadNil(s *smithy.Schema) (bool, error) {
+	if d.eof() {
+		return false, errUnexpectedEOF
+	}
+
+	if d.peekMajor() == majorType7 {
+		minor := d.peekMinor()
+		if minor == major7Nil || minor == major7Undefined {
+			d.off++
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ReadInt8 implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt8(s *smithy.Schema, v *int8) error {
+	return readInt(d, v, math.MinInt8, math.MaxInt8)
+}
+
+// ReadInt16 implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt16(s *smithy.Schema, v *int16) error {
+	return readInt(d, v, math.MinInt16, math.MaxInt16)
+}
+
+// ReadInt32 implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt32(s *smithy.Schema, v *int32) error {
+	return readInt(d, v, math.MinInt32, math.MaxInt32)
+}
+
+// ReadInt64 implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt64(s *smithy.Schema, v *int64) error {
+	return readInt(d, v, math.MinInt64, math.MaxInt64)
+}
+
+// ReadInt8Ptr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt8Ptr(s *smithy.Schema, v **int8) error {
+	return readPtr(d, s, v, d.ReadInt8)
+}
+
+// ReadInt16Ptr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt16Ptr(s *smithy.Schema, v **int16) error {
+	return readPtr(d, s, v, d.ReadInt16)
+}
+
+// ReadInt32Ptr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt32Ptr(s *smithy.Schema, v **int32) error {
+	return readPtr(d, s, v, d.ReadInt32)
+}
+
+// ReadInt64Ptr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt64Ptr(s *smithy.Schema, v **int64) error {
+	return readPtr(d, s, v, d.ReadInt64)
+}
+
+// ReadFloat32 implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadFloat32(s *smithy.Schema, v *float32) error {
+	return readFloat(d, v)
+}
+
+// ReadFloat64 implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadFloat64(s *smithy.Schema, v *float64) error {
+	return readFloat(d, v)
+}
+
+// ReadFloat32Ptr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadFloat32Ptr(s *smithy.Schema, v **float32) error {
+	return readPtr(d, s, v, d.ReadFloat32)
+}
+
+// ReadFloat64Ptr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadFloat64Ptr(s *smithy.Schema, v **float64) error {
+	return readPtr(d, s, v, d.ReadFloat64)
+}
+
+// ReadBool implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadBool(s *smithy.Schema, v *bool) error {
+	if d.eof() {
+		return errUnexpectedEOF
+	}
+	if d.peekMajor() != majorType7 {
+		return fmt.Errorf("expected bool, got major type %d", d.peekMajor())
+	}
+	minor := d.peekMinor()
+	switch minor {
+	case major7True:
+		*v = true
+		d.off++
+		return nil
+	case major7False:
+		*v = false
+		d.off++
+		return nil
+	default:
+		return fmt.Errorf("expected bool, got minor %d", minor)
+	}
+}
+
+// ReadBoolPtr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadBoolPtr(s *smithy.Schema, v **bool) error {
+	return readPtr(d, s, v, d.ReadBool)
+}
+
+// ReadString implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadString(s *smithy.Schema, v *string) error {
+	if d.eof() {
+		return errUnexpectedEOF
+	}
+
+	if d.peekMajor() != majorTypeString {
+		return fmt.Errorf("expected string, got major type %d", d.peekMajor())
+	}
+
+	if d.peekMinor() == minorIndefinite {
+		d.off++
+		var result []byte
+		for d.off < len(d.p) && d.p[d.off] != 0xff {
+			if d.peekMajor() != majorTypeString {
+				return fmt.Errorf("expected string chunk, got major type %d", d.peekMajor())
+			}
+			slen, err := d.readArg()
+			if err != nil {
+				return err
+			}
+			if d.off+int(slen) > len(d.p) {
+				return fmt.Errorf("string chunk length %d exceeds remaining data", slen)
+			}
+			result = append(result, d.p[d.off:d.off+int(slen)]...)
+			d.off += int(slen)
+		}
+		d.off++ // skip terminator
+		*v = string(result)
+		return nil
+	}
+
+	slen, err := d.readArg()
+	if err != nil {
+		return err
+	}
+	if d.off+int(slen) > len(d.p) {
+		return fmt.Errorf("string length %d exceeds remaining data", slen)
+	}
+	*v = string(d.p[d.off : d.off+int(slen)])
+	d.off += int(slen)
+	return nil
+}
+
+// ReadStringPtr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadStringPtr(s *smithy.Schema, v **string) error {
+	return readPtr(d, s, v, d.ReadString)
+}
+
+// ReadTime implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadTime(schema *smithy.Schema, v *time.Time) error {
+	if d.eof() {
+		return errUnexpectedEOF
+	}
+
+	if d.peekMajor() != majorTypeTag {
+		return fmt.Errorf("expected tag for timestamp, got major type %d", d.peekMajor())
+	}
+	tagID, err := d.readArg()
+	if err != nil {
+		return err
+	}
+	if tagID != 1 {
+		return fmt.Errorf("expected tag 1 for timestamp, got %d", tagID)
+	}
+
+	if d.eof() {
+		return errUnexpectedEOF
+	}
+
+	major := d.peekMajor()
+	switch major {
+	case majorTypeUint, majorTypeNegInt:
+		secs, err := d.readInt64()
+		if err != nil {
+			return err
+		}
+		*v = time.Unix(secs, 0)
+		return nil
+	case majorType7:
+		f, err := d.readFloat64()
+		if err != nil {
+			return err
+		}
+		*v = time.UnixMilli(int64(f * 1e3))
+		return nil
+	default:
+		return fmt.Errorf("unexpected major type %d in timestamp tag", major)
+	}
+}
+
+// ReadTimePtr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadTimePtr(schema *smithy.Schema, v **time.Time) error {
+	return readPtr(d, schema, v, d.ReadTime)
+}
+
+// ReadBlob implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadBlob(s *smithy.Schema, v *[]byte) error {
+	if isNil, err := d.ReadNil(s); isNil || err != nil {
+		return err
+	}
+
+	if d.peekMajor() != majorTypeSlice {
+		return fmt.Errorf("expected byte string, got major type %d", d.peekMajor())
+	}
+	slen, err := d.readArg()
+	if err != nil {
+		return err
+	}
+	if d.off+int(slen) > len(d.p) {
+		return fmt.Errorf("blob length %d exceeds remaining data", slen)
+	}
+	*v = make([]byte, slen)
+	copy(*v, d.p[d.off:d.off+int(slen)])
+	d.off += int(slen)
+	return nil
+}
+
+// ReadList implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadList(s *smithy.Schema) error {
+	if d.eof() {
+		return errUnexpectedEOF
+	}
+
+	if d.peekMajor() != majorTypeList {
+		return fmt.Errorf("expected list, got major type %d", d.peekMajor())
+	}
+	if d.peekMinor() == minorIndefinite {
+		d.off++
+		d.head.push(deserCtx{kind: deserCtxList, remaining: -1})
+		return nil
+	}
+	count, err := d.readArg()
+	if err != nil {
+		return err
+	}
+	d.head.push(deserCtx{kind: deserCtxList, remaining: int(count)})
+	return nil
+}
+
+// ReadListItem implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadListItem(s *smithy.Schema) (bool, error) {
+	lc := d.head.top()
+	if lc == nil || lc.kind != deserCtxList {
+		return false, fmt.Errorf("ReadListItem called without ReadList")
+	}
+
+	if lc.remaining == -1 {
+		if d.off < len(d.p) && d.p[d.off] == 0xff {
+			d.off++
+			d.head.pop()
+			return false, nil
+		}
+		return true, nil
+	}
+	if lc.remaining <= 0 {
+		d.head.pop()
+		return false, nil
+	}
+	lc.remaining--
+	return true, nil
+}
+
+// ReadMap implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadMap(s *smithy.Schema) error {
+	if d.eof() {
+		return errUnexpectedEOF
+	}
+
+	if d.peekMajor() != majorTypeMap {
+		return fmt.Errorf("expected map, got major type %d", d.peekMajor())
+	}
+	if d.peekMinor() == minorIndefinite {
+		d.off++
+		d.head.push(deserCtx{kind: deserCtxMap, remaining: -1})
+		return nil
+	}
+	count, err := d.readArg()
+	if err != nil {
+		return err
+	}
+	d.head.push(deserCtx{kind: deserCtxMap, remaining: int(count)})
+	return nil
+}
+
+// ReadMapKey implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadMapKey(s *smithy.Schema) (string, bool, error) {
+	mc := d.head.top()
+	if mc == nil || mc.kind != deserCtxMap {
+		return "", false, fmt.Errorf("ReadMapKey called without ReadMap")
+	}
+
+	if mc.remaining == -1 {
+		if d.off < len(d.p) && d.p[d.off] == 0xff {
+			d.off++
+			d.head.pop()
+			return "", false, nil
+		}
+	} else {
+		if mc.remaining <= 0 {
+			d.head.pop()
+			return "", false, nil
+		}
+		mc.remaining--
+	}
+
+	var key string
+	if err := d.ReadString(nil, &key); err != nil {
+		return "", false, err
+	}
+	return key, true, nil
+}
+
+// ReadStruct implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadStruct(s *smithy.Schema) error {
+	if isNil, err := d.ReadNil(s); isNil || err != nil {
+		return err
+	}
+
+	if d.peekMajor() != majorTypeMap {
+		return fmt.Errorf("expected map for struct, got major type %d", d.peekMajor())
+	}
+	if d.peekMinor() == minorIndefinite {
+		d.off++
+		d.head.push(deserCtx{kind: deserCtxStruct, schema: s, remaining: -1})
+		return nil
+	}
+	count, err := d.readArg()
+	if err != nil {
+		return err
+	}
+	d.head.push(deserCtx{kind: deserCtxStruct, schema: s, remaining: int(count)})
+	return nil
+}
+
+// ReadStructMember implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadStructMember() (*smithy.Schema, error) {
+	sc := d.head.top()
+	if sc == nil || sc.kind != deserCtxStruct {
+		return nil, fmt.Errorf("ReadStructMember called without ReadStruct")
+	}
+
+	if sc.remaining == -1 {
+		if d.off < len(d.p) && d.p[d.off] == 0xff {
+			d.off++
+			d.head.pop()
+			return nil, nil
+		}
+	} else {
+		if sc.remaining <= 0 {
+			d.head.pop()
+			return nil, nil
+		}
+		sc.remaining--
+	}
+
+	var key string
+	if err := d.ReadString(nil, &key); err != nil {
+		return nil, err
+	}
+
+	member := sc.schema.Member(key)
+	if member == nil {
+		if err := d.skip(); err != nil {
+			return nil, err
+		}
+		return d.ReadStructMember()
+	}
+
+	return member, nil
+}
+
+// ReadUnion implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadUnion(s *smithy.Schema) (*smithy.Schema, error) {
+	top := d.head.top()
+	if top == nil || top.kind != deserCtxUnion { // first call: open the map
+		if d.eof() {
+			return nil, errUnexpectedEOF
+		}
+		if d.peekMajor() != majorTypeMap {
+			return nil, fmt.Errorf("expected map for union, got major type %d", d.peekMajor())
+		}
+		if d.peekMinor() == minorIndefinite {
+			d.off++
+			d.head.push(deserCtx{kind: deserCtxUnion, schema: s, remaining: -1})
+		} else {
+			count, err := d.readArg()
+			if err != nil {
+				return nil, err
+			}
+			d.head.push(deserCtx{kind: deserCtxUnion, schema: s, remaining: int(count)})
+		}
+	}
+
+	uc := d.head.top()
+	for {
+		if uc.remaining == -1 {
+			if d.off < len(d.p) && d.p[d.off] == 0xff {
+				d.off++
+				d.head.pop()
+				return nil, nil
+			}
+		} else if uc.remaining <= 0 {
+			d.head.pop()
+			return nil, nil
+		} else {
+			uc.remaining--
+		}
+
+		var key string
+		if err := d.ReadString(nil, &key); err != nil {
+			return nil, err
+		}
+
+		if d.off < len(d.p) && d.peekMajor() == majorType7 {
+			minor := d.peekMinor()
+			if minor == major7Nil || minor == major7Undefined {
+				d.off++
+				continue
+			}
+		}
+
+		member := s.Member(key)
+		if member == nil {
+			if err := d.skip(); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		return member, nil
+	}
+}
+
+// ReadDocument is unimplemented and will panic.
+func (d *ShapeDeserializer) ReadDocument(schema *smithy.Schema, v *document.Value) error {
+	panic("unimplemented")
+}
+
+func (d *ShapeDeserializer) skip() error {
+	if d.eof() {
+		return errUnexpectedEOF
+	}
+	major := d.peekMajor()
+	switch major {
+	case majorTypeUint, majorTypeNegInt:
+		_, err := d.readArg()
+		return err
+	case majorTypeSlice, majorTypeString:
+		if d.peekMinor() == minorIndefinite {
+			return d.skipIndefiniteBytes()
+		}
+		slen, err := d.readArg()
+		if err != nil {
+			return err
+		}
+		d.off += int(slen)
+		return nil
+	case majorTypeList, majorTypeMap:
+		itemsPerEntry := 1
+		if major == majorTypeMap {
+			itemsPerEntry = 2
+		}
+		if d.peekMinor() == minorIndefinite {
+			d.off++
+			for d.off < len(d.p) && d.p[d.off] != 0xff {
+				for range itemsPerEntry {
+					if err := d.skip(); err != nil {
+						return err
+					}
+				}
+			}
+			d.off++ // skip terminator
+			return nil
+		}
+		count, err := d.readArg()
+		if err != nil {
+			return err
+		}
+		for range int(count) * itemsPerEntry {
+			if err := d.skip(); err != nil {
+				return err
+			}
+		}
+		return nil
+	case majorTypeTag:
+		_, err := d.readArg()
+		if err != nil {
+			return err
+		}
+		return d.skip() // skip the tagged value
+	case majorType7:
+		minor := d.peekMinor()
+		n := 0
+		if minor >= minorArg1 && minor <= minorArg8 {
+			n = major7ExtraSizes[minor-minorArg1]
+		}
+		d.off += 1 + n
+		return nil
+	default:
+		return fmt.Errorf("unexpected major type %d", major)
+	}
+}
+
+func (d *ShapeDeserializer) skipIndefiniteBytes() error {
+	d.off++ // skip the indefinite marker
+	for d.off < len(d.p) && d.p[d.off] != 0xff {
+		if err := d.skip(); err != nil {
+			return err
+		}
+	}
+	d.off++ // skip break
+	return nil
+}
+
+func readPtr[T any](d *ShapeDeserializer, s *smithy.Schema, v **T, read func(*smithy.Schema, *T) error) error {
+	if isNil, err := d.ReadNil(s); isNil || err != nil {
+		return err
+	}
+	if *v == nil {
+		*v = new(T)
+	}
+	return read(s, *v)
+}
+
+type tint interface {
+	int8 | int16 | int32 | int64
+}
+
+func readInt[T tint](d *ShapeDeserializer, v *T, min, max int64) error {
+	n, err := d.readInt64()
+	if err != nil {
+		return err
+	}
+	if n < min || n > max {
+		return fmt.Errorf("int %d exceeds %T range", n, *v)
+	}
+	*v = T(n)
+	return nil
+}
+
+type tfloat interface {
+	float32 | float64
+}
+
+func readFloat[T tfloat](d *ShapeDeserializer, v *T) error {
+	n, err := d.readFloat64()
+	if err != nil {
+		return err
+	}
+	*v = T(n)
+	return nil
+}
+
+// GetProtocolErrorInfo decodes error type/message from a CBOR response body.
+func GetProtocolErrorInfo(p []byte) (typ, message string, err error) {
+	v, decErr := smithycbor.Decode(p)
+	if decErr != nil {
+		return "", "", decErr
+	}
+
+	m, ok := v.(smithycbor.Map)
+	if !ok {
+		return "", "", nil
+	}
+
+	if t, ok := m["__type"]; ok {
+		if s, ok := t.(smithycbor.String); ok {
+			typ = string(s)
+		}
+	}
+	if msg, ok := m["message"]; ok {
+		if s, ok := msg.(smithycbor.String); ok {
+			message = string(s)
+		}
+	}
+
+	return typ, message, nil
+}

--- a/smithy-http-protocols/internal/cbor/shape_deserializer.go
+++ b/smithy-http-protocols/internal/cbor/shape_deserializer.go
@@ -181,7 +181,7 @@ func (d *ShapeDeserializer) readFloat64() (float64, error) {
 			d.off += 9
 			return math.Float64frombits(bits), nil
 		default:
-			return 0, fmt.Errorf("expected float, got minor %d", minor)
+			return 0, fmt.Errorf("given majorType7, expected a minor of float type, instead got %d", minor)
 		}
 	case majorTypeUint:
 		v, err := d.readArg()

--- a/smithy-http-protocols/internal/cbor/shape_deserializer.go
+++ b/smithy-http-protocols/internal/cbor/shape_deserializer.go
@@ -493,7 +493,7 @@ func (d *ShapeDeserializer) ReadMap(s *smithy.Schema) error {
 func (d *ShapeDeserializer) ReadMapKey(s *smithy.Schema) (string, bool, error) {
 	mc := d.head.top()
 	if mc == nil || mc.kind != deserCtxMap {
-		return "", false, fmt.Errorf("ReadMapKey called without ReadMap")
+		return "", false, errors.New("ReadMapKey called without ReadMap")
 	}
 
 	if mc.remaining == -1 {

--- a/smithy-http-protocols/internal/cbor/shape_serializer.go
+++ b/smithy-http-protocols/internal/cbor/shape_serializer.go
@@ -1,0 +1,456 @@
+package cbor
+
+import (
+	"encoding/binary"
+	"math"
+	"math/big"
+	"time"
+
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/document"
+	"github.com/aws/smithy-go/traits"
+)
+
+// ShapeSerializer implements marshaling of Smithy shapes to CBOR.
+type ShapeSerializer struct {
+	buf  []byte
+	head []byte
+
+	opts ShapeSerializerOptions
+
+	// rootSchema is the schema passed to the first WriteStruct call,
+	// used by the protocol to determine if the input is a Unit shape.
+	rootSchema *smithy.Schema
+}
+
+// ShapeSerializerOptions configures ShapeSerializer.
+type ShapeSerializerOptions struct {
+	WriteZeroValues bool
+}
+
+var _ smithy.ShapeSerializer = (*ShapeSerializer)(nil)
+
+// NewShapeSerializer creates a new ShapeSerializer.
+func NewShapeSerializer(opts ...func(*ShapeSerializerOptions)) *ShapeSerializer {
+	o := ShapeSerializerOptions{}
+	for _, fn := range opts {
+		fn(&o)
+	}
+	return &ShapeSerializer{opts: o}
+}
+
+// Bytes returns the serialized CBOR bytes.
+func (s *ShapeSerializer) Bytes() []byte {
+	return s.buf
+}
+
+// IsUnitShape returns true if the serialized content represents a Unit shape
+// (a struct with no defined input, marked with the UnitShape trait).
+func (s *ShapeSerializer) IsUnitShape() bool {
+	if s.rootSchema == nil {
+		return false
+	}
+	_, ok := smithy.SchemaTrait[*traits.UnitShape](s.rootSchema)
+	return ok
+}
+
+func (s *ShapeSerializer) top() byte {
+	if len(s.head) == 0 {
+		return 0xff
+	}
+	return s.head[len(s.head)-1]
+}
+
+func (s *ShapeSerializer) push(v byte) {
+	s.head = append(s.head, v)
+}
+
+func (s *ShapeSerializer) pop() {
+	s.head = s.head[:len(s.head)-1]
+}
+
+// WriteInt8Ptr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt8Ptr(schema *smithy.Schema, v *int8) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteInt8(schema, *v) })
+	}
+}
+
+// WriteInt16Ptr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt16Ptr(schema *smithy.Schema, v *int16) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteInt16(schema, *v) })
+	}
+}
+
+// WriteInt32Ptr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt32Ptr(schema *smithy.Schema, v *int32) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteInt32(schema, *v) })
+	}
+}
+
+// WriteInt64Ptr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt64Ptr(schema *smithy.Schema, v *int64) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteInt64(schema, *v) })
+	}
+}
+
+// WriteFloat32Ptr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteFloat32Ptr(schema *smithy.Schema, v *float32) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteFloat32(schema, *v) })
+	}
+}
+
+// WriteFloat64Ptr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteFloat64Ptr(schema *smithy.Schema, v *float64) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteFloat64(schema, *v) })
+	}
+}
+
+// WriteBoolPtr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteBoolPtr(schema *smithy.Schema, v *bool) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteBool(schema, *v) })
+	}
+}
+
+// WriteStringPtr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteStringPtr(schema *smithy.Schema, v *string) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteString(schema, *v) })
+	}
+}
+
+func (s *ShapeSerializer) withWriteZero(fn func()) {
+	prev := s.opts.WriteZeroValues
+	s.opts.WriteZeroValues = true
+	fn()
+	s.opts.WriteZeroValues = prev
+}
+
+func (s *ShapeSerializer) skipZeroValue() bool {
+	if s.opts.WriteZeroValues {
+		return false
+	}
+	if len(s.head) == 0 {
+		return false
+	}
+	switch s.top() {
+	case ctxList, ctxMapValue:
+		return false
+	default:
+		return true
+	}
+}
+
+// WriteBool implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteBool(schema *smithy.Schema, v bool) {
+	if !v && s.skipZeroValue() {
+		return
+	}
+	s.writeKey(schema)
+	if v {
+		s.buf = append(s.buf, compose(majorType7, major7True))
+	} else {
+		s.buf = append(s.buf, compose(majorType7, major7False))
+	}
+}
+
+func (s *ShapeSerializer) writeInt(v int64) {
+	if v >= 0 {
+		s.writeUint(uint64(v))
+	} else {
+		s.writeArg(majorTypeNegInt, uint64(-v-1))
+	}
+}
+
+func (s *ShapeSerializer) writeUint(v uint64) {
+	s.writeArg(majorTypeUint, v)
+}
+
+// WriteInt8 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt8(schema *smithy.Schema, v int8) {
+	if v == 0 && s.skipZeroValue() {
+		return
+	}
+	s.writeKey(schema)
+	s.writeInt(int64(v))
+}
+
+// WriteInt16 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt16(schema *smithy.Schema, v int16) {
+	if v == 0 && s.skipZeroValue() {
+		return
+	}
+	s.writeKey(schema)
+	s.writeInt(int64(v))
+}
+
+// WriteInt32 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt32(schema *smithy.Schema, v int32) {
+	if v == 0 && s.skipZeroValue() {
+		return
+	}
+	s.writeKey(schema)
+	s.writeInt(int64(v))
+}
+
+// WriteInt64 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt64(schema *smithy.Schema, v int64) {
+	if v == 0 && s.skipZeroValue() {
+		return
+	}
+	s.writeKey(schema)
+	s.writeInt(v)
+}
+
+// WriteFloat32 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteFloat32(schema *smithy.Schema, v float32) {
+	if v == 0 && !math.Signbit(float64(v)) && s.skipZeroValue() {
+		return
+	}
+	s.writeKey(schema)
+	s.buf = append(s.buf, compose(majorType7, major7Float32))
+	s.buf = binary.BigEndian.AppendUint32(s.buf, math.Float32bits(v))
+}
+
+// WriteFloat64 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteFloat64(schema *smithy.Schema, v float64) {
+	if v == 0 && !math.Signbit(v) && s.skipZeroValue() {
+		return
+	}
+	s.writeKey(schema)
+	s.buf = append(s.buf, compose(majorType7, major7Float64))
+	s.buf = binary.BigEndian.AppendUint64(s.buf, math.Float64bits(v))
+}
+
+// WriteString implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteString(schema *smithy.Schema, v string) {
+	if v == "" && s.skipZeroValue() {
+		return
+	}
+	s.writeKey(schema)
+	s.writeTextString(v)
+}
+
+// WriteBlob implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteBlob(schema *smithy.Schema, v []byte) {
+	if v == nil {
+		return
+	}
+	s.writeKey(schema)
+	s.writeArg(majorTypeSlice, uint64(len(v)))
+	s.buf = append(s.buf, v...)
+}
+
+// WriteList implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteList(schema *smithy.Schema) {
+	s.writeKey(schema)
+	if s.top() == ctxMapValue {
+		s.pop()
+	}
+	s.buf = append(s.buf, compose(majorTypeList, minorIndefinite))
+	s.push(ctxList)
+}
+
+// CloseList implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) CloseList() {
+	if s.top() != ctxList {
+		return
+	}
+	s.pop()
+	s.buf = append(s.buf, 0xff)
+}
+
+// WriteMap implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteMap(schema *smithy.Schema) {
+	if s.rootSchema == nil && len(s.head) == 0 {
+		s.rootSchema = schema
+	}
+	s.writeKey(schema)
+	if s.top() == ctxMapValue {
+		s.pop()
+	}
+	s.buf = append(s.buf, compose(majorTypeMap, minorIndefinite))
+	s.push(ctxMap)
+}
+
+// WriteKey implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteKey(_ *smithy.Schema, key string) {
+	s.writeTextString(key)
+	s.push(ctxMapValue)
+}
+
+// CloseMap implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) CloseMap() {
+	if s.top() != ctxMap {
+		return
+	}
+	s.pop()
+	s.buf = append(s.buf, 0xff)
+}
+
+// WriteTime implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteTime(schema *smithy.Schema, v time.Time) {
+	s.writeKey(schema)
+	if s.top() == ctxMapValue {
+		s.pop()
+	}
+
+	// rpcv2Cbor: always epoch-seconds as float64, tag 1
+	epoch := float64(v.UnixMilli()) / 1e3
+	s.writeArg(majorTypeTag, 1)
+	s.buf = append(s.buf, compose(majorType7, major7Float64))
+	s.buf = binary.BigEndian.AppendUint64(s.buf, math.Float64bits(epoch))
+}
+
+// WriteTimePtr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteTimePtr(schema *smithy.Schema, v *time.Time) {
+	if v != nil {
+		s.WriteTime(schema, *v)
+	}
+}
+
+// WriteUnion implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteUnion(schema, variant *smithy.Schema, v smithy.Serializable) {
+	s.writeKey(schema)
+	// union is a map with a single key
+	s.writeArg(majorTypeMap, 1)
+	s.writeTextString(variant.MemberName())
+	v.Serialize(s)
+}
+
+// WriteStruct implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteStruct(schema *smithy.Schema, v smithy.Serializable) {
+	if v == nil {
+		return
+	}
+	s.writeKey(schema)
+	if s.top() == ctxMapValue {
+		s.pop()
+	}
+	v.Serialize(s)
+}
+
+// WriteNil implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteNil(schema *smithy.Schema) {
+	s.writeKey(schema)
+	if s.top() == ctxMapValue {
+		s.pop()
+	}
+	s.buf = append(s.buf, compose(majorType7, major7Nil))
+}
+
+// WriteBigInteger is unimplemented and will panic.
+func (s *ShapeSerializer) WriteBigInteger(schema *smithy.Schema, v big.Int) {
+	panic("unimplemented")
+}
+
+// WriteBigDecimal is unimplemented and will panic.
+func (s *ShapeSerializer) WriteBigDecimal(schema *smithy.Schema, v big.Float) {
+	panic("unimplemented")
+}
+
+// WriteDocument is unimplemented and will panic.
+func (s *ShapeSerializer) WriteDocument(schema *smithy.Schema, v document.Value) {
+	panic("unimplemented")
+}
+
+// writeKey writes the member name as a CBOR text string key when inside a
+// struct or map context.
+func (s *ShapeSerializer) writeKey(schema *smithy.Schema) {
+	// If we're in a map value context (after WriteKey), just pop it and
+	// don't write a key - the key was already written by WriteKey.
+	if s.top() == ctxMapValue {
+		s.pop()
+		return
+	}
+	if schema == nil {
+		return
+	}
+
+	if s.top() == ctxMap {
+		name := schema.MemberName()
+		if name != "" {
+			s.writeTextString(name)
+		}
+	}
+}
+
+func (s *ShapeSerializer) writeTextString(v string) {
+	s.writeArg(majorTypeString, uint64(len(v)))
+	s.buf = append(s.buf, v...)
+}
+
+func (s *ShapeSerializer) writeArg(major majorType, arg uint64) {
+	if arg < 24 {
+		s.buf = append(s.buf, byte(major)<<5|byte(arg))
+	} else if arg < 0x100 {
+		s.buf = append(s.buf, compose(major, minorArg1), byte(arg))
+	} else if arg < 0x10000 {
+		s.buf = append(s.buf, compose(major, minorArg2))
+		s.buf = binary.BigEndian.AppendUint16(s.buf, uint16(arg))
+	} else if arg < 0x100000000 {
+		s.buf = append(s.buf, compose(major, minorArg4))
+		s.buf = binary.BigEndian.AppendUint32(s.buf, uint32(arg))
+	} else {
+		s.buf = append(s.buf, compose(major, minorArg8))
+		s.buf = binary.BigEndian.AppendUint64(s.buf, arg)
+	}
+}
+
+// duplicated from the old encoding/cbor
+
+type majorType byte
+
+const (
+	majorTypeUint   majorType = 0
+	majorTypeNegInt majorType = 1
+	majorTypeSlice  majorType = 2
+	majorTypeString majorType = 3
+	majorTypeList   majorType = 4
+	majorTypeMap    majorType = 5
+	majorTypeTag    majorType = 6
+	majorType7      majorType = 7
+)
+
+const (
+	minorArg1       = 24
+	minorArg2       = 25
+	minorArg4       = 26
+	minorArg8       = 27
+	minorIndefinite = 31
+)
+
+const (
+	major7False   = 20
+	major7True    = 21
+	major7Nil       = 22
+	major7Undefined = 23
+	major7Float16   = minorArg2
+	major7Float32 = minorArg4
+	major7Float64 = minorArg8
+)
+
+// maps minor argument indicators (minorArg1..minorArg8) to the number of bytes
+// that follow for the argument value
+var argSizes = [4]int{1, 2, 4, 8}
+
+// maps minor values (minorArg1..minorArg8) in major type 7 to the number of
+// payload bytes that follow
+var major7ExtraSizes = [4]int{0, 2, 4, 8}
+
+func compose(major majorType, minor byte) byte {
+	return byte(major)<<5 | minor
+}
+
+// context sentinels for the serialization state stack
+const (
+	ctxList     byte = iota // inside a list
+	ctxMap                  // inside a map (struct or smithy map)
+	ctxMapValue             // next write is a map value (after WriteKey)
+)

--- a/smithy-http-protocols/rpcv2/rpcv2.go
+++ b/smithy-http-protocols/rpcv2/rpcv2.go
@@ -17,6 +17,9 @@ import (
 )
 
 // Protocol implements an RPC v2 protocol.
+//
+// RPCv2 protocol family:
+//   - CBOR: https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html
 type Protocol struct {
 	options ProtocolOptions
 

--- a/smithy-http-protocols/rpcv2/rpcv2.go
+++ b/smithy-http-protocols/rpcv2/rpcv2.go
@@ -1,0 +1,229 @@
+package rpcv2
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/eventstream"
+	internalerrors "github.com/aws/smithy-go/internal/errors"
+	smithyio "github.com/aws/smithy-go/io"
+	"github.com/aws/smithy-go/middleware"
+	internalcbor "github.com/aws/smithy-go/smithy-http-protocols/internal/cbor"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+// Protocol implements an RPC v2 protocol.
+type Protocol struct {
+	options ProtocolOptions
+
+	codec       smithy.Codec
+	contentType string
+	protocolID  string
+
+	*eventstream.Codec
+}
+
+// ProtocolOptions configures a Protocol.
+type ProtocolOptions struct {
+	// When enabled, support reading legacy AWS query error codes in error
+	// responses.
+	//
+	// See https://smithy.io/2.0/aws/protocols/aws-query-protocol.html#aws-protocols-awsquerycompatible-trait.
+	UseQueryCompatible bool
+}
+
+// UseQueryCompatible enables support for AWS query compatibility.
+func UseQueryCompatible(o *ProtocolOptions) {
+	o.UseQueryCompatible = true
+}
+
+var _ smithyhttp.ClientProtocol = (*Protocol)(nil)
+
+// NewCBOR returns an instance of the smithy.protocols#rpcv2Cbor protocol.
+func NewCBOR(opts ...func(*ProtocolOptions)) *Protocol {
+	var options ProtocolOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+	codec := &internalcbor.Codec{}
+	return &Protocol{
+		options:     options,
+		codec:       codec,
+		contentType: "application/cbor",
+		protocolID:  "smithy.protocols#rpcv2Cbor",
+		Codec: &eventstream.Codec{
+			Codec:       codec,
+			ContentType: "application/cbor",
+		},
+	}
+}
+
+// ID identifies the protocol.
+func (p *Protocol) ID() string {
+	return p.protocolID
+}
+
+// SerializeRequest serializes a request for rpcv2Cbor.
+func (p *Protocol) SerializeRequest(
+	ctx context.Context,
+	schema *smithy.OperationSchema,
+	in smithy.Serializable,
+	req *smithyhttp.Request,
+) error {
+	req.Method = http.MethodPost
+	req.URL.Path = fmt.Sprintf("/service/%s/operation/%s",
+		middleware.GetServiceName(ctx), middleware.GetOperationName(ctx))
+	req.Header.Set("Smithy-Protocol", "rpc-v2-cbor")
+	req.Header.Set("Accept", "application/cbor")
+	if p.options.UseQueryCompatible {
+		req.Header.Set("X-Amzn-Query-Mode", "true")
+	}
+
+	if schema.IsInputEventStream() {
+		req.Header.Set("Content-Type", "application/vnd.amazon.eventstream")
+		return nil
+	}
+
+	ss := p.codec.Serializer()
+	in.Serialize(ss)
+
+	payload := ss.Bytes()
+	if len(payload) == 0 {
+		return nil
+	}
+
+	// operations targeting Unit MUST NOT have a body, check if we backfilled
+	// an input
+	if cs, ok := ss.(*internalcbor.ShapeSerializer); ok && cs.IsUnitShape() {
+		return nil
+	}
+
+	req.Header.Set("Content-Type", p.contentType)
+
+	sreq, err := req.SetStream(bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("set stream: %w", err)
+	}
+
+	*req = *sreq
+	return nil
+}
+
+// DeserializeResponse deserializes a response for rpcv2Cbor.
+func (p *Protocol) DeserializeResponse(
+	ctx context.Context,
+	schema *smithy.OperationSchema,
+	types *smithy.TypeRegistry,
+	resp *smithyhttp.Response,
+	out smithy.Deserializable,
+) error {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return p.deserializeError(types, resp)
+	}
+
+	if schema.IsOutputEventStream() {
+		return nil
+	}
+
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return &smithy.DeserializationError{Err: err}
+	}
+
+	if len(payload) == 0 {
+		return nil
+	}
+
+	sd := p.codec.Deserializer(payload)
+	if err := out.Deserialize(sd); err != nil {
+		return &smithy.DeserializationError{Err: err}
+	}
+
+	return nil
+}
+
+// HasInitialEventMessage is true because this is an RPC protocol.
+func (*Protocol) HasInitialEventMessage() bool {
+	return true
+}
+
+func (p *Protocol) deserializeError(types *smithy.TypeRegistry, response *smithyhttp.Response) error {
+	var errorBuffer bytes.Buffer
+	if _, err := io.Copy(&errorBuffer, response.Body); err != nil {
+		return &smithy.DeserializationError{Err: fmt.Errorf("failed to copy error response body, %w", err)}
+	}
+	errorBody := errorBuffer.Bytes()
+
+	errorCode := "UnknownError"
+	errorMessage := errorCode
+
+	var buff [1024]byte
+	ringBuffer := smithyio.NewRingBuffer(buff[:])
+
+	body := io.TeeReader(bytes.NewReader(errorBody), ringBuffer)
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		var snapshot bytes.Buffer
+		io.Copy(&snapshot, ringBuffer)
+		return &smithy.DeserializationError{
+			Err:      fmt.Errorf("failed to read response body, %w", err),
+			Snapshot: snapshot.Bytes(),
+		}
+	}
+
+	bodyType, bodyMessage, err := internalcbor.GetProtocolErrorInfo(bodyBytes)
+	if err != nil {
+		var snapshot bytes.Buffer
+		io.Copy(&snapshot, ringBuffer)
+		return &smithy.DeserializationError{
+			Err:      fmt.Errorf("failed to decode response body, %w", err),
+			Snapshot: snapshot.Bytes(),
+		}
+	}
+
+	if bodyType != "" {
+		errorCode = bodyType
+	}
+	if bodyMessage != "" {
+		errorMessage = bodyMessage
+	}
+
+	errorCode = internalerrors.SanitizeErrorCode(errorCode)
+
+	var queryCode string
+	var queryFault smithy.ErrorFault
+	if p.options.UseQueryCompatible {
+		queryHeader := response.Header.Get("X-Amzn-Query-Error")
+		queryCode, queryFault = internalerrors.ParseQueryError(queryHeader)
+	}
+
+	perr, ok := types.DeserializableError(errorCode)
+	if !ok {
+		code := errorCode
+		if queryCode != "" {
+			code = queryCode
+		}
+		return &smithy.GenericAPIError{
+			Code:    code,
+			Message: errorMessage,
+			Fault:   queryFault,
+		}
+	}
+
+	if len(bodyBytes) > 0 {
+		deser := p.codec.Deserializer(bodyBytes)
+		if err := perr.Deserialize(deser); err != nil {
+			return &smithy.DeserializationError{Err: err}
+		}
+	}
+
+	if queryCode != "" {
+		internalerrors.SetErrorCodeOverride(perr, queryCode)
+	}
+
+	return perr
+}

--- a/traits/traits.go
+++ b/traits/traits.go
@@ -46,3 +46,11 @@ type AWSQueryError struct {
 
 // TraitID identifies the trait.
 func (*AWSQueryError) TraitID() string { return "aws.protocols#awsQueryError" }
+
+// UnitShape is a synthetic trait applied to input/output shapes that were
+// backfilled from Unit. It indicates the shape has no defined members and
+// should be treated as absent for protocol serialization purposes.
+type UnitShape struct{}
+
+// TraitID identifies the trait.
+func (*UnitShape) TraitID() string { return "smithy.go#unitShape" }


### PR DESCRIPTION
Port `smithy.protocols#rpcv2Cbor` to schema-serde. I elected to rewrite the codec in this instance to get away from the old DOM method, and because reading from bytes better fits the new ShapeDeserializer API.

I realized in doing this that we needed to actually call ReadUnion iteratively to "close" the union structure in a deserialize, so I added a helper like the existing smithy.ReadStruct that does this. I backported that change to the json codec. I also realized that we missed query-compat support for json so I added a TODO. I did implement it for cbor and checked those protocol tests as well.