### PR TITLE
Bump Smithy version to 1.69.0

### DIFF
--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,2 +1,2 @@
-smithyVersion=1.67.0
+smithyVersion=1.69.0
 smithyGradleVersion=0.7.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bumping Smithy to the latest version. Interested in referencing `smithy.api#longPoll` released on this version on the SDK https://github.com/smithy-lang/smithy/releases/tag/1.69.0


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
