### PR TITLE
check @enum on strings for cbor

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde/SerdeUtil.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde/SerdeUtil.java
@@ -32,6 +32,7 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShortShape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
+import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -70,7 +71,8 @@ public final class SerdeUtil {
         return switch (shape.getType()) {
             case BLOB -> BlobShape.builder().id("com.amazonaws.synthetic#Blob").build();
             case BOOLEAN -> BooleanShape.builder().id("com.amazonaws.synthetic#Bool").build();
-            case STRING -> StringShape.builder().id("com.amazonaws.synthetic#String").build();
+            case STRING -> shape.hasTrait(EnumTrait.class) ? shape
+                    : StringShape.builder().id("com.amazonaws.synthetic#String").build();
             case TIMESTAMP -> TimestampShape.builder().id("com.amazonaws.synthetic#Time").build();
             case BYTE -> ByteShape.builder().id("com.amazonaws.synthetic#Int8").build();
             case SHORT -> ShortShape.builder().id("com.amazonaws.synthetic#Int16").build();

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde/cbor/CborDeserializerGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde/cbor/CborDeserializerGenerator.java
@@ -42,6 +42,7 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -82,7 +83,8 @@ public final class CborDeserializerGenerator {
             case DOUBLE -> deserializeStatic(shape, SmithyGoDependency.SMITHY_CBOR.func("AsFloat64"));
             case TIMESTAMP -> deserializeStatic(shape, SmithyGoDependency.SMITHY_CBOR.func("AsTime"));
             case INT_ENUM -> deserializeIntEnum(shape);
-            case STRING -> deserializeString(shape);
+            case STRING -> shape.hasTrait(EnumTrait.class)
+                    ? deserializeAssertFunc(shape) : deserializeString(shape);
             case DOCUMENT -> deserializeDocument(shape); // implemented, but not currently supported
             default -> deserializeAssertFunc(shape); // everything else is a static assert
         };
@@ -181,7 +183,9 @@ public final class CborDeserializerGenerator {
     private Writable zeroValue(Shape shape) {
         return switch (shape.getType()) {
             case STRING ->
-                    goTemplate("\"\"");
+                    shape.hasTrait(EnumTrait.class)
+                            ? goTemplate("$T(\"\")", symbolProvider.toSymbol(shape))
+                            : goTemplate("\"\"");
             case BOOLEAN ->
                     goTemplate("false");
             case BLOB, LIST, SET, MAP, STRUCTURE, UNION ->
@@ -197,7 +201,9 @@ public final class CborDeserializerGenerator {
 
     private Writable deserializeAsserted(Shape shape, String ident) {
         return switch (shape.getType()) {
-            case STRING -> goTemplate("return string($L), nil", ident);
+            case STRING -> shape.hasTrait(EnumTrait.class)
+                    ? goTemplate("return $T($L), nil", symbolProvider.toSymbol(shape), ident)
+                    : goTemplate("return string($L), nil", ident);
             case ENUM -> goTemplate("return $T($L), nil", symbolProvider.toSymbol(shape), ident);
             case BOOLEAN -> goTemplate("return bool($L), nil", ident);
             case BLOB -> goTemplate("return []byte($L), nil", ident);

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde/cbor/CborSerializerGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde/cbor/CborSerializerGenerator.java
@@ -42,6 +42,7 @@ import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -87,7 +88,9 @@ public final class CborSerializerGenerator {
             case BYTE, SHORT, INTEGER, LONG, INT_ENUM -> generateSerializeIntegral();
             case FLOAT -> goTemplate("return $T(v), nil", SmithyGoDependency.SMITHY_CBOR.func("Float32"));
             case DOUBLE -> goTemplate("return $T(v), nil", SmithyGoDependency.SMITHY_CBOR.func("Float64"));
-            case STRING -> goTemplate("return $T(v), nil", SmithyGoDependency.SMITHY_CBOR.func("String"));
+            case STRING -> shape.hasTrait(EnumTrait.class)
+                    ? goTemplate("return $T(string(v)), nil", SmithyGoDependency.SMITHY_CBOR.func("String"))
+                    : goTemplate("return $T(v), nil", SmithyGoDependency.SMITHY_CBOR.func("String"));
             case BOOLEAN -> goTemplate("return $T(v), nil", SmithyGoDependency.SMITHY_CBOR.func("Bool"));
             case BLOB -> goTemplate("return $T(v), nil", SmithyGoDependency.SMITHY_CBOR.func("Slice"));
             case ENUM -> goTemplate("return $T(string(v)), nil", SmithyGoDependency.SMITHY_CBOR.func("String"));
@@ -223,9 +226,11 @@ public final class CborSerializerGenerator {
             case BLOB, LIST, SET, MAP, STRUCTURE, UNION ->
                     serializeNilableMember(member, target, false);
             case STRING ->
-                    isPointable(symbol)
-                            ? serializeNilableMember(member, target, true)
-                            : serializeString(member, target);
+                    target.hasTrait(EnumTrait.class)
+                            ? serializeString(member, target)
+                            : isPointable(symbol)
+                                    ? serializeNilableMember(member, target, true)
+                                    : serializeString(member, target);
             case ENUM ->
                     serializeString(member, target);
             default ->


### PR DESCRIPTION
we need to handle both EnumShape and StringShape + @enum (latter is deprecated).

the old json code already does this, https://github.com/aws/aws-sdk-go-v2/blob/main/codegen/smithy-aws-go-codegen/src/main/java/software/amazon/smithy/aws/go/codegen/DocumentMemberSerVisitor.java#L177-L184, cbor never got it.

note to self to check this for the schema-serde stuff as well