### PR TITLE
Implement BDD generator for @endpointBdd Smithy trait

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -37,6 +37,7 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.DeprecatedTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
+import software.amazon.smithy.rulesengine.traits.EndpointBddTrait;
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
 
 /**
@@ -137,7 +138,8 @@ public final class OperationGenerator implements Runnable {
                 }, true);
 
         var rulesTrait = service.getTrait(EndpointRuleSetTrait.class);
-        if (rulesTrait.isPresent()) {
+        var bddTrait = service.getTrait(EndpointBddTrait.class);
+        if (rulesTrait.isPresent() || bddTrait.isPresent()) {
             writer.write(new EndpointParameterOperationBindingsGenerator(ctx, operation, inputShape)
                     .generate());
         }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -77,6 +77,7 @@ public final class SmithyGoDependency {
     public static final GoDependency SMITHY_AUTH_BEARER = smithy("auth/bearer");
     public static final GoDependency SMITHY_ENDPOINTS = smithy("endpoints", "smithyendpoints");
     public static final GoDependency SMITHY_ENDPOINT_RULESFN = smithy("endpoints/private/rulesfn");
+    public static final GoDependency SMITHY_ENDPOINT_BDD = smithy("endpoints/private/bdd");
     public static final GoDependency SMITHY_TRACING = smithy("tracing");
     public static final GoDependency SMITHY_METRICS = smithy("metrics");
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointBddResolverGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointBddResolverGenerator.java
@@ -105,9 +105,13 @@ public final class EndpointBddResolverGenerator {
         var results = trait.getResults();
         var parameters = trait.getParameters();
 
-        // Build a scope that maps parameter references to "params.FieldName" (pointer form, for isSet)
+        // ptrScope: maps references to their raw pointer form (e.g. "params.Region", "c.url").
+        // Used in evalCondition for isSet nil checks where we need the pointer itself.
         var ptrScope = Scope.empty();
-        // Build a scope that maps parameter references to dereferenced form (for value access)
+        // derefScope (and condScope built from it): maps references to their dereferenced value
+        // form (e.g. "*params.Region", "*c.url", but "c.parsedUrl" for struct pointers that
+        // Go auto-derefs). Used in evalCondition for non-isSet cases and in resolveResult
+        // where expressions need the underlying value, not the pointer.
         var derefScope = Scope.empty();
         for (Iterator<Parameter> iter = parameters.iterator(); iter.hasNext();) {
             Parameter p = iter.next();

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointBddResolverGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointBddResolverGenerator.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 import java.util.TreeMap;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.go.codegen.ChainWritable;
-import software.amazon.smithy.go.codegen.GoUniverseTypes;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.go.codegen.SymbolUtils;
@@ -43,7 +42,6 @@ import software.amazon.smithy.rulesengine.language.syntax.expressions.Expression
 import software.amazon.smithy.rulesengine.language.syntax.expressions.ExpressionVisitor;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.Reference;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.FunctionDefinition;
-import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.IsSet;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.LibraryFunction;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.literal.Literal;
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter;
@@ -74,6 +72,7 @@ public final class EndpointBddResolverGenerator {
     private static final String CTX_ARG_NAME = "c";
 
     private final FnProvider fnProvider;
+    private final FnGenerator fnGenerator;
     private final Symbol endpointType;
     private final Symbol parametersType;
     private final Symbol resolverInterfaceType;
@@ -83,6 +82,7 @@ public final class EndpointBddResolverGenerator {
 
     public EndpointBddResolverGenerator(FnProvider fnProvider) {
         this.fnProvider = fnProvider;
+        this.fnGenerator = new FnGenerator(Scope.empty(), fnProvider);
         this.endpointType = SymbolUtils.createValueSymbolBuilder("Endpoint",
                 SmithyGoDependency.SMITHY_ENDPOINTS).build();
         this.parametersType = SymbolUtils.createValueSymbolBuilder(
@@ -189,7 +189,7 @@ public final class EndpointBddResolverGenerator {
                         continue;
                     }
                     var fieldName = condFieldName(cond);
-                    var goType = goTypeForConditionFn(cond);
+                    var goType = fnGenerator.returnTypeForCondition(cond);
                     w.write("$L $P", fieldName, goType);
                 }
             });
@@ -491,7 +491,7 @@ public final class EndpointBddResolverGenerator {
 
                 // Only dereference simple pointer fields (*string, *bool).
                 // Struct pointers (*PartitionConfig, *URL, *ARN) auto-deref in Go for field access.
-                var goType = goTypeForConditionFn(cond);
+                var goType = fnGenerator.returnTypeForCondition(cond);
                 if (SymbolUtils.isPointable(goType) && SymbolUtils.isUniverseType(goType)) {
                     fieldAccess = "*" + fieldAccess;
                 }
@@ -509,73 +509,6 @@ public final class EndpointBddResolverGenerator {
         return condition.getResult()
                 .map(ident -> ident.getName().getValue())
                 .orElseThrow(() -> new IllegalStateException("condition has no result identifier"));
-    }
-
-    /**
-     * Determine the Go type string for a condition function's return value.
-     * This is used for the conditionContext struct fields.
-     */
-    private Symbol goTypeForConditionFn(Condition condition) {
-        var fn = condition.getFunction();
-
-        // isSet stores the pointer value directly — type comes from the inner expression
-        if (fn instanceof IsSet) {
-            var inner = ((IsSet) fn).getArguments().get(0);
-            return goTypeForExpression(inner);
-        }
-
-        // Derive Go type from the function's return type
-        var fnDef = fn.getFunctionDefinition();
-        var fnId = fnDef.getId();
-
-        // Look up the Go function symbol to determine its return type
-        Symbol goFn = fnProvider.fnFor(fnId);
-        if (goFn == null) {
-            goFn = new FnGenerator.DefaultFnProvider().fnFor(fnId);
-        }
-
-        if (goFn != null) {
-            return goReturnTypeForFn(fnId, fn.type());
-        }
-
-        // Fallback based on Smithy type
-        var type = fn.type();
-        if (type instanceof OptionalType opt) {
-            return SymbolUtils.pointerTo(ExpressionGenerator.goTypeForType(opt.inner()));
-        }
-        return ExpressionGenerator.goTypeForType(type);
-    }
-
-    /**
-     * Map known function IDs to their Go return types for conditionContext fields.
-     */
-    private static Symbol goReturnTypeForFn(String fnId,
-            software.amazon.smithy.rulesengine.language.evaluation.type.Type smithyType) {
-        return switch (fnId) {
-            case "parseURL" -> SymbolUtils.createPointableSymbolBuilder("URL",
-                    SmithyGoDependency.SMITHY_ENDPOINT_RULESFN).build();
-            case "substring" -> SymbolUtils.pointerTo(GoUniverseTypes.String);
-            case "aws.parseArn" -> SymbolUtils.createPointableSymbolBuilder("ARN",
-                    "github.com/aws/aws-sdk-go-v2/internal/endpoints/awsrulesfn").build();
-            case "aws.partition" -> SymbolUtils.createPointableSymbolBuilder("PartitionConfig",
-                     "github.com/aws/aws-sdk-go-v2/internal/endpoints/awsrulesfn").build();
-            case "isValidHostLabel", "aws.isVirtualHostableS3Bucket" -> GoUniverseTypes.Bool;
-            case "uriEncode" -> GoUniverseTypes.String;
-            case "split" -> SymbolUtils.sliceOf(GoUniverseTypes.String);
-            case "ite", "coalesce" -> {
-                var type = smithyType instanceof OptionalType opt ? opt.inner() : smithyType;
-                yield ExpressionGenerator.goTypeForType(type);
-            }
-            default -> GoUniverseTypes.Any;
-        };
-    }
-
-    private static Symbol goTypeForExpression(Expression expr) {
-        var type = expr.type();
-        if (type instanceof OptionalType opt) {
-            return SymbolUtils.pointerTo(ExpressionGenerator.goTypeForType(opt.inner()));
-        }
-        return SymbolUtils.pointerTo(ExpressionGenerator.goTypeForType(type));
     }
 
     private static boolean isConditionalFnResultOptional(Condition condition, Expression fn) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointBddResolverGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointBddResolverGenerator.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.TreeMap;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.go.codegen.ChainWritable;
+import software.amazon.smithy.go.codegen.GoUniverseTypes;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.go.codegen.SymbolUtils;
@@ -189,7 +190,7 @@ public final class EndpointBddResolverGenerator {
                     }
                     var fieldName = condFieldName(cond);
                     var goType = goTypeForConditionFn(cond);
-                    w.write("$L $L", fieldName, goType);
+                    w.write("$L $P", fieldName, goType);
                 }
             });
         };
@@ -491,7 +492,7 @@ public final class EndpointBddResolverGenerator {
                 // Only dereference simple pointer fields (*string, *bool).
                 // Struct pointers (*PartitionConfig, *URL, *ARN) auto-deref in Go for field access.
                 var goType = goTypeForConditionFn(cond);
-                if (goType.equals("*string") || goType.equals("*bool")) {
+                if (SymbolUtils.isPointable(goType) && SymbolUtils.isUniverseType(goType)) {
                     fieldAccess = "*" + fieldAccess;
                 }
 
@@ -514,7 +515,7 @@ public final class EndpointBddResolverGenerator {
      * Determine the Go type string for a condition function's return value.
      * This is used for the conditionContext struct fields.
      */
-    private String goTypeForConditionFn(Condition condition) {
+    private Symbol goTypeForConditionFn(Condition condition) {
         var fn = condition.getFunction();
 
         // isSet stores the pointer value directly — type comes from the inner expression
@@ -540,62 +541,41 @@ public final class EndpointBddResolverGenerator {
         // Fallback based on Smithy type
         var type = fn.type();
         if (type instanceof OptionalType opt) {
-            return goTypeForType(opt.inner());
+            return SymbolUtils.pointerTo(ExpressionGenerator.goTypeForType(opt.inner()));
         }
-        return goValueTypeForType(type);
+        return ExpressionGenerator.goTypeForType(type);
     }
 
     /**
      * Map known function IDs to their Go return types for conditionContext fields.
      */
-    private static String goReturnTypeForFn(String fnId,
+    private static Symbol goReturnTypeForFn(String fnId,
             software.amazon.smithy.rulesengine.language.evaluation.type.Type smithyType) {
         return switch (fnId) {
-            // These return pointers — stored as-is in conditionContext
-            case "parseURL" -> "*rulesfn.URL";
-            case "substring" -> "*string";
-            case "aws.parseArn" -> "*awsrulesfn.ARN";
-            case "aws.partition" -> "*awsrulesfn.PartitionConfig";
-            // These return values
-            case "isValidHostLabel" -> "bool";
-            case "uriEncode" -> "string";
-            case "split" -> "[]string";
-            case "aws.isVirtualHostableS3Bucket" -> "bool";
-            // BDD-specific: ite and coalesce return values based on their Smithy type
+            case "parseURL" -> SymbolUtils.createPointableSymbolBuilder("URL",
+                    SmithyGoDependency.SMITHY_ENDPOINT_RULESFN).build();
+            case "substring" -> SymbolUtils.pointerTo(GoUniverseTypes.String);
+            case "aws.parseArn" -> SymbolUtils.createPointableSymbolBuilder("ARN",
+                    "github.com/aws/aws-sdk-go-v2/internal/endpoints/awsrulesfn").build();
+            case "aws.partition" -> SymbolUtils.createPointableSymbolBuilder("PartitionConfig",
+                     "github.com/aws/aws-sdk-go-v2/internal/endpoints/awsrulesfn").build();
+            case "isValidHostLabel", "aws.isVirtualHostableS3Bucket" -> GoUniverseTypes.Bool;
+            case "uriEncode" -> GoUniverseTypes.String;
+            case "split" -> SymbolUtils.sliceOf(GoUniverseTypes.String);
             case "ite", "coalesce" -> {
                 var type = smithyType instanceof OptionalType opt ? opt.inner() : smithyType;
-                yield goValueTypeForType(type);
+                yield ExpressionGenerator.goTypeForType(type);
             }
-            default -> "any";
+            default -> GoUniverseTypes.Any;
         };
     }
 
-    private static String goTypeForExpression(Expression expr) {
+    private static Symbol goTypeForExpression(Expression expr) {
         var type = expr.type();
         if (type instanceof OptionalType opt) {
-            return goTypeForType(opt.inner());
+            return SymbolUtils.pointerTo(ExpressionGenerator.goTypeForType(opt.inner()));
         }
-        return goTypeForType(type);
-    }
-
-    private static String goTypeForType(software.amazon.smithy.rulesengine.language.evaluation.type.Type type) {
-        if (type instanceof software.amazon.smithy.rulesengine.language.evaluation.type.StringType) {
-            return "*string";
-        }
-        if (type instanceof software.amazon.smithy.rulesengine.language.evaluation.type.BooleanType) {
-            return "*bool";
-        }
-        return "interface{}";
-    }
-
-    private static String goValueTypeForType(software.amazon.smithy.rulesengine.language.evaluation.type.Type type) {
-        if (type instanceof software.amazon.smithy.rulesengine.language.evaluation.type.StringType) {
-            return "string";
-        }
-        if (type instanceof software.amazon.smithy.rulesengine.language.evaluation.type.BooleanType) {
-            return "bool";
-        }
-        return "interface{}";
+        return SymbolUtils.pointerTo(ExpressionGenerator.goTypeForType(type));
     }
 
     private static boolean isConditionalFnResultOptional(Condition condition, Expression fn) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointBddResolverGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointBddResolverGenerator.java
@@ -1,0 +1,620 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.go.codegen.endpoints;
+
+import static software.amazon.smithy.go.codegen.GoWriter.emptyGoTemplate;
+import static software.amazon.smithy.go.codegen.GoWriter.goBlockTemplate;
+import static software.amazon.smithy.go.codegen.GoWriter.goDocTemplate;
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+import static software.amazon.smithy.go.codegen.GoWriter.joinWritables;
+import static software.amazon.smithy.go.codegen.endpoints.EndpointParametersGenerator.getExportedParameterName;
+import static software.amazon.smithy.go.codegen.endpoints.FnGenerator.isFnResultOptional;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.ChainWritable;
+import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.SymbolUtils;
+import software.amazon.smithy.go.codegen.Writable;
+import software.amazon.smithy.rulesengine.language.Endpoint;
+import software.amazon.smithy.rulesengine.language.evaluation.type.OptionalType;
+import software.amazon.smithy.rulesengine.language.syntax.Identifier;
+import software.amazon.smithy.rulesengine.language.syntax.expressions.Expression;
+import software.amazon.smithy.rulesengine.language.syntax.expressions.ExpressionVisitor;
+import software.amazon.smithy.rulesengine.language.syntax.expressions.Reference;
+import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.FunctionDefinition;
+import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.IsSet;
+import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.LibraryFunction;
+import software.amazon.smithy.rulesengine.language.syntax.expressions.literal.Literal;
+import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter;
+import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameters;
+import software.amazon.smithy.rulesengine.language.syntax.rule.Condition;
+import software.amazon.smithy.rulesengine.language.syntax.rule.EndpointRule;
+import software.amazon.smithy.rulesengine.language.syntax.rule.ErrorRule;
+import software.amazon.smithy.rulesengine.language.syntax.rule.Rule;
+import software.amazon.smithy.rulesengine.traits.EndpointBddTrait;
+import software.amazon.smithy.rulesengine.logic.bdd.Bdd;
+import software.amazon.smithy.utils.MapUtils;
+
+/**
+ * Generates a BDD-based endpoint resolver for Go.
+ *
+ * <p>Reads an {@link EndpointBddTrait} and emits:
+ * <ol>
+ *   <li>Node array literal + root constant</li>
+ *   <li>{@code conditionContext} struct for condition-assigned values</li>
+ *   <li>{@code evalCondition} switch dispatching each BDD condition</li>
+ *   <li>{@code resolveResult} switch dispatching each BDD result</li>
+ *   <li>{@code ResolveEndpoint} method wiring the BDD evaluator</li>
+ *   <li>Resolver type boilerplate (interface, struct, constructor)</li>
+ * </ol>
+ */
+public final class EndpointBddResolverGenerator {
+    private static final String PARAMS_ARG_NAME = "params";
+    private static final String CTX_ARG_NAME = "c";
+
+    private final FnProvider fnProvider;
+    private final Symbol endpointType;
+    private final Symbol parametersType;
+    private final Symbol resolverInterfaceType;
+    private final Symbol resolverImplementationType;
+    private final Symbol newResolverFn;
+    private final String resolveEndpointMethodName;
+
+    public EndpointBddResolverGenerator(FnProvider fnProvider) {
+        this.fnProvider = fnProvider;
+        this.endpointType = SymbolUtils.createValueSymbolBuilder("Endpoint",
+                SmithyGoDependency.SMITHY_ENDPOINTS).build();
+        this.parametersType = SymbolUtils.createValueSymbolBuilder(
+                EndpointResolutionGenerator.PARAMETERS_TYPE_NAME).build();
+        this.resolverInterfaceType = SymbolUtils.createValueSymbolBuilder(
+                EndpointResolutionGenerator.RESOLVER_INTERFACE_NAME).build();
+        this.resolverImplementationType = SymbolUtils.createValueSymbolBuilder(
+                EndpointResolutionGenerator.RESOLVER_IMPLEMENTATION_NAME).build();
+        this.newResolverFn = SymbolUtils.createValueSymbolBuilder(
+                EndpointResolutionGenerator.NEW_RESOLVER_FUNC_NAME).build();
+        this.resolveEndpointMethodName = EndpointResolutionGenerator.RESOLVER_ENDPOINT_METHOD_NAME;
+    }
+
+    /**
+     * Generate the full BDD resolver from the trait.
+     */
+    public Writable generate(EndpointBddTrait trait) {
+        var bdd = trait.getBdd();
+        var conditions = trait.getConditions();
+        var results = trait.getResults();
+        var parameters = trait.getParameters();
+
+        // Build a scope that maps parameter references to "params.FieldName" (pointer form, for isSet)
+        var ptrScope = Scope.empty();
+        // Build a scope that maps parameter references to dereferenced form (for value access)
+        var derefScope = Scope.empty();
+        for (Iterator<Parameter> iter = parameters.iterator(); iter.hasNext();) {
+            Parameter p = iter.next();
+            var ptrName = PARAMS_ARG_NAME + "." + getExportedParameterName(p);
+            ptrScope = ptrScope.withIdent(p.toExpression(), ptrName);
+            derefScope = derefScope.withIdent(p.toExpression(), "*" + ptrName);
+        }
+        // Add condition-assigned vars to ptrScope (pointer form, no deref)
+        for (var cond : conditions) {
+            if (cond.getResult().isPresent()) {
+                var ident = cond.getResult().get();
+                var ref = new Reference(ident, cond.getSourceLocation());
+                ptrScope = ptrScope.withIdent(ref, CTX_ARG_NAME + "." + condFieldName(cond));
+            }
+        }
+
+        // Build a scope that also includes condition-assigned variables mapped to "c.fieldName"
+        var condScope = buildConditionScope(derefScope, conditions);
+
+        return goTemplate("""
+                $stringSlice:W
+
+                $nodeArray:W
+
+                $conditionContext:W
+
+                $evalCondition:W
+
+                $resolveResult:W
+
+                $resolverType:W
+                """,
+                MapUtils.of(
+                        "stringSlice", generateStringSliceHelper(),
+                        "nodeArray", generateNodeArray(bdd),
+                        "conditionContext", generateConditionContext(conditions),
+                        "evalCondition", generateEvalCondition(conditions, ptrScope, condScope),
+                        "resolveResult", generateResolveResult(results, condScope),
+                        "resolverType", generateResolverType(parameters)));
+    }
+
+    // ---- Component 0: stringSlice helper ----
+
+    private Writable generateStringSliceHelper() {
+        return goTemplate("""
+                type stringSlice []string
+
+                func (s stringSlice) Get(i int) *string {
+                    if i < 0 || i >= len(s) {
+                        return nil
+                    }
+
+                    v := s[i]
+                    return &v
+                }""");
+    }
+
+    // ---- Component 1: Node array ----
+
+    private Writable generateNodeArray(Bdd bdd) {
+        return (GoWriter w) -> {
+            w.write("const bddRoot int32 = $L", bdd.getRootRef());
+            w.openBlock("var bddNodes = [$L]int32{", "}", bdd.getNodeCount() * 3, () -> {
+                bdd.getNodes((varIdx, high, low) -> {
+                    w.writeInline("$L, $L, $L, ", varIdx, high, low);
+                });
+            });
+        };
+    }
+
+    // ---- Component 2: conditionContext struct ----
+
+    private Writable generateConditionContext(List<Condition> conditions) {
+        return (GoWriter w) -> {
+            w.openBlock("type conditionContext struct {", "}", () -> {
+                for (int i = 0; i < conditions.size(); i++) {
+                    var cond = conditions.get(i);
+                    if (cond.getResult().isEmpty()) {
+                        continue;
+                    }
+                    var fieldName = condFieldName(cond);
+                    var goType = goTypeForConditionFn(cond);
+                    w.write("$L $L", fieldName, goType);
+                }
+            });
+        };
+    }
+
+    // ---- Component 3: evalCondition switch ----
+
+    private Writable generateEvalCondition(List<Condition> conditions, Scope paramScope, Scope condScope) {
+        return (GoWriter w) -> {
+            w.openBlock(
+                    "func evalCondition(idx int, $L *$T, $L *conditionContext) bool {",
+                    "}",
+                    PARAMS_ARG_NAME, parametersType, CTX_ARG_NAME,
+                    () -> {
+                        w.openBlock("switch idx {", "}", () -> {
+                            for (int i = 0; i < conditions.size(); i++) {
+                                w.write("case $L:", i);
+                                w.indent();
+                                w.write("$W", generateConditionCase(conditions.get(i), i, paramScope, condScope));
+                                w.dedent();
+                            }
+                        });
+                        w.write("return false");
+                    });
+        };
+    }
+
+    private Writable generateConditionCase(Condition condition, int idx, Scope paramScope, Scope condScope) {
+        var fn = condition.getFunction();
+
+        // For isSet conditions: check if the parameter is non-nil
+        if (fn.getName().equals("isSet")) {
+            var inner = fn.getArguments().get(0);
+            var generator = new ExpressionGenerator(paramScope, fnProvider);
+            if (condition.getResult().isPresent()) {
+                // isSet with assign: store value and return true if non-nil
+                return goTemplate("""
+                        if v := $target:W; v != nil {
+                            $ctx:L.$field:L = v
+                            return true
+                        }
+                        return false
+                        """,
+                        MapUtils.of(
+                                "target", generator.generate(inner),
+                                "ctx", CTX_ARG_NAME,
+                                "field", condFieldName(condition)));
+            }
+            // isSet without assign: just check non-nil
+            return goTemplate("return $target:W != nil",
+                    MapUtils.of("target", generator.generate(inner)));
+        }
+
+        // For function calls that produce an optional result (e.g. parseURL, substring)
+        boolean isOptional = fn.type() instanceof OptionalType || isConditionalFnResultOptional(condition, fn);
+        var generator = new ExpressionGenerator(condScope, fnProvider);
+
+        if (condition.getResult().isPresent() && isOptional) {
+            return goTemplate("""
+                    if v := $target:W; v != nil {
+                        $ctx:L.$field:L = v
+                        return true
+                    }
+                    return false
+                    """,
+                    MapUtils.of(
+                            "target", generator.generate(fn),
+                            "ctx", CTX_ARG_NAME,
+                            "field", condFieldName(condition)));
+        }
+
+        if (condition.getResult().isPresent()) {
+            // Non-optional function with assign (e.g. uriEncode)
+            return goTemplate("""
+                    $ctx:L.$field:L = $target:W
+                    return true
+                    """,
+                    MapUtils.of(
+                            "target", generator.generate(fn),
+                            "ctx", CTX_ARG_NAME,
+                            "field", condFieldName(condition)));
+        }
+
+        // Boolean condition (no assign) — optional results need nil check
+        if (isOptional) {
+            return goTemplate("return $target:W != nil",
+                    MapUtils.of("target", generator.generate(fn)));
+        }
+        return goTemplate("return $target:W",
+                MapUtils.of("target", generator.generate(fn)));
+    }
+
+    // ---- Component 4: resolveResult switch ----
+
+    private Writable generateResolveResult(List<Rule> results, Scope scope) {
+        return (GoWriter w) -> {
+            w.addUseImports(SmithyGoDependency.FMT);
+            w.openBlock(
+                    "func resolveResult(idx int32, $L *$T, $L *conditionContext) ($T, error) {",
+                    "}",
+                    PARAMS_ARG_NAME, parametersType, CTX_ARG_NAME, endpointType,
+                    () -> {
+                        w.openBlock("switch idx {", "}", () -> {
+                            for (int i = 0; i < results.size(); i++) {
+                                w.write("case $L:", i);
+                                w.indent();
+                                w.write("$W", generateResultCase(results.get(i), scope));
+                                w.dedent();
+                            }
+                        });
+                        w.write("return $T{}, fmt.Errorf(\"endpoint rule error, invalid result index: %d\", idx)",
+                                endpointType);
+                    });
+        };
+    }
+
+    private Writable generateResultCase(Rule result, Scope scope) {
+        if (result instanceof ErrorRule errorRule) {
+            var generator = new ExpressionGenerator(scope, fnProvider);
+            return goTemplate(
+                    "return $endpointType:T{}, fmt.Errorf(\"endpoint rule error, %s\", $errorExpr:W)",
+                    MapUtils.of(
+                            "endpointType", endpointType,
+                            "errorExpr", generator.generate(errorRule.getError())));
+        }
+
+        if (result instanceof EndpointRule endpointRule) {
+            var endpoint = endpointRule.getEndpoint();
+            var generator = new ExpressionGenerator(scope, fnProvider);
+            return goTemplate("""
+                    uriString := $url:W
+                    uri, err := url.Parse(uriString)
+                    if err != nil {
+                        return $endpointType:T{}, fmt.Errorf("Failed to parse uri: %s", uriString)
+                    }
+                    return $endpoint:W, nil
+                    """,
+                    MapUtils.of(
+                            "endpointType", endpointType,
+                            "url", generator.generate(endpoint.getUrl()),
+                            "endpoint", generateEndpoint(endpoint, scope)));
+        }
+
+        // NoMatchRule (index 0)
+        return goTemplate(
+                "return $endpointType:T{}, fmt.Errorf(\"endpoint resolution failed: no matching rule\")",
+                MapUtils.of("endpointType", endpointType));
+    }
+
+    private Writable generateEndpoint(Endpoint endpoint, Scope scope) {
+        return goTemplate("""
+                $endpointType:T{
+                    URI: *uri,
+                    $headers:W
+                    $properties:W
+                }
+                """,
+                MapUtils.of(
+                        "endpointType", endpointType,
+                        "headers", generateEndpointHeaders(endpoint.getHeaders(), scope),
+                        "properties", generateEndpointProperties(endpoint.getProperties(), scope)));
+    }
+
+    private Writable generateEndpointHeaders(Map<String, List<Expression>> headers, Scope scope) {
+        if (headers.isEmpty()) {
+            return goTemplate("Headers: $T,",
+                    SymbolUtils.createValueSymbolBuilder("Header{}", SmithyGoDependency.NET_HTTP).build());
+        }
+
+        var generator = new ExpressionGenerator(scope, fnProvider);
+        var writableHeaders = new TreeMap<String, List<Writable>>();
+        headers.forEach((k, vs) -> {
+            var writables = new ArrayList<Writable>();
+            vs.forEach(v -> writables.add(generator.generate(v)));
+            writableHeaders.put(k, writables);
+        });
+
+        return goBlockTemplate("Headers: func() $headerType:T {", "}(),",
+                MapUtils.of(
+                        "headerType", SymbolUtils.createPointableSymbolBuilder("Header",
+                                SmithyGoDependency.NET_HTTP).build()),
+                (w) -> {
+                    w.write("headers := $T{}",
+                            SymbolUtils.createValueSymbolBuilder("Header", SmithyGoDependency.NET_HTTP).build());
+                    writableHeaders.forEach((k, vs) -> {
+                        w.write("headers.Set($S, $W)", k, joinWritables(vs, ", "));
+                    });
+                    w.write("return headers");
+                });
+    }
+
+    private Writable generateEndpointProperties(Map<Identifier, Literal> properties, Scope scope) {
+        if (properties.isEmpty()) {
+            return emptyGoTemplate();
+        }
+
+        var generator = new ExpressionGenerator(scope, fnProvider);
+        return goTemplate("""
+                Properties: func() $1T {
+                    var out $1T
+                    $2W
+                    return out
+                }(),
+                """,
+                SmithyGoDependency.SMITHY.struct("Properties"),
+                ChainWritable.of(
+                        properties.entrySet().stream()
+                                .map(it -> generateSetProperty(generator, it.getKey(), it.getValue()))
+                                .toList()
+                ).compose(false));
+    }
+
+    private Writable generateSetProperty(ExpressionGenerator generator, Identifier ident, Expression expr) {
+        return ident.toString().equals("authSchemes")
+                ? new AuthSchemePropertyGenerator(generator).generate(expr)
+                : goTemplate("out.Set($S, $W)", ident.toString(), generator.generate(expr));
+    }
+
+    // ---- Component 5 & 6: ResolveEndpoint method + resolver type boilerplate ----
+
+    private Writable generateResolverType(Parameters parameters) {
+        var hasRequired = EndpointParametersGenerator.haveRequiredParameters(parameters);
+
+        return goTemplate("""
+                // $resolverInterfaceType:T provides the interface for resolving service endpoints.
+                type $resolverInterfaceType:T interface {
+                    $resolveEndpointMethodName:L(ctx $context:T, $paramArgName:L $parametersType:T) (
+                        $endpointType:T, error,
+                    )
+                }
+
+                // $resolverImplementationType:T provides the implementation for resolving endpoints.
+                type $resolverImplementationType:T struct{}
+
+                func $newResolverFn:T() $resolverInterfaceType:T {
+                    return &$resolverImplementationType:T{}
+                }
+
+                // $resolveEndpointMethodName:L attempts to resolve the endpoint with the provided options,
+                // returning the endpoint if found. Otherwise an error is returned.
+                func (r *$resolverImplementationType:T) $resolveEndpointMethodName:L(
+                    ctx $context:T, $paramArgName:L $parametersType:T,
+                ) (
+                    endpoint $endpointType:T, err error,
+                ) {
+                    $paramArgName:L = $paramArgName:L.$withDefaults:L()
+                    $validateParams:W
+
+                    $ctx:L := &conditionContext{}
+                    ref := $bdd:T(bddNodes[:], bddRoot, func(idx int) bool {
+                        return evalCondition(idx, &$paramArgName:L, $ctx:L)
+                    })
+                    return resolveResult(ref, &$paramArgName:L, $ctx:L)
+                }
+                """,
+                MapUtils.of(
+                        "context", SymbolUtils.createValueSymbolBuilder("Context",
+                                SmithyGoDependency.CONTEXT).build(),
+                        "paramArgName", PARAMS_ARG_NAME,
+                        "parametersType", parametersType,
+                        "endpointType", endpointType,
+                        "resolverInterfaceType", resolverInterfaceType,
+                        "resolverImplementationType", resolverImplementationType,
+                        "newResolverFn", newResolverFn,
+                        "resolveEndpointMethodName", resolveEndpointMethodName,
+                        "withDefaults", EndpointParametersGenerator.DEFAULT_VALUE_FUNC_NAME,
+                        "ctx", CTX_ARG_NAME),
+                MapUtils.of(
+                        "bdd", SymbolUtils.createValueSymbolBuilder("Evaluate",
+                                SmithyGoDependency.SMITHY_ENDPOINT_BDD).build(),
+                        "validateParams", hasRequired
+                                ? goTemplate("""
+                                        if err = $paramArgName:L.$validate:L(); err != nil {
+                                            return endpoint, $fmtErrorf:T("endpoint parameters are not valid, %w", err)
+                                        }
+                                        """,
+                                        MapUtils.of(
+                                                "paramArgName", PARAMS_ARG_NAME,
+                                                "validate", EndpointParametersGenerator.VALIDATE_REQUIRED_FUNC_NAME,
+                                                "fmtErrorf", SymbolUtils.createValueSymbolBuilder("Errorf",
+                                                        SmithyGoDependency.FMT).build()))
+                                : emptyGoTemplate()));
+    }
+
+    // ---- Helpers ----
+
+    /**
+     * Build a scope that includes both parameter references and condition-assigned variable
+     * references pointing to conditionContext fields.
+     */
+    private Scope buildConditionScope(Scope paramScope, List<Condition> conditions) {
+        var scope = paramScope;
+        for (var cond : conditions) {
+            if (cond.getResult().isPresent()) {
+                var ident = cond.getResult().get();
+                var ref = new Reference(ident, cond.getSourceLocation());
+                var fieldAccess = CTX_ARG_NAME + "." + condFieldName(cond);
+
+                // Only dereference simple pointer fields (*string, *bool).
+                // Struct pointers (*PartitionConfig, *URL, *ARN) auto-deref in Go for field access.
+                var goType = goTypeForConditionFn(cond);
+                if (goType.equals("*string") || goType.equals("*bool")) {
+                    fieldAccess = "*" + fieldAccess;
+                }
+
+                scope = scope.withIdent(ref, fieldAccess);
+            }
+        }
+        return scope;
+    }
+
+    /**
+     * Derive the Go struct field name for a condition's assigned result.
+     */
+    private static String condFieldName(Condition condition) {
+        return condition.getResult()
+                .map(ident -> ident.getName().getValue())
+                .orElseThrow(() -> new IllegalStateException("condition has no result identifier"));
+    }
+
+    /**
+     * Determine the Go type string for a condition function's return value.
+     * This is used for the conditionContext struct fields.
+     */
+    private String goTypeForConditionFn(Condition condition) {
+        var fn = condition.getFunction();
+
+        // isSet stores the pointer value directly — type comes from the inner expression
+        if (fn instanceof IsSet) {
+            var inner = ((IsSet) fn).getArguments().get(0);
+            return goTypeForExpression(inner);
+        }
+
+        // Derive Go type from the function's return type
+        var fnDef = fn.getFunctionDefinition();
+        var fnId = fnDef.getId();
+
+        // Look up the Go function symbol to determine its return type
+        Symbol goFn = fnProvider.fnFor(fnId);
+        if (goFn == null) {
+            goFn = new FnGenerator.DefaultFnProvider().fnFor(fnId);
+        }
+
+        if (goFn != null) {
+            return goReturnTypeForFn(fnId, fn.type());
+        }
+
+        // Fallback based on Smithy type
+        var type = fn.type();
+        if (type instanceof OptionalType opt) {
+            return goTypeForType(opt.inner());
+        }
+        return goValueTypeForType(type);
+    }
+
+    /**
+     * Map known function IDs to their Go return types for conditionContext fields.
+     */
+    private static String goReturnTypeForFn(String fnId,
+            software.amazon.smithy.rulesengine.language.evaluation.type.Type smithyType) {
+        return switch (fnId) {
+            // These return pointers — stored as-is in conditionContext
+            case "parseURL" -> "*rulesfn.URL";
+            case "substring" -> "*string";
+            case "aws.parseArn" -> "*awsrulesfn.ARN";
+            case "aws.partition" -> "*awsrulesfn.PartitionConfig";
+            // These return values
+            case "isValidHostLabel" -> "bool";
+            case "uriEncode" -> "string";
+            case "split" -> "[]string";
+            case "aws.isVirtualHostableS3Bucket" -> "bool";
+            // BDD-specific: ite and coalesce return values based on their Smithy type
+            case "ite", "coalesce" -> {
+                var type = smithyType instanceof OptionalType opt ? opt.inner() : smithyType;
+                yield goValueTypeForType(type);
+            }
+            default -> "any";
+        };
+    }
+
+    private static String goTypeForExpression(Expression expr) {
+        var type = expr.type();
+        if (type instanceof OptionalType opt) {
+            return goTypeForType(opt.inner());
+        }
+        return goTypeForType(type);
+    }
+
+    private static String goTypeForType(software.amazon.smithy.rulesengine.language.evaluation.type.Type type) {
+        if (type instanceof software.amazon.smithy.rulesengine.language.evaluation.type.StringType) {
+            return "*string";
+        }
+        if (type instanceof software.amazon.smithy.rulesengine.language.evaluation.type.BooleanType) {
+            return "*bool";
+        }
+        return "interface{}";
+    }
+
+    private static String goValueTypeForType(software.amazon.smithy.rulesengine.language.evaluation.type.Type type) {
+        if (type instanceof software.amazon.smithy.rulesengine.language.evaluation.type.StringType) {
+            return "string";
+        }
+        if (type instanceof software.amazon.smithy.rulesengine.language.evaluation.type.BooleanType) {
+            return "bool";
+        }
+        return "interface{}";
+    }
+
+    private static boolean isConditionalFnResultOptional(Condition condition, Expression fn) {
+        if (condition.getResult().isEmpty()) {
+            return false;
+        }
+        final boolean[] isOptionalResult = {false};
+        fn.accept(new ExpressionVisitor.Default<Void>() {
+            @Override
+            public Void getDefault() {
+                return null;
+            }
+
+            @Override
+            public Void visitLibraryFunction(FunctionDefinition fnDef, List<Expression> args) {
+                isOptionalResult[0] = isFnResultOptional(fnDef);
+                return null;
+            }
+        });
+        return isOptionalResult[0];
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointBddResolverGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointBddResolverGenerator.java
@@ -45,6 +45,7 @@ import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.
 import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.LibraryFunction;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.literal.Literal;
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter;
+import software.amazon.smithy.rulesengine.language.syntax.parameters.ParameterType;
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameters;
 import software.amazon.smithy.rulesengine.language.syntax.rule.Condition;
 import software.amazon.smithy.rulesengine.language.syntax.rule.EndpointRule;
@@ -117,7 +118,7 @@ public final class EndpointBddResolverGenerator {
             Parameter p = iter.next();
             var ptrName = PARAMS_ARG_NAME + "." + getExportedParameterName(p);
             ptrScope = ptrScope.withIdent(p.toExpression(), ptrName);
-            derefScope = derefScope.withIdent(p.toExpression(), "*" + ptrName);
+            derefScope = derefScope.withIdent(p.toExpression(), derefParam(p, ptrName));
         }
         // Add condition-assigned vars to ptrScope (pointer form, no deref)
         for (var cond : conditions) {
@@ -145,7 +146,8 @@ public final class EndpointBddResolverGenerator {
                 $resolverType:W
                 """,
                 MapUtils.of(
-                        "stringSlice", generateStringSliceHelper(),
+                        "stringSlice", needsStringSlice(conditions, parameters)
+                                ? EndpointResolverGenerator.generateStringSliceHelper() : emptyGoTemplate(),
                         "nodeArray", generateNodeArray(bdd),
                         "conditionContext", generateConditionContext(conditions),
                         "evalCondition", generateEvalCondition(conditions, ptrScope, condScope),
@@ -153,20 +155,22 @@ public final class EndpointBddResolverGenerator {
                         "resolverType", generateResolverType(parameters)));
     }
 
-    // ---- Component 0: stringSlice helper ----
+    // STRING_ARRAY is the only array parameter type in the Smithy rules engine
+    // (see https://smithy.io/2.0/additional-specs/rules-engine/parameters.html).
+    // It maps to []string in Go, which needs a stringSlice cast for .Get() index access.
+    private static String derefParam(Parameter p, String ptrName) {
+        return p.getType() == ParameterType.STRING_ARRAY
+                ? "stringSlice(" + ptrName + ")"
+                : "*" + ptrName;
+    }
 
-    private Writable generateStringSliceHelper() {
-        return goTemplate("""
-                type stringSlice []string
-
-                func (s stringSlice) Get(i int) *string {
-                    if i < 0 || i >= len(s) {
-                        return nil
-                    }
-
-                    v := s[i]
-                    return &v
-                }""");
+    private static boolean needsStringSlice(List<Condition> conditions, Parameters parameters) {
+        for (Iterator<Parameter> iter = parameters.iterator(); iter.hasNext();) {
+            if (iter.next().getType() == ParameterType.STRING_ARRAY) {
+                return true;
+            }
+        }
+        return conditions.stream().anyMatch(c -> c.getFunction().getName().equals("split"));
     }
 
     // ---- Component 1: Node array ----

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointBddResolverGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointBddResolverGenerator.java
@@ -209,7 +209,7 @@ public final class EndpointBddResolverGenerator {
                             for (int i = 0; i < conditions.size(); i++) {
                                 w.write("case $L:", i);
                                 w.indent();
-                                w.write("$W", generateConditionCase(conditions.get(i), i, paramScope, condScope));
+                                w.write(" $W", generateConditionCase(conditions.get(i), i, paramScope, condScope));
                                 w.dedent();
                             }
                         });

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointClientPluginsGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointClientPluginsGenerator.java
@@ -28,7 +28,9 @@ import software.amazon.smithy.go.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.rulesengine.language.EndpointRuleSet;
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter;
+import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameters;
 import software.amazon.smithy.rulesengine.traits.ClientContextParamsTrait;
+import software.amazon.smithy.rulesengine.traits.EndpointBddTrait;
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.StringUtils;
@@ -76,13 +78,19 @@ public class EndpointClientPluginsGenerator implements GoIntegration {
     @Override
     public void processFinalizedModel(GoSettings settings, Model model) {
         var service = settings.getService(model);
-        if (!service.hasTrait(EndpointRuleSetTrait.class) || !service.hasTrait(ClientContextParamsTrait.class)) {
+        if ((!service.hasTrait(EndpointRuleSetTrait.class) && !service.hasTrait(EndpointBddTrait.class))
+                || !service.hasTrait(ClientContextParamsTrait.class)) {
             return;
         }
 
-        var ruleset = EndpointRuleSet.fromNode(service.expectTrait(EndpointRuleSetTrait.class).getRuleSet());
+        Parameters parameters;
+        if (service.hasTrait(EndpointRuleSetTrait.class)) {
+            parameters = EndpointRuleSet.fromNode(
+                    service.expectTrait(EndpointRuleSetTrait.class).getRuleSet()).getParameters();
+        } else {
+            parameters = service.expectTrait(EndpointBddTrait.class).getParameters();
+        }
         var ccParams = service.expectTrait(ClientContextParamsTrait.class).getParameters();
-        var parameters = ruleset.getParameters();
         parameters.forEach(param -> {
             var ccParam = ccParams.get(param.getName().getName().getValue());
             if (ccParam == null || param.getBuiltIn().isPresent()) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointParameterBindingsGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointParameterBindingsGenerator.java
@@ -27,6 +27,7 @@ import software.amazon.smithy.go.codegen.Writable;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter;
 import software.amazon.smithy.rulesengine.traits.ClientContextParamsTrait;
+import software.amazon.smithy.rulesengine.traits.EndpointBddTrait;
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
 import software.amazon.smithy.utils.MapUtils;
 
@@ -70,6 +71,7 @@ public class EndpointParameterBindingsGenerator {
                 MapUtils.of(
                         "context", GoStdlibTypes.Context.Context,
                         "builtinBindings", context.getService().hasTrait(EndpointRuleSetTrait.class)
+                                || context.getService().hasTrait(EndpointBddTrait.class)
                                 ? generateBuiltinBindings()
                                 : emptyGoTemplate(),
                         "clientContextBindings", generateClientContextBindings()

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointParameterOperationBindingsGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointParameterOperationBindingsGenerator.java
@@ -28,9 +28,7 @@ import software.amazon.smithy.jmespath.JmespathExpression;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.StructureShape;
-import software.amazon.smithy.rulesengine.language.EndpointRuleSet;
 import software.amazon.smithy.rulesengine.traits.ContextParamTrait;
-import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
 import software.amazon.smithy.rulesengine.traits.OperationContextParamDefinition;
 import software.amazon.smithy.rulesengine.traits.OperationContextParamsTrait;
 import software.amazon.smithy.rulesengine.traits.StaticContextParamDefinition;
@@ -45,8 +43,6 @@ public class EndpointParameterOperationBindingsGenerator {
     private final OperationShape operation;
     private final StructureShape input;
 
-    private final EndpointRuleSet rules;
-
     public EndpointParameterOperationBindingsGenerator(
             GoCodegenContext ctx,
             OperationShape operation,
@@ -55,10 +51,6 @@ public class EndpointParameterOperationBindingsGenerator {
         this.ctx = ctx;
         this.operation = operation;
         this.input = input;
-
-        this.rules = ctx.settings().getService(ctx.model())
-                .expectTrait(EndpointRuleSetTrait.class)
-                .getEndpointRuleSet();
     }
 
     private boolean hasBindings() {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolutionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolutionGenerator.java
@@ -25,6 +25,7 @@ import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.go.codegen.SymbolUtils;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.rulesengine.language.EndpointRuleSet;
+import software.amazon.smithy.rulesengine.traits.EndpointBddTrait;
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
 import software.amazon.smithy.rulesengine.traits.EndpointTestCase;
 import software.amazon.smithy.rulesengine.traits.EndpointTestsTrait;
@@ -87,6 +88,26 @@ public class EndpointResolutionGenerator {
         var bindingGenerator = new EndpointParameterBindingsGenerator(context);
         var middlewareGenerator = new EndpointMiddlewareGenerator(context);
 
+        // Prefer BDD trait over tree-based ruleset when available
+        var bddTrait = serviceShape.getTrait(EndpointBddTrait.class);
+        if (bddTrait.isPresent()) {
+            Optional<EndpointRuleSet> ruleset = serviceShape.getTrait(EndpointRuleSetTrait.class)
+                    .map((trait) -> EndpointRuleSet.fromNode(trait.getRuleSet()));
+            if (ruleset.isEmpty()) {
+                ruleset = Optional.of(EndpointRuleSet.builder()
+                        .version(bddTrait.get().getVersion().toString())
+                        .parameters(bddTrait.get().getParameters())
+                        .build());
+            }
+            var bddResolver = new EndpointBddResolverGenerator(this.fnProvider);
+            writer
+                    .write("$W\n", parametersGenerator.generate(ruleset))
+                    .write("$W\n", bddResolver.generate(bddTrait.get()))
+                    .write("$W\n", bindingGenerator.generate())
+                    .write("$W", middlewareGenerator.generate());
+            return;
+        }
+
         Optional<EndpointRuleSet> ruleset = serviceShape.getTrait(EndpointRuleSetTrait.class)
                 .map((trait) -> EndpointRuleSet.fromNode(trait.getRuleSet()));
 
@@ -106,6 +127,13 @@ public class EndpointResolutionGenerator {
         var serviceShape = context.getService();
         Optional<EndpointRuleSet> ruleset = serviceShape.getTrait(EndpointRuleSetTrait.class)
                 .map((trait) -> EndpointRuleSet.fromNode(trait.getRuleSet()));
+        if (ruleset.isEmpty()) {
+            ruleset = serviceShape.getTrait(EndpointBddTrait.class)
+                    .map((trait) -> EndpointRuleSet.builder()
+                            .version(trait.getVersion().toString())
+                            .parameters(trait.getParameters())
+                            .build());
+        }
 
         var testsGenerator = EndpointTestsGenerator.builder()
             .parametersType(parametersType)

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolverGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolverGenerator.java
@@ -605,7 +605,7 @@ public final class EndpointResolverGenerator {
         }
     }
 
-    private Writable generateStringSliceHelper() {
+    static Writable generateStringSliceHelper() {
         return goTemplate("""
                 type stringSlice []string
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/ExpressionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/ExpressionGenerator.java
@@ -29,8 +29,12 @@ import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.go.codegen.SymbolUtils;
 import software.amazon.smithy.go.codegen.Writable;
 import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.rulesengine.language.evaluation.type.AnyType;
+import software.amazon.smithy.rulesengine.language.evaluation.type.ArrayType;
 import software.amazon.smithy.rulesengine.language.evaluation.type.OptionalType;
 import software.amazon.smithy.rulesengine.language.syntax.Identifier;
+import software.amazon.smithy.rulesengine.language.evaluation.type.Type;
+import software.amazon.smithy.rulesengine.language.evaluation.type.StringType;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.Expression;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.ExpressionVisitor;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.Reference;
@@ -310,13 +314,21 @@ final class ExpressionGenerator {
         return StringUtils.capitalize(ident.getName().toString());
     }
 
-    static Symbol goTypeForType(
-            software.amazon.smithy.rulesengine.language.evaluation.type.Type type) {
-        if (type instanceof software.amazon.smithy.rulesengine.language.evaluation.type.StringType) {
+    static Symbol goTypeForType(Type type) {
+        if (type instanceof StringType) {
             return GoUniverseTypes.String;
         }
         if (type instanceof software.amazon.smithy.rulesengine.language.evaluation.type.BooleanType) {
             return GoUniverseTypes.Bool;
+        }
+        if (type instanceof ArrayType arr) {
+            return SymbolUtils.sliceOf(goTypeForType(arr.getMember()));
+        }
+        if (type instanceof OptionalType opt) {
+            return SymbolUtils.pointerTo(goTypeForType(opt.inner()));
+        }
+        if (type instanceof AnyType) {
+            return GoUniverseTypes.Any;
         }
         throw new UnsupportedOperationException("unsupported Smithy type for Go mapping: " + type);
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/ExpressionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/ExpressionGenerator.java
@@ -21,6 +21,7 @@ import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import software.amazon.smithy.go.codegen.ChainWritable;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.go.codegen.SymbolUtils;
@@ -146,43 +147,69 @@ final class ExpressionGenerator {
 
         @Override
         public Writable visitCoalesce(List<Expression> expressions) {
-            // coalesce(a, b) → if a is non-nil use *a, else use b
-            // The first expression is optional (pointer), the second is the default value.
-            if (expressions.size() == 2) {
-                var first = expressions.get(0);
-                var second = expressions.get(1);
-                var resultType = second.type();
-                if (resultType instanceof OptionalType opt) {
-                    resultType = opt.inner();
-                }
-                var goType = goTypeNameForType(resultType);
-
-                // For the first arg, we need the pointer form (no dereference) to nil-check.
-                // Strip leading "*" if the scope added one.
-                var generator = new ExpressionGenerator(scope, fnProvider);
-                var firstWritable = generator.generate(first);
-                var optIdent = scope.getIdent(first);
-                if (optIdent.isPresent() && optIdent.get().startsWith("*")) {
-                    // Use the pointer form (without the leading *)
-                    var ptrIdent = optIdent.get().substring(1);
-                    firstWritable = goTemplate(ptrIdent);
-                }
-
-                var finalFirst = firstWritable;
-                return goTemplate("""
-                        func() $goType:L {
-                            if v := $first:W; v != nil {
-                                return *v
-                            }
-                            return $second:W
-                        }()""",
-                        MapUtils.of(
-                                "goType", goType,
-                                "first", finalFirst,
-                                "second", generator.generate(second)));
+            if (expressions.size() == 1) {
+                return new ExpressionGenerator(scope, fnProvider).generate(expressions.get(0));
             }
-            // Fallback: just generate the first expression
-            return new ExpressionGenerator(scope, fnProvider).generate(expressions.get(0));
+
+            var generator = new ExpressionGenerator(scope, fnProvider);
+            boolean allOptional = expressions.stream()
+                    .allMatch(e -> e.type() instanceof OptionalType);
+
+            // determine the inner value type from the first expression
+            var firstType = expressions.get(0).type();
+            var innerType = firstType instanceof OptionalType opt ? opt.inner() : firstType;
+            var goType = goTypeNameForType(innerType);
+
+            // build the chain of if-statements for each arg
+            var checks = new java.util.ArrayList<Writable>();
+            for (int i = 0; i < expressions.size(); i++) {
+                var expr = expressions.get(i);
+                boolean isOptional = expr.type() instanceof OptionalType;
+                boolean isLast = i == expressions.size() - 1;
+
+                if (!isOptional) {
+                    // required arg: just return it, nothing after matters
+                    checks.add(goTemplate("return $val:W",
+                            Map.of("val", generator.generate(expr))));
+                    break;
+                }
+
+                // optional arg: get pointer form for nil-check
+                var valWritable = generator.generate(expr);
+                var optIdent = scope.getIdent(expr);
+                if (optIdent.isPresent() && optIdent.get().startsWith("*")) {
+                    valWritable = goTemplate(optIdent.get().substring(1));
+                }
+
+                if (isLast) {
+                    // last arg and optional: return as-is (pointer)
+                    checks.add(goTemplate("return $val:W",
+                            Map.of("val", valWritable)));
+                } else if (allOptional) {
+                    // optional, not last, result is pointer: return pointer if non-nil
+                    checks.add(goTemplate("""
+                            if v := $val:W; v != nil {
+                                return v
+                            }""",
+                            Map.of("val", valWritable)));
+                } else {
+                    // optional, not last, result is value: deref if non-nil
+                    checks.add(goTemplate("""
+                            if v := $val:W; v != nil {
+                                return *v
+                            }""",
+                            Map.of("val", valWritable)));
+                }
+            }
+
+            var retType = allOptional ? "*" + goType : goType;
+            return goTemplate("""
+                    func() $retType:L {
+                        $checks:W
+                    }()""",
+                    MapUtils.of(
+                            "retType", retType,
+                            "checks", ChainWritable.of(checks).compose(false)));
         }
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/ExpressionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/ExpressionGenerator.java
@@ -21,7 +21,9 @@ import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.go.codegen.ChainWritable;
+import software.amazon.smithy.go.codegen.GoUniverseTypes;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.go.codegen.SymbolUtils;
@@ -130,9 +132,9 @@ final class ExpressionGenerator {
             if (resultType instanceof OptionalType opt) {
                 resultType = opt.inner();
             }
-            var goType = goTypeNameForType(resultType);
+            var goType = goTypeForType(resultType);
             return goTemplate("""
-                    func() $goType:L {
+                    func() $goType:T {
                         if $cond:W {
                             return $trueVal:W
                         }
@@ -158,7 +160,7 @@ final class ExpressionGenerator {
             // determine the inner value type from the first expression
             var firstType = expressions.get(0).type();
             var innerType = firstType instanceof OptionalType opt ? opt.inner() : firstType;
-            var goType = goTypeNameForType(innerType);
+            var goType = goTypeForType(innerType);
 
             // build the chain of if-statements for each arg
             var checks = new java.util.ArrayList<Writable>();
@@ -202,9 +204,9 @@ final class ExpressionGenerator {
                 }
             }
 
-            var retType = allOptional ? "*" + goType : goType;
+            var retType = allOptional ? SymbolUtils.pointerTo(goType) : goType;
             return goTemplate("""
-                    func() $retType:L {
+                    func() $retType:P {
                         $checks:W
                     }()""",
                     MapUtils.of(
@@ -308,14 +310,14 @@ final class ExpressionGenerator {
         return StringUtils.capitalize(ident.getName().toString());
     }
 
-    static String goTypeNameForType(
+    static Symbol goTypeForType(
             software.amazon.smithy.rulesengine.language.evaluation.type.Type type) {
         if (type instanceof software.amazon.smithy.rulesengine.language.evaluation.type.StringType) {
-            return "string";
+            return GoUniverseTypes.String;
         }
         if (type instanceof software.amazon.smithy.rulesengine.language.evaluation.type.BooleanType) {
-            return "bool";
+            return GoUniverseTypes.Bool;
         }
-        return "any";
+        throw new UnsupportedOperationException("unsupported Smithy type for Go mapping: " + type);
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/ExpressionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/ExpressionGenerator.java
@@ -26,6 +26,7 @@ import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.go.codegen.SymbolUtils;
 import software.amazon.smithy.go.codegen.Writable;
 import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.rulesengine.language.evaluation.type.OptionalType;
 import software.amazon.smithy.rulesengine.language.syntax.Identifier;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.Expression;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.ExpressionVisitor;
@@ -119,6 +120,69 @@ final class ExpressionGenerator {
         @Override
         public Writable visitLibraryFunction(FunctionDefinition fnDef, List<Expression> args) {
             return new FnGenerator(scope, fnProvider).generate(fnDef, args);
+        }
+
+        @Override
+        public Writable visitIte(Expression condition, Expression trueValue, Expression falseValue) {
+            var generator = new ExpressionGenerator(scope, fnProvider);
+            var resultType = trueValue.type();
+            if (resultType instanceof OptionalType opt) {
+                resultType = opt.inner();
+            }
+            var goType = goTypeNameForType(resultType);
+            return goTemplate("""
+                    func() $goType:L {
+                        if $cond:W {
+                            return $trueVal:W
+                        }
+                        return $falseVal:W
+                    }()""",
+                    MapUtils.of(
+                            "goType", goType,
+                            "cond", generator.generate(condition),
+                            "trueVal", generator.generate(trueValue),
+                            "falseVal", generator.generate(falseValue)));
+        }
+
+        @Override
+        public Writable visitCoalesce(List<Expression> expressions) {
+            // coalesce(a, b) → if a is non-nil use *a, else use b
+            // The first expression is optional (pointer), the second is the default value.
+            if (expressions.size() == 2) {
+                var first = expressions.get(0);
+                var second = expressions.get(1);
+                var resultType = second.type();
+                if (resultType instanceof OptionalType opt) {
+                    resultType = opt.inner();
+                }
+                var goType = goTypeNameForType(resultType);
+
+                // For the first arg, we need the pointer form (no dereference) to nil-check.
+                // Strip leading "*" if the scope added one.
+                var generator = new ExpressionGenerator(scope, fnProvider);
+                var firstWritable = generator.generate(first);
+                var optIdent = scope.getIdent(first);
+                if (optIdent.isPresent() && optIdent.get().startsWith("*")) {
+                    // Use the pointer form (without the leading *)
+                    var ptrIdent = optIdent.get().substring(1);
+                    firstWritable = goTemplate(ptrIdent);
+                }
+
+                var finalFirst = firstWritable;
+                return goTemplate("""
+                        func() $goType:L {
+                            if v := $first:W; v != nil {
+                                return *v
+                            }
+                            return $second:W
+                        }()""",
+                        MapUtils.of(
+                                "goType", goType,
+                                "first", finalFirst,
+                                "second", generator.generate(second)));
+            }
+            // Fallback: just generate the first expression
+            return new ExpressionGenerator(scope, fnProvider).generate(expressions.get(0));
         }
     }
 
@@ -215,5 +279,16 @@ final class ExpressionGenerator {
 
     private static String getBuiltinMemberName(Identifier ident) {
         return StringUtils.capitalize(ident.getName().toString());
+    }
+
+    static String goTypeNameForType(
+            software.amazon.smithy.rulesengine.language.evaluation.type.Type type) {
+        if (type instanceof software.amazon.smithy.rulesengine.language.evaluation.type.StringType) {
+            return "string";
+        }
+        if (type instanceof software.amazon.smithy.rulesengine.language.evaluation.type.BooleanType) {
+            return "bool";
+        }
+        return "any";
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/FnGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/FnGenerator.java
@@ -21,11 +21,15 @@ import static software.amazon.smithy.go.codegen.GoWriter.joinWritables;
 import java.util.ArrayList;
 import java.util.List;
 import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.GoUniverseTypes;
 import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.go.codegen.SymbolUtils;
 import software.amazon.smithy.go.codegen.Writable;
+import software.amazon.smithy.rulesengine.language.evaluation.type.OptionalType;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.Expression;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.FunctionDefinition;
+import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.IsSet;
+import software.amazon.smithy.rulesengine.language.syntax.rule.Condition;
 import software.amazon.smithy.utils.MapUtils;
 
 public class FnGenerator {
@@ -95,6 +99,71 @@ public class FnGenerator {
 
             default -> false;
         };
+    }
+
+    /**
+     * Determine the Go type Symbol for a condition function's return value.
+     * This is used for conditionContext struct fields.
+     */
+    Symbol returnTypeForCondition(Condition condition) {
+        var fn = condition.getFunction();
+
+        // isSet stores the pointer value directly — type comes from the inner expression
+        if (fn instanceof IsSet) {
+            var inner = ((IsSet) fn).getArguments().get(0);
+            return returnTypeForExpression(inner);
+        }
+
+        // Derive Go type from the function's return type
+        var fnId = fn.getFunctionDefinition().getId();
+
+        Symbol goFn = fnProvider.fnFor(fnId);
+        if (goFn == null) {
+            goFn = new DefaultFnProvider().fnFor(fnId);
+        }
+
+        if (goFn != null) {
+            return returnTypeForFn(fnId, fn.type());
+        }
+
+        // Fallback based on Smithy type
+        var type = fn.type();
+        if (type instanceof OptionalType opt) {
+            return SymbolUtils.pointerTo(ExpressionGenerator.goTypeForType(opt.inner()));
+        }
+        return ExpressionGenerator.goTypeForType(type);
+    }
+
+    /**
+     * Map known function IDs to their Go return type Symbols.
+     */
+    static Symbol returnTypeForFn(String fnId,
+            software.amazon.smithy.rulesengine.language.evaluation.type.Type smithyType) {
+        return switch (fnId) {
+            case "parseURL" -> SymbolUtils.createPointableSymbolBuilder("URL",
+                    SmithyGoDependency.SMITHY_ENDPOINT_RULESFN).build();
+            case "substring" -> SymbolUtils.pointerTo(GoUniverseTypes.String);
+            case "aws.parseArn" -> SymbolUtils.createPointableSymbolBuilder("ARN",
+                    "github.com/aws/aws-sdk-go-v2/internal/endpoints/awsrulesfn").build();
+            case "aws.partition" -> SymbolUtils.createPointableSymbolBuilder("PartitionConfig",
+                    "github.com/aws/aws-sdk-go-v2/internal/endpoints/awsrulesfn").build();
+            case "isValidHostLabel", "aws.isVirtualHostableS3Bucket" -> GoUniverseTypes.Bool;
+            case "uriEncode" -> GoUniverseTypes.String;
+            case "split" -> SymbolUtils.sliceOf(GoUniverseTypes.String);
+            case "ite", "coalesce" -> {
+                var type = smithyType instanceof OptionalType opt ? opt.inner() : smithyType;
+                yield ExpressionGenerator.goTypeForType(type);
+            }
+            default -> GoUniverseTypes.Any;
+        };
+    }
+
+    private static Symbol returnTypeForExpression(Expression expr) {
+        var type = expr.type();
+        if (type instanceof OptionalType opt) {
+            return SymbolUtils.pointerTo(ExpressionGenerator.goTypeForType(opt.inner()));
+        }
+        return SymbolUtils.pointerTo(ExpressionGenerator.goTypeForType(type));
     }
 
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/FnGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/FnGenerator.java
@@ -52,6 +52,13 @@ public class FnGenerator {
             writableFnArgs.add(new ExpressionGenerator(scope, this.fnProvider).generate(expr));
         });
 
+        // Wrap split() in stringSlice() for safe .Get() index access
+        if (fnDef.getId().equals("split")) {
+            return goTemplate("stringSlice($fn:T($args:W))", MapUtils.of(
+                    "fn", goFn,
+                    "args", joinWritables(writableFnArgs, ", ")));
+        }
+
         return goTemplate("$fn:T($args:W)", MapUtils.of(
                 "fn", goFn,
                 "args", joinWritables(writableFnArgs, ", ")));
@@ -70,6 +77,8 @@ public class FnGenerator {
                         SmithyGoDependency.SMITHY_ENDPOINT_RULESFN).build();
                 case "uriEncode" -> SymbolUtils.createValueSymbolBuilder("URIEncode",
                         SmithyGoDependency.SMITHY_ENDPOINT_RULESFN).build();
+                case "split" -> SymbolUtils.createValueSymbolBuilder("Split",
+                        SmithyGoDependency.SMITHY_ENDPOINT_RULESFN).build();
 
                 default -> null;
             };
@@ -82,6 +91,7 @@ public class FnGenerator {
             case "parseURL" -> true;
             case "substring" -> true;
             case "uriEncode" -> false;
+            case "split" -> false;
 
             default -> false;
         };

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
@@ -42,6 +42,7 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.rulesengine.language.EndpointRuleSet;
+import software.amazon.smithy.rulesengine.traits.EndpointBddTrait;
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
 import software.amazon.smithy.utils.CaseUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
@@ -537,7 +538,15 @@ public interface ProtocolGenerator {
         }
 
         public EndpointRuleSet getEndpointRules() {
-            return EndpointRuleSet.fromNode(service.expectTrait(EndpointRuleSetTrait.class).getRuleSet());
+            if (service.hasTrait(EndpointRuleSetTrait.class)) {
+                return EndpointRuleSet.fromNode(service.expectTrait(EndpointRuleSetTrait.class).getRuleSet());
+            }
+            // Fall back to BDD trait — callers only use getParameters(), rules will be empty.
+            var bddTrait = service.expectTrait(EndpointBddTrait.class);
+            return EndpointRuleSet.builder()
+                    .version(bddTrait.getVersion().toString())
+                    .parameters(bddTrait.getParameters())
+                    .build();
         }
 
         public SymbolProvider getSymbolProvider() {

--- a/endpoints/private/bdd/evaluate.go
+++ b/endpoints/private/bdd/evaluate.go
@@ -1,0 +1,35 @@
+package bdd
+
+const resultOffset int32 = 100_000_000
+const intsPerNode = 3
+
+// Evaluate traverses a compiled BDD node array and returns the result index.
+// nodes is a flat array of [condIdx, hi, lo] triples (1-indexed).
+// root is the root node reference. evalCond returns true/false for condition index.
+func Evaluate(nodes []int32, root int32, evalCond func(int) bool) int32 {
+	ref := root
+	for {
+		if ref >= resultOffset {
+			return ref - resultOffset
+		}
+		if ref == 1 || ref == -1 {
+			return 0 // NoMatchRule
+		}
+
+		complement := ref < 0
+		nodeIdx := ref
+		if complement {
+			nodeIdx = -ref
+		}
+		base := (nodeIdx - 1) * intsPerNode
+		condIdx := nodes[base]
+		hi := nodes[base+1]
+		lo := nodes[base+2]
+
+		if complement != evalCond(int(condIdx)) {
+			ref = hi
+		} else {
+			ref = lo
+		}
+	}
+}

--- a/endpoints/private/rulesfn/split.go
+++ b/endpoints/private/rulesfn/split.go
@@ -1,0 +1,16 @@
+package rulesfn
+
+import "strings"
+
+// Split splits the input string by the delimiter and returns the resulting
+// parts. If limit is > 0, at most limit substrings are returned. Returns nil
+// if the input is empty.
+func Split(input, delimiter string, limit int) []string {
+	if len(input) == 0 {
+		return nil
+	}
+	if limit > 0 {
+		return strings.SplitN(input, delimiter, limit)
+	}
+	return strings.Split(input, delimiter)
+}

--- a/endpoints/private/rulesfn/split.go
+++ b/endpoints/private/rulesfn/split.go
@@ -3,11 +3,11 @@ package rulesfn
 import "strings"
 
 // Split splits the input string by the delimiter and returns the resulting
-// parts. If limit is > 0, at most limit substrings are returned. Returns nil
-// if the input is empty.
+// parts. If limit is > 0, at most limit substrings are returned.
+// Returns a slice with a single empty string if the input is empty.
 func Split(input, delimiter string, limit int) []string {
 	if len(input) == 0 {
-		return nil
+		return []string{""}
 	}
 	if limit > 0 {
 		return strings.SplitN(input, delimiter, limit)


### PR DESCRIPTION
Adds a new code generation path that reads the `@endpointBdd` Smithy trait and emits a BDD (Binary Decision Diagram)-based endpoint resolver for Go, as an alternative to the existing `@endpointRuleSet` trait. 

More information can be found at [smithy official docs](https://smithy.io/2.0/additional-specs/rules-engine/specification.html#smithy-rules-endpointbdd-trait)

There are currently no services that produce this value, this is in preparation of services rolling this out in the future. Currently only test code uses this.

### Changes

#### Runtime (endpoints/private/)

Adding two new functions to the generated Go code 

- endpoints/private/bdd/evaluate.go — BDD evaluator: The main guts of BDD evaluation
- endpoints/private/rulesfn/split.go — Implements support for [split](https://smithy.io/2.0/additional-specs/rules-engine/standard-library.html#split-function) Smithy function

#### Codegen (codegen/smithy-go-codegen/)

- EndpointBddResolverGenerator.java (new) — Main generator. Reads EndpointBddTrait and emits:
  1. BDD node array literal and root constant
  2. conditionContext struct for condition-assigned intermediate values
  3. evalCondition switch — dispatches each BDD condition index to its Go expression
  4. resolveResult switch — dispatches each BDD result index to endpoint construction or error
  5. Resolver type boilerplate (ResolveEndpoint method, interface, struct, constructor)

- EndpointResolutionGenerator.java — Detects EndpointBddTrait and routes to EndpointBddResolverGenerator when present, falling back to the existing tree-based generator otherwise. Also provides parameter extraction from the BDD
trait for test generation.

- ExpressionGenerator.java — Added support for two new functions from the standard library, `ite` (if-then-else) ([docs](https://smithy.io/2.0/additional-specs/rules-engine/standard-library.html#ite-function)) and `coalesce` (Evaluates arguments in order and returns the first non-empty result, otherwise returns the result of the last argument.) ([docs](https://smithy.io/2.0/additional-specs/rules-engine/standard-library.html#coalesce-function))

- EndpointParameterOperationBindingsGenerator.java — Removed direct dependency on EndpointRuleSetTrait/EndpointRuleSet (no longer needed since the caller handles trait selection).

### Testing

The neat thing is that endpoint tests are still exactly the same, and are still expected to pass after we generate bdd code.

We have an internal tool to convert from a `@endpointRuleSet` to `@endpointBdd`, so I

1. Converted all services to their `@endpointBdd` version
2. Regenerated all code
3. Ran all tests, and ensured they all passed.

There is a smaller change that we'll need to make on the SDK to get DynamoDB, who uses AccountIDEndpointRouting and needs to be aware of bdd traits, but other than that we should be covered