### PR TITLE
Ensure javadoc uses utf-8

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -80,6 +80,10 @@ subprojects {
             options.encoding = "UTF-8"
         }
 
+        tasks.withType<Javadoc> {
+            options.encoding = "UTF-8"
+        }
+
         // Use Junit5's test runner.
         tasks.withType<Test> {
             useJUnitPlatform()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`javadoc` on some environments defaults to `ascii`. When it finds any non-ascii character, even outside of javadoc strings, it chokes and fails the build.

This was happening due to our AI friend, the emdash (—), which was causing a build failure when generating javadocs on some runners

```
codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointBddResolverGenerator.java:285: error: unmappable character (0x94) for encoding US-ASCII
        // Boolean condition (no assign) ??? optional results need nil check
```

[Faulty line](https://github.com/aws/smithy-go/blob/main/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointBddResolverGenerator.java#L285) is the comment here
```
        // Boolean condition (no assign) — optional results need nil check
        if (isOptional) {
            return goTemplate("return $target:W != nil",
                    MapUtils.of("target", generator.generate(fn)));
        }
```

# Testing
This doesn't happen on local environment, since it uses `UTF-8` by default. I had to reproduce the issue by locally setting the encoding to `"US-ASCII"` and ensure the task failed with the same error

```
        tasks.withType<Javadoc> {
            options.encoding = "US-ASCII"
        }
```

```bash
$ cd codegen && ./gradlew :smithy-go-codegen:javadoc
./gradlew :smithy-go-codegen:javadoc

> Task :smithy-go-codegen:javadoc FAILED
/.../smithy-go/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointBddResolverGenerator.java:285: error: unmappable character (0xE2) for encoding US-ASCII
        // Boolean condition (no assign) ��� optional results need nil check
```
Then I set it to `"UTF-8"` and ensured it worked