### PR TITLE
implement awsquery/ec2query

### DIFF
--- a/aws-protocols/awsquery/awsquery.go
+++ b/aws-protocols/awsquery/awsquery.go
@@ -1,0 +1,150 @@
+package awsquery
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/aws/smithy-go"
+	internalquery "github.com/aws/smithy-go/aws-protocols/internal/query"
+	internalxml "github.com/aws/smithy-go/aws-protocols/internal/xml"
+	"github.com/aws/smithy-go/eventstream"
+	"github.com/aws/smithy-go/middleware"
+	"github.com/aws/smithy-go/traits"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+// Protocol implements aws.protocols#awsQuery.
+type Protocol struct {
+	eventstream.NoEventStream
+
+	// Service API version (e.g. "2020-01-08"), sent as the "Version" parameter
+	// in every request.
+	Version string
+
+	// the query protocols do not have a "codec", they just inline a query
+	// serializer and xml deserializer
+}
+
+var _ smithyhttp.ClientProtocol = (*Protocol)(nil)
+
+// New returns an instance of the awsQuery protocol.
+func New(version string) *Protocol {
+	return &Protocol{Version: version}
+}
+
+// ID identifies the protocol.
+func (*Protocol) ID() string {
+	return "aws.protocols#awsQuery"
+}
+
+// SerializeRequest serializes a request for awsQuery.
+func (p *Protocol) SerializeRequest(
+	ctx context.Context,
+	schema *smithy.OperationSchema,
+	in smithy.Serializable,
+	req *smithyhttp.Request,
+) error {
+	req.Method = http.MethodPost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	ss := internalquery.NewShapeSerializer(middleware.GetOperationName(ctx), p.Version)
+	in.Serialize(ss)
+
+	sreq, err := req.SetStream(bytes.NewReader(ss.Bytes()))
+	if err != nil {
+		return fmt.Errorf("set stream: %w", err)
+	}
+
+	*req = *sreq
+	return nil
+}
+
+// DeserializeResponse deserializes a response for awsQuery.
+func (p *Protocol) DeserializeResponse(
+	ctx context.Context,
+	schema *smithy.OperationSchema,
+	types *smithy.TypeRegistry,
+	resp *smithyhttp.Response,
+	out smithy.Deserializable,
+) error {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return p.deserializeError(types, resp)
+	}
+
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return &smithy.DeserializationError{Err: err}
+	}
+
+	if len(payload) == 0 {
+		return nil
+	}
+
+	inner, err := internalxml.ExtractElement(payload, middleware.GetOperationName(ctx)+"Result")
+	if err != nil {
+		return &smithy.DeserializationError{Err: err}
+	}
+
+	if len(inner) == 0 {
+		return nil
+	}
+
+	sd := internalxml.NewShapeDeserializer(inner)
+	return out.Deserialize(sd)
+}
+
+func (p *Protocol) deserializeError(types *smithy.TypeRegistry, resp *smithyhttp.Response) error {
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return &smithy.DeserializationError{Err: err}
+	}
+
+	errorCode, errorMessage, errorBody, err := internalxml.GetProtocolErrorInfo(payload)
+	if err != nil {
+		return &smithy.DeserializationError{Err: err}
+	}
+
+	// resolveError checks both direct shape name and @awsQueryError trait.
+	perr, ok := resolveError(types, errorCode)
+	if !ok {
+		return &smithy.GenericAPIError{
+			Code:    errorCode,
+			Message: errorMessage,
+		}
+	}
+
+	if len(errorBody) > 0 {
+		sd := internalxml.NewShapeDeserializer(errorBody)
+		if err := perr.Deserialize(sd); err != nil {
+			return &smithy.DeserializationError{Err: err}
+		}
+	}
+
+	return perr
+}
+
+func resolveError(types *smithy.TypeRegistry, code string) (smithy.DeserializableError, bool) {
+	if perr, ok := types.DeserializableError(code); ok {
+		return perr, true
+	}
+
+	for _, entry := range types.Entries {
+		if entry.Schema == nil {
+			continue
+		}
+
+		if t, ok := smithy.SchemaTrait[*traits.AWSQueryError](entry.Schema); ok {
+			if t.ErrorCode == code {
+				v := entry.New()
+				if perr, ok := v.(smithy.DeserializableError); ok {
+					return perr, true
+				}
+			}
+		}
+	}
+
+	return nil, false
+}

--- a/aws-protocols/ec2query/ec2query.go
+++ b/aws-protocols/ec2query/ec2query.go
@@ -1,0 +1,125 @@
+package ec2query
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"bytes"
+
+	"github.com/aws/smithy-go"
+	internalquery "github.com/aws/smithy-go/aws-protocols/internal/query"
+	internalxml "github.com/aws/smithy-go/aws-protocols/internal/xml"
+	"github.com/aws/smithy-go/eventstream"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+// Protocol implements aws.protocols#ec2Query.
+type Protocol struct {
+	eventstream.NoEventStream
+
+	// Service API version (e.g. "2016-11-15"), sent as the "Version"
+	// parameter in every request.
+	Version string
+}
+
+var _ smithyhttp.ClientProtocol = (*Protocol)(nil)
+
+// New returns an instance of the ec2Query protocol.
+func New(version string) *Protocol {
+	return &Protocol{Version: version}
+}
+
+// ID identifies the protocol.
+func (*Protocol) ID() string {
+	return "aws.protocols#ec2Query"
+}
+
+// SerializeRequest serializes a request for ec2Query.
+func (p *Protocol) SerializeRequest(
+	ctx context.Context,
+	schema *smithy.OperationSchema,
+	in smithy.Serializable,
+	req *smithyhttp.Request,
+) error {
+	req.Method = http.MethodPost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	ss := internalquery.NewShapeSerializer(middleware.GetOperationName(ctx), p.Version,
+		func(o *internalquery.ShapeSerializerOptions) { o.EC2Mode = true },
+	)
+	in.Serialize(ss)
+
+	sreq, err := req.SetStream(bytes.NewReader(ss.Bytes()))
+	if err != nil {
+		return fmt.Errorf("set stream: %w", err)
+	}
+
+	*req = *sreq
+	return nil
+}
+
+// DeserializeResponse deserializes a response for ec2Query.
+func (p *Protocol) DeserializeResponse(
+	ctx context.Context,
+	schema *smithy.OperationSchema,
+	types *smithy.TypeRegistry,
+	resp *smithyhttp.Response,
+	out smithy.Deserializable,
+) error {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return p.deserializeError(types, resp)
+	}
+
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return &smithy.DeserializationError{Err: err}
+	}
+
+	if len(payload) == 0 {
+		return nil
+	}
+
+	inner, err := internalxml.ExtractElement(payload, middleware.GetOperationName(ctx)+"Response")
+	if err != nil {
+		return &smithy.DeserializationError{Err: err}
+	}
+
+	if len(inner) == 0 {
+		return nil
+	}
+
+	sd := internalxml.NewShapeDeserializer(inner)
+	return out.Deserialize(sd)
+}
+
+func (p *Protocol) deserializeError(types *smithy.TypeRegistry, resp *smithyhttp.Response) error {
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return &smithy.DeserializationError{Err: err}
+	}
+
+	errorCode, errorMessage, errorBody, err := internalxml.GetProtocolErrorInfo(payload)
+	if err != nil {
+		return &smithy.DeserializationError{Err: err}
+	}
+
+	// ec2query does not support @awsQueryError so this is a straight lookup
+	perr, ok := types.DeserializableError(errorCode)
+	if !ok {
+		return &smithy.GenericAPIError{
+			Code:    errorCode,
+			Message: errorMessage,
+		}
+	}
+
+	if len(errorBody) > 0 {
+		sd := internalxml.NewShapeDeserializer(errorBody)
+		if err := perr.Deserialize(sd); err != nil {
+			return &smithy.DeserializationError{Err: err}
+		}
+	}
+
+	return perr
+}

--- a/aws-protocols/internal/query/shape_deserializer.go
+++ b/aws-protocols/internal/query/shape_deserializer.go
@@ -1,0 +1,4 @@
+package query
+
+// ShapeDeserializer doesn't exist for query. The awsquery and ec2query
+// protocols use XML responses.

--- a/aws-protocols/internal/query/shape_serializer.go
+++ b/aws-protocols/internal/query/shape_serializer.go
@@ -23,6 +23,8 @@ const (
 	ctxKindMap
 	ctxKindMapValue
 	ctxKindStruct
+
+	ctxKindNone ctxKind = 0xff
 )
 
 type serCtx struct {
@@ -109,7 +111,7 @@ func (s *ShapeSerializer) Bytes() []byte {
 
 func (s *ShapeSerializer) top() ctxKind {
 	if len(s.stack) == 0 {
-		return 0xff
+		return ctxKindNone
 	}
 	return s.stack[len(s.stack)-1].kind
 }
@@ -226,58 +228,50 @@ func (s *ShapeSerializer) bufferMapEntry(key, value string) bool {
 
 // WriteInt8Ptr implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteInt8Ptr(schema *smithy.Schema, v *int8) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteInt8(schema, *v) })
-	}
+	writePtr(s, schema, v, (*ShapeSerializer).WriteInt8)
 }
 
 // WriteInt16Ptr implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteInt16Ptr(schema *smithy.Schema, v *int16) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteInt16(schema, *v) })
-	}
+	writePtr(s, schema, v, (*ShapeSerializer).WriteInt16)
 }
 
 // WriteInt32Ptr implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteInt32Ptr(schema *smithy.Schema, v *int32) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteInt32(schema, *v) })
-	}
+	writePtr(s, schema, v, (*ShapeSerializer).WriteInt32)
 }
 
 // WriteInt64Ptr implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteInt64Ptr(schema *smithy.Schema, v *int64) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteInt64(schema, *v) })
-	}
+	writePtr(s, schema, v, (*ShapeSerializer).WriteInt64)
 }
 
 // WriteFloat32Ptr implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteFloat32Ptr(schema *smithy.Schema, v *float32) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteFloat32(schema, *v) })
-	}
+	writePtr(s, schema, v, (*ShapeSerializer).WriteFloat32)
 }
 
 // WriteFloat64Ptr implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteFloat64Ptr(schema *smithy.Schema, v *float64) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteFloat64(schema, *v) })
-	}
+	writePtr(s, schema, v, (*ShapeSerializer).WriteFloat64)
 }
 
 // WriteBoolPtr implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteBoolPtr(schema *smithy.Schema, v *bool) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteBool(schema, *v) })
-	}
+	writePtr(s, schema, v, (*ShapeSerializer).WriteBool)
 }
 
 // WriteStringPtr implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteStringPtr(schema *smithy.Schema, v *string) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteString(schema, *v) })
+	writePtr(s, schema, v, (*ShapeSerializer).WriteString)
+}
+
+func writePtr[T any](s *ShapeSerializer, schema *smithy.Schema, v *T, write func(*ShapeSerializer, *smithy.Schema, T)) {
+	if v == nil {
+		return
 	}
+
+	s.withWriteZero(func() { write(s, schema, *v) })
 }
 
 // WriteBool implements [smithy.ShapeSerializer].
@@ -294,25 +288,24 @@ func (s *ShapeSerializer) WriteBool(schema *smithy.Schema, v bool) {
 }
 
 // WriteInt8 implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt8(schema *smithy.Schema, v int8) {
-	if v == 0 && s.skipZeroValue() {
-		return
-	}
-
-	s.writeValue(s.resolveKey(schema), strconv.FormatInt(int64(v), 10))
-}
+func (s *ShapeSerializer) WriteInt8(schema *smithy.Schema, v int8) { writeInt(s, schema, v) }
 
 // WriteInt16 implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt16(schema *smithy.Schema, v int16) {
-	if v == 0 && s.skipZeroValue() {
-		return
-	}
-
-	s.writeValue(s.resolveKey(schema), strconv.FormatInt(int64(v), 10))
-}
+func (s *ShapeSerializer) WriteInt16(schema *smithy.Schema, v int16) { writeInt(s, schema, v) }
 
 // WriteInt32 implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt32(schema *smithy.Schema, v int32) {
+func (s *ShapeSerializer) WriteInt32(schema *smithy.Schema, v int32) { writeInt(s, schema, v) }
+
+// WriteInt64 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt64(schema *smithy.Schema, v int64) { writeInt(s, schema, v) }
+
+// WriteFloat32 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteFloat32(schema *smithy.Schema, v float32) { writeFloat(s, schema, v) }
+
+// WriteFloat64 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteFloat64(schema *smithy.Schema, v float64) { writeFloat(s, schema, v) }
+
+func writeInt[T int8 | int16 | int32 | int64](s *ShapeSerializer, schema *smithy.Schema, v T) {
 	if v == 0 && s.skipZeroValue() {
 		return
 	}
@@ -320,31 +313,12 @@ func (s *ShapeSerializer) WriteInt32(schema *smithy.Schema, v int32) {
 	s.writeValue(s.resolveKey(schema), strconv.FormatInt(int64(v), 10))
 }
 
-// WriteInt64 implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt64(schema *smithy.Schema, v int64) {
-	if v == 0 && s.skipZeroValue() {
-		return
-	}
-
-	s.writeValue(s.resolveKey(schema), strconv.FormatInt(v, 10))
-}
-
-// WriteFloat32 implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteFloat32(schema *smithy.Schema, v float32) {
+func writeFloat[T float32 | float64](s *ShapeSerializer, schema *smithy.Schema, v T) {
 	if v == 0 && s.skipZeroValue() {
 		return
 	}
 
 	s.writeValue(s.resolveKey(schema), formatFloat(float64(v)))
-}
-
-// WriteFloat64 implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteFloat64(schema *smithy.Schema, v float64) {
-	if v == 0 && s.skipZeroValue() {
-		return
-	}
-
-	s.writeValue(s.resolveKey(schema), formatFloat(v))
 }
 
 func formatFloat(v float64) string {

--- a/aws-protocols/internal/query/shape_serializer.go
+++ b/aws-protocols/internal/query/shape_serializer.go
@@ -1,0 +1,641 @@
+package query
+
+import (
+	"encoding/base64"
+	"math"
+	"math/big"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/document"
+	smithytime "github.com/aws/smithy-go/time"
+	"github.com/aws/smithy-go/traits"
+)
+
+type ctxKind byte
+
+const (
+	ctxKindList ctxKind = iota
+	ctxKindMap
+	ctxKindMapValue
+	ctxKindStruct
+)
+
+type serCtx struct {
+	kind      ctxKind
+	flattened bool
+	prefix    string // popped back onto s.currPrefix as you pop out the stack
+
+	listIndex  int
+	listPrefix string
+
+	mapIndex     int
+	mapKeyName   string
+	mapValueName string
+	mapBuf       []mapBufEntry
+}
+
+// ShapeSerializer serializes Smithy shapes to the AWS query string format.
+type ShapeSerializer struct {
+	opts ShapeSerializerOptions
+
+	values     url.Values
+	stack      []serCtx
+	currPrefix string // runs as values are written e.g. for list
+}
+
+type mapBufEntry struct {
+	prefix string
+	key    string
+	values []kv
+}
+
+type kv struct {
+	k, v string
+}
+
+// ShapeSerializerOptions configures a ShapeSerializer.
+type ShapeSerializerOptions struct {
+	WriteZeroValues bool
+
+	// Adjusts serialization for the ec2Query protocol:
+	//  - Member names resolve via @ec2QueryName, then @xmlName
+	//    capitalized, then member name capitalized (instead of @xmlName
+	//    or member name as-is).
+	//  - All lists serialize as flat regardless of @xmlFlattened.
+	//  - Empty lists are omitted (instead of emitting a "Key=" sentinel).
+	EC2Mode bool
+}
+
+var _ smithy.ShapeSerializer = (*ShapeSerializer)(nil)
+
+// NewShapeSerializer returns a new ShapeSerializer.
+func NewShapeSerializer(action, version string, opts ...func(*ShapeSerializerOptions)) *ShapeSerializer {
+	o := ShapeSerializerOptions{}
+	for _, fn := range opts {
+		fn(&o)
+	}
+	v := url.Values{}
+	v.Set("Action", action)
+	v.Set("Version", version)
+	return &ShapeSerializer{values: v, opts: o}
+}
+
+// Bytes returns the encoded query string as bytes.
+func (s *ShapeSerializer) Bytes() []byte {
+	keys := make([]string, 0, len(s.values))
+	for k := range s.values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var buf strings.Builder
+	for _, k := range keys {
+		for _, v := range s.values[k] {
+			if buf.Len() > 0 {
+				buf.WriteByte('&')
+			}
+			buf.WriteString(url.QueryEscape(k))
+			buf.WriteByte('=')
+			buf.WriteString(url.QueryEscape(v))
+		}
+	}
+	return []byte(buf.String())
+}
+
+func (s *ShapeSerializer) top() ctxKind {
+	if len(s.stack) == 0 {
+		return 0xff
+	}
+	return s.stack[len(s.stack)-1].kind
+}
+
+func (s *ShapeSerializer) push(ctx serCtx) {
+	s.stack = append(s.stack, ctx)
+}
+
+func (s *ShapeSerializer) pop() serCtx {
+	n := len(s.stack)
+	v := s.stack[n-1]
+	s.stack = s.stack[:n-1]
+	return v
+}
+
+func (s *ShapeSerializer) topCtx() *serCtx {
+	return &s.stack[len(s.stack)-1]
+}
+
+func (s *ShapeSerializer) withWriteZero(fn func()) {
+	prev := s.opts.WriteZeroValues
+	s.opts.WriteZeroValues = true
+	fn()
+	s.opts.WriteZeroValues = prev
+}
+
+func (s *ShapeSerializer) skipZeroValue() bool {
+	if s.opts.WriteZeroValues {
+		return false
+	}
+	if len(s.stack) == 0 {
+		return false
+	}
+
+	switch s.top() {
+	case ctxKindList, ctxKindMapValue:
+		return false
+	default:
+		return true
+	}
+}
+
+func (s *ShapeSerializer) memberName(schema *smithy.Schema) string {
+	if s.opts.EC2Mode {
+		return ec2MemberName(schema)
+	}
+	if xn, ok := smithy.SchemaTrait[*traits.XMLName](schema); ok {
+		return xn.Name
+	}
+	return schema.MemberName()
+}
+
+func (s *ShapeSerializer) appendMemberPrefix(schema *smithy.Schema) {
+	name := s.memberName(schema)
+	if name == "" {
+		return
+	}
+	if s.currPrefix != "" {
+		s.currPrefix = s.currPrefix + "." + name
+	} else {
+		s.currPrefix = name
+	}
+}
+
+// nexus point (alongside writeValue) through which basically every write flows
+// to handle putting the appropriate prefix in place
+func (s *ShapeSerializer) resolveKey(schema *smithy.Schema) string {
+	switch s.top() {
+	case ctxKindMapValue:
+		valPrefix := s.consumeMapValue()
+		return valPrefix
+	case ctxKindList:
+		ctx := s.topCtx()
+		ctx.listIndex++
+		return s.currPrefix + "." + strconv.Itoa(ctx.listIndex)
+	default:
+		name := s.memberName(schema)
+		if name == "" {
+			return s.currPrefix
+		}
+		if s.currPrefix == "" {
+			return name
+		}
+		return s.currPrefix + "." + name
+	}
+}
+
+func (s *ShapeSerializer) writeValue(key, value string) {
+	if s.bufferMapEntry(key, value) {
+		return
+	}
+
+	s.values.Add(key, value)
+}
+
+func (s *ShapeSerializer) bufferMapEntry(key, value string) bool {
+	for i := len(s.stack) - 1; i >= 0; i-- {
+		ctx := &s.stack[i]
+		if ctx.kind != ctxKindMap {
+			continue
+		}
+		if len(ctx.mapBuf) == 0 {
+			return false
+		}
+
+		entry := &ctx.mapBuf[len(ctx.mapBuf)-1]
+		suffix := strings.TrimPrefix(key, entry.prefix)
+		entry.values = append(entry.values, kv{k: suffix, v: value})
+		return true
+	}
+
+	return false
+}
+
+// WriteInt8Ptr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt8Ptr(schema *smithy.Schema, v *int8) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteInt8(schema, *v) })
+	}
+}
+
+// WriteInt16Ptr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt16Ptr(schema *smithy.Schema, v *int16) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteInt16(schema, *v) })
+	}
+}
+
+// WriteInt32Ptr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt32Ptr(schema *smithy.Schema, v *int32) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteInt32(schema, *v) })
+	}
+}
+
+// WriteInt64Ptr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt64Ptr(schema *smithy.Schema, v *int64) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteInt64(schema, *v) })
+	}
+}
+
+// WriteFloat32Ptr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteFloat32Ptr(schema *smithy.Schema, v *float32) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteFloat32(schema, *v) })
+	}
+}
+
+// WriteFloat64Ptr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteFloat64Ptr(schema *smithy.Schema, v *float64) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteFloat64(schema, *v) })
+	}
+}
+
+// WriteBoolPtr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteBoolPtr(schema *smithy.Schema, v *bool) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteBool(schema, *v) })
+	}
+}
+
+// WriteStringPtr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteStringPtr(schema *smithy.Schema, v *string) {
+	if v != nil {
+		s.withWriteZero(func() { s.WriteString(schema, *v) })
+	}
+}
+
+// WriteBool implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteBool(schema *smithy.Schema, v bool) {
+	if !v && s.skipZeroValue() {
+		return
+	}
+
+	if v {
+		s.writeValue(s.resolveKey(schema), "true")
+	} else {
+		s.writeValue(s.resolveKey(schema), "false")
+	}
+}
+
+// WriteInt8 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt8(schema *smithy.Schema, v int8) {
+	if v == 0 && s.skipZeroValue() {
+		return
+	}
+
+	s.writeValue(s.resolveKey(schema), strconv.FormatInt(int64(v), 10))
+}
+
+// WriteInt16 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt16(schema *smithy.Schema, v int16) {
+	if v == 0 && s.skipZeroValue() {
+		return
+	}
+
+	s.writeValue(s.resolveKey(schema), strconv.FormatInt(int64(v), 10))
+}
+
+// WriteInt32 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt32(schema *smithy.Schema, v int32) {
+	if v == 0 && s.skipZeroValue() {
+		return
+	}
+
+	s.writeValue(s.resolveKey(schema), strconv.FormatInt(int64(v), 10))
+}
+
+// WriteInt64 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteInt64(schema *smithy.Schema, v int64) {
+	if v == 0 && s.skipZeroValue() {
+		return
+	}
+
+	s.writeValue(s.resolveKey(schema), strconv.FormatInt(v, 10))
+}
+
+// WriteFloat32 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteFloat32(schema *smithy.Schema, v float32) {
+	if v == 0 && s.skipZeroValue() {
+		return
+	}
+
+	s.writeValue(s.resolveKey(schema), formatFloat(float64(v)))
+}
+
+// WriteFloat64 implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteFloat64(schema *smithy.Schema, v float64) {
+	if v == 0 && s.skipZeroValue() {
+		return
+	}
+
+	s.writeValue(s.resolveKey(schema), formatFloat(v))
+}
+
+func formatFloat(v float64) string {
+	switch {
+	case math.IsInf(v, 1):
+		return "Infinity"
+	case math.IsInf(v, -1):
+		return "-Infinity"
+	case math.IsNaN(v):
+		return "NaN"
+	default:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	}
+}
+
+// WriteString implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteString(schema *smithy.Schema, v string) {
+	if v == "" && s.skipZeroValue() {
+		return
+	}
+
+	s.writeValue(s.resolveKey(schema), v)
+}
+
+// WriteBlob implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteBlob(schema *smithy.Schema, v []byte) {
+	if v == nil {
+		return
+	}
+
+	s.writeValue(s.resolveKey(schema), base64.StdEncoding.EncodeToString(v))
+}
+
+// WriteTime implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteTime(schema *smithy.Schema, v time.Time) {
+	format := "date-time"
+	if t, ok := smithy.SchemaTrait[*traits.TimestampFormat](schema); ok {
+		format = t.Format
+	}
+
+	var sv string
+	switch format {
+	case "date-time":
+		sv = smithytime.FormatDateTime(v)
+	case "http-date":
+		sv = smithytime.FormatHTTPDate(v)
+	case "epoch-seconds":
+		sv = strconv.FormatFloat(smithytime.FormatEpochSeconds(v), 'f', -1, 64)
+	default:
+		sv = smithytime.FormatDateTime(v)
+	}
+
+	s.writeValue(s.resolveKey(schema), sv)
+}
+
+// WriteTimePtr implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteTimePtr(schema *smithy.Schema, v *time.Time) {
+	if v != nil {
+		s.WriteTime(schema, *v)
+	}
+}
+
+// WriteStruct implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteStruct(schema *smithy.Schema, v smithy.Serializable) {
+	if v == nil {
+		return
+	}
+
+	saved := s.currPrefix
+	switch s.top() {
+	case ctxKindMapValue:
+		valPrefix := s.consumeMapValue()
+		s.currPrefix, saved = valPrefix, s.currPrefix
+	case ctxKindList:
+		ctx := s.topCtx()
+		ctx.listIndex++
+		s.currPrefix = s.currPrefix + "." + strconv.Itoa(ctx.listIndex)
+	default:
+		s.appendMemberPrefix(schema)
+	}
+
+	v.Serialize(s)
+	s.currPrefix = saved
+}
+
+// WriteUnion implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteUnion(schema, variant *smithy.Schema, v smithy.Serializable) {
+	saved := s.currPrefix
+	s.appendMemberPrefix(schema)
+	if s.top() == ctxKindMapValue {
+		s.pop()
+	}
+	v.Serialize(s)
+	s.currPrefix = saved
+}
+
+// WriteNil implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteNil(_ *smithy.Schema) {
+	if s.top() == ctxKindMapValue {
+		s.consumeMapValue()
+	}
+}
+
+// enterContainer handles the prefix setup common to WriteList and WriteMap.
+// It returns the prefix to save for restoration on close.
+func (s *ShapeSerializer) enterContainer(schema *smithy.Schema) string {
+	saved := s.currPrefix
+	switch s.top() {
+	case ctxKindMapValue:
+		// WriteKey set s.prefix to the value path and pushed ctxMapValue
+		// with the map prefix. Pop ctxMapValue and use its saved prefix
+		// as the restore point — s.prefix (the value path) is already
+		// the correct working prefix.
+		ctx := s.pop()
+		saved = ctx.prefix
+		return saved
+	case ctxKindList:
+		ctx := s.topCtx()
+		ctx.listIndex++
+		s.currPrefix = s.currPrefix + "." + strconv.Itoa(ctx.listIndex)
+	}
+
+	s.appendMemberPrefix(schema)
+	return saved
+}
+
+// WriteList implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteList(schema *smithy.Schema) {
+	saved := s.enterContainer(schema)
+
+	_, flattened := smithy.SchemaTrait[*traits.XMLFlattened](schema)
+	flattened = flattened || s.opts.EC2Mode
+
+	listPrefix := s.currPrefix
+	if !flattened {
+		locName := "member"
+		if schema != nil {
+			if lm := schema.ListMember(); lm != nil {
+				if xn, ok := smithy.SchemaTrait[*traits.XMLName](lm); ok {
+					locName = xn.Name
+				}
+			}
+		}
+		s.currPrefix = s.currPrefix + "." + locName
+	}
+
+	s.push(serCtx{
+		kind:       ctxKindList,
+		flattened:  flattened,
+		prefix:     saved,
+		listPrefix: listPrefix,
+	})
+}
+
+// CloseList implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) CloseList() {
+	if s.top() != ctxKindList {
+		return
+	}
+
+	ctx := s.pop()
+	if ctx.listIndex == 0 && !s.opts.EC2Mode {
+		s.writeValue(ctx.listPrefix, "")
+	}
+
+	s.currPrefix = ctx.prefix
+}
+
+// WriteMap implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteMap(schema *smithy.Schema) {
+	// Structs use WriteMap/CloseMap as a generic "begin object" scope.
+	if schema != nil && schema.Type() == smithy.ShapeTypeStructure {
+		saved := s.enterContainer(schema)
+		s.push(serCtx{kind: ctxKindStruct, prefix: saved})
+		return
+	}
+
+	saved := s.enterContainer(schema)
+
+	_, flattened := smithy.SchemaTrait[*traits.XMLFlattened](schema)
+	if !flattened {
+		s.currPrefix = s.currPrefix + ".entry"
+	}
+
+	keyLoc, valLoc := "key", "value"
+	if schema != nil {
+		if mk := schema.MapKey(); mk != nil {
+			if xn, ok := smithy.SchemaTrait[*traits.XMLName](mk); ok {
+				keyLoc = xn.Name
+			}
+		}
+		if mv := schema.MapValue(); mv != nil {
+			if xn, ok := smithy.SchemaTrait[*traits.XMLName](mv); ok {
+				valLoc = xn.Name
+			}
+		}
+	}
+
+	s.push(serCtx{
+		kind:         ctxKindMap,
+		flattened:    flattened,
+		prefix:       saved,
+		mapKeyName:   keyLoc,
+		mapValueName: valLoc,
+	})
+}
+
+// WriteKey implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteKey(_ *smithy.Schema, key string) {
+	ctx := s.topCtx()
+	ctx.mapIndex++
+
+	prefix := s.currPrefix + "." + strconv.Itoa(ctx.mapIndex)
+	ctx.mapBuf = append(ctx.mapBuf, mapBufEntry{
+		prefix: prefix,
+		key:    key,
+	})
+
+	s.writeValue(prefix+"."+ctx.mapKeyName, key)
+
+	// Push ctxMapValue with the current prefix so the next value write can
+	// restore it. Set s.prefix to the value path.
+	s.push(serCtx{kind: ctxKindMapValue, prefix: s.currPrefix})
+	s.currPrefix = prefix + "." + ctx.mapValueName
+}
+
+// CloseMap implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) CloseMap() {
+	if s.top() == ctxKindStruct {
+		ctx := s.pop()
+		s.currPrefix = ctx.prefix
+		return
+	}
+	if s.top() != ctxKindMap {
+		return
+	}
+
+	ctx := s.pop()
+
+	// Sort entries by map key for deterministic output.
+	sort.Slice(ctx.mapBuf, func(i, j int) bool {
+		return ctx.mapBuf[i].key < ctx.mapBuf[j].key
+	})
+
+	// Flush with sequential indices.
+	for i, entry := range ctx.mapBuf {
+		newPrefix := s.currPrefix + "." + strconv.Itoa(i+1)
+		for _, kv := range entry.values {
+			s.writeValue(newPrefix+kv.k, kv.v)
+		}
+	}
+
+	s.currPrefix = ctx.prefix
+}
+
+// WriteBigInteger is unimplemented.
+func (s *ShapeSerializer) WriteBigInteger(_ *smithy.Schema, _ big.Int) {
+	panic("query: BigInteger not supported")
+}
+
+// WriteBigDecimal is unimplemented.
+func (s *ShapeSerializer) WriteBigDecimal(_ *smithy.Schema, _ big.Float) {
+	panic("query: BigDecimal not supported")
+}
+
+// WriteDocument is unimplemented.
+func (s *ShapeSerializer) WriteDocument(_ *smithy.Schema, _ document.Value) {
+	panic("query: Document not supported")
+}
+
+func (s *ShapeSerializer) consumeMapValue() string {
+	ctx := s.pop()
+	valPrefix := s.currPrefix
+	s.currPrefix = ctx.prefix
+	return valPrefix
+}
+
+func ec2MemberName(schema *smithy.Schema) string {
+	if t, ok := smithy.SchemaTrait[*traits.EC2QueryName](schema); ok {
+		return t.Name
+	}
+	if xn, ok := smithy.SchemaTrait[*traits.XMLName](schema); ok {
+		return capitalize(xn.Name)
+	}
+	return capitalize(schema.MemberName())
+}
+
+func capitalize(s string) string {
+	if s == "" || s[0] >= 'A' && s[0] <= 'Z' {
+		return s
+	}
+
+	return string(s[0]-'a'+'A') + s[1:]
+}

--- a/aws-protocols/internal/xml/error.go
+++ b/aws-protocols/internal/xml/error.go
@@ -1,0 +1,40 @@
+package xml
+
+import "io"
+
+// GetProtocolErrorInfo extracts Smithy error details from a query-protocol
+// response.
+//
+// This version of GetProtocolErrorInfo also handles the extraction of the
+// modeled error body from the protocol wrapper so the caller can operate on it
+// directly.
+func GetProtocolErrorInfo(payload []byte) (code, message string, errorBody []byte, err error) {
+	code = "UnknownError"
+	message = code
+
+	errorBody, err = ExtractElement(payload, "Error")
+	if err != nil || len(errorBody) == 0 {
+		return
+	}
+
+	// we are in a fragment here so just leverage ExtractElement to get the
+	// inner XML of these, instead of having to wrap in a tag to pass to the
+	// stdlib decoder
+	c, err := ExtractElement(errorBody, "Code")
+	if err != nil && err != io.EOF {
+		return
+	}
+	m, err := ExtractElement(errorBody, "Message")
+	if err != nil && err != io.EOF {
+		return
+	}
+
+	err = nil
+	if len(c) > 0 {
+		code = string(c)
+	}
+	if len(m) > 0 {
+		message = string(m)
+	}
+	return
+}

--- a/aws-protocols/internal/xml/error.go
+++ b/aws-protocols/internal/xml/error.go
@@ -29,6 +29,7 @@ func GetProtocolErrorInfo(payload []byte) (code, message string, errorBody []byt
 		return
 	}
 
+    // clear err if it was io.EOF
 	err = nil
 	if len(c) > 0 {
 		code = string(c)

--- a/aws-protocols/internal/xml/extract.go
+++ b/aws-protocols/internal/xml/extract.go
@@ -1,0 +1,72 @@
+package xml
+
+import (
+	"bytes"
+	"encoding/xml"
+	"strings"
+)
+
+// ExtractElement finds the first occurrence of the named element in the XML
+// and returns its INNER content as raw bytes.
+//
+// This is used to extract both success and error responses from the protocol
+// XML that wraps them.
+//
+// e.g. for awsquery, with an operation output shape named XmlListsResult:
+//
+//	<XmlListsResponse>
+//	 	<XmlListsResult>
+//	 		<member1>foo</member1>
+//	 		...
+//	 	</XmlListsResult>
+//	</XmlListsResponse>
+//
+// ExtractElement gives you "<member1>foo</member1>...".
+//
+// ExtractElement will forward the io.EOF returned by the underlying decoder if
+// the target element is not found, which the caller can index on if they're
+// looking for an optional element.
+func ExtractElement(payload []byte, name string) ([]byte, error) {
+	dec := xml.NewDecoder(bytes.NewReader(payload))
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+
+		if start, ok := tok.(xml.StartElement); ok {
+			if strings.EqualFold(start.Name.Local, name) {
+				return extract(dec)
+			}
+		}
+	}
+}
+
+func extract(dec *xml.Decoder) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := xml.NewEncoder(&buf)
+	depth := 1
+
+	for depth > 0 {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			depth++
+			enc.EncodeToken(t)
+		case xml.EndElement:
+			depth--
+			if depth > 0 {
+				enc.EncodeToken(t)
+			}
+		case xml.CharData:
+			enc.EncodeToken(t)
+		}
+	}
+
+	enc.Flush()
+	return buf.Bytes(), nil
+}

--- a/aws-protocols/internal/xml/shape_deserializer.go
+++ b/aws-protocols/internal/xml/shape_deserializer.go
@@ -37,7 +37,7 @@ type deserCtx struct {
 
 	// for map, ReadX after ReadMapKey will leave the stream at </value>
 	// which the next call to ReadMapKey must consume
-	inEntry bool
+	inMapEntry bool
 }
 
 // ShapeDeserializer implements unmarshaling of XML into Smithy shapes.
@@ -238,8 +238,8 @@ func (d *ShapeDeserializer) ReadMap(s *smithy.Schema) error {
 // ReadMapKey implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadMapKey(ks *smithy.Schema) (string, bool, error) {
 	ctx := d.top()
-	if ctx.inEntry {
-		ctx.inEntry = false
+	if ctx.inMapEntry {
+		ctx.inMapEntry = false
 		if _, _, err := d.nextStart(); err != nil {
 			return "", false, err
 		}
@@ -338,7 +338,7 @@ func (d *ShapeDeserializer) readEntry(ks, vs *smithy.Schema) (string, bool, erro
 				return "", false, err
 			}
 		case strings.EqualFold(child.Name.Local, vname):
-			ctx.inEntry = true
+			ctx.inMapEntry = true
 			return key, true, nil
 		default:
 			if err := d.skip(); err != nil {

--- a/aws-protocols/internal/xml/shape_deserializer.go
+++ b/aws-protocols/internal/xml/shape_deserializer.go
@@ -1,0 +1,686 @@
+package xml
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/document"
+	smithytime "github.com/aws/smithy-go/time"
+	"github.com/aws/smithy-go/traits"
+)
+
+type ctxKind byte
+
+const (
+	ctxKindStruct ctxKind = iota
+	ctxKindList
+	ctxKindMap
+)
+
+type deserCtx struct {
+	kind      ctxKind
+	schema    *smithy.Schema
+	flattened bool
+
+	// for flattened list/map, ReadStructMember consumes the start element
+	// when it discovers the member, subsequent calls to ReadMapKey or
+	// ReadListItem will do that instead
+	first bool
+
+	// for map, ReadX after ReadMapKey will leave the stream at </value>
+	// which the next call to ReadMapKey must consume
+	inEntry bool
+}
+
+// ShapeDeserializer implements unmarshaling of XML into Smithy shapes.
+//
+// ShapeDeserializer expects the **inner XML** of the protocol response that
+// represents the operation output. For example, an awsquery response body
+// looks like this:
+//
+//	<[OperationName]Response>
+//	    <[OperationName]Result>
+//	        <Member1>...</Member1>
+//	        <Member2>...</Member2>
+//	        ...
+//	        <MemberN>...</MemberN>
+//	    </[OperationName]Result>
+//	    <ResponseMetadata>
+//	        ...
+//	    </ResponseMetadata>
+//	</[OperationName]Response>
+//
+// The deserializer must receive "<Member1>...</MemberN>" to operate correctly.
+type ShapeDeserializer struct {
+	dec    *xml.Decoder
+	peeked xml.Token
+	stack  []deserCtx
+}
+
+var _ smithy.ShapeDeserializer = (*ShapeDeserializer)(nil)
+
+// NewShapeDeseralizer returns a new ShapeDeserializer.
+func NewShapeDeserializer(p []byte) *ShapeDeserializer {
+	return &ShapeDeserializer{
+		dec: xml.NewDecoder(bytes.NewReader(p)),
+	}
+}
+
+func (d *ShapeDeserializer) push(ctx deserCtx) {
+	d.stack = append(d.stack, ctx)
+}
+
+func (d *ShapeDeserializer) pop() deserCtx {
+	n := len(d.stack)
+	v := d.stack[n-1]
+	d.stack = d.stack[:n-1]
+	return v
+}
+
+func (d *ShapeDeserializer) top() *deserCtx {
+	if len(d.stack) == 0 {
+		return nil
+	}
+	return &d.stack[len(d.stack)-1]
+}
+
+func xmlMemberName(schema *smithy.Schema) string {
+	if t, ok := smithy.SchemaTrait[*traits.XMLName](schema); ok {
+		return t.Name
+	}
+	return schema.MemberName()
+}
+
+func findMember(schema *smithy.Schema, elemName string) *smithy.Schema {
+	if schema == nil {
+		return nil
+	}
+
+	for _, m := range schema.Members() {
+		mName := xmlMemberName(m)
+		if strings.EqualFold(mName, elemName) {
+			return m
+		}
+	}
+	return nil
+}
+
+// ReadStruct implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadStruct(s *smithy.Schema) error {
+	d.push(deserCtx{kind: ctxKindStruct, schema: s})
+	return nil
+}
+
+// ReadStructMember implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadStructMember() (*smithy.Schema, error) {
+	ctx := d.top()
+	if ctx == nil || ctx.kind != ctxKindStruct {
+		return nil, fmt.Errorf("ReadStructMember called without ReadStruct")
+	}
+
+	for {
+		start, ok, err := d.nextStart()
+		if err != nil {
+			// on the top-level struct we are guaranteed to get an EOF since
+			// we're operating on inner XML
+			if err == io.EOF && len(d.stack) == 1 {
+				d.pop()
+				return nil, nil
+			}
+
+			return nil, err
+		}
+		if !ok {
+			d.pop()
+			return nil, nil
+		}
+
+		member := findMember(ctx.schema, start.Name.Local)
+		if member == nil {
+			if err := d.skip(); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		return member, nil
+	}
+}
+
+// ReadList implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadList(s *smithy.Schema) error {
+	_, flattened := smithy.SchemaTrait[*traits.XMLFlattened](s)
+	d.push(deserCtx{
+		kind:      ctxKindList,
+		schema:    s,
+		flattened: flattened,
+		first:     flattened,
+	})
+	return nil
+}
+
+// ReadListItem implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadListItem(_ *smithy.Schema) (bool, error) {
+	ctx := d.top()
+	if ctx.flattened {
+		return d.readFlatListItem()
+	}
+	return d.readWrappedListItem()
+}
+
+func (d *ShapeDeserializer) readWrappedListItem() (bool, error) {
+	// the old version used WrapNodeDecoder on each item and didn't check its
+	// name (or for xmlName) so we're ignoring it too
+	_, ok, err := d.nextStart()
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		d.pop()
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (d *ShapeDeserializer) readFlatListItem() (bool, error) {
+	ctx := d.top()
+	if ctx.first {
+		ctx.first = false
+		return true, nil
+	}
+
+	expectName := xmlMemberName(ctx.schema)
+
+	for {
+		tok, err := d.token()
+		if err != nil {
+			return false, err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if strings.EqualFold(t.Name.Local, expectName) {
+				return true, nil
+			}
+
+			d.peeked = t
+			d.pop()
+			return false, nil
+		case xml.EndElement:
+			d.peeked = t
+			d.pop()
+			return false, nil
+		}
+	}
+}
+
+// ReadMap implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadMap(s *smithy.Schema) error {
+	_, flattened := smithy.SchemaTrait[*traits.XMLFlattened](s)
+	d.push(deserCtx{
+		kind:      ctxKindMap,
+		schema:    s,
+		flattened: flattened,
+		first:     flattened,
+	})
+	return nil
+}
+
+// ReadMapKey implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadMapKey(ks *smithy.Schema) (string, bool, error) {
+	ctx := d.top()
+	if ctx.inEntry {
+		ctx.inEntry = false
+		if _, _, err := d.nextStart(); err != nil {
+			return "", false, err
+		}
+	}
+
+	vs := ctx.schema.MapValue()
+
+	if ctx.flattened {
+		return d.readFlatMapKey(ks, vs)
+	}
+
+	return d.readWrappedMapKey(ks, vs)
+}
+
+func (d *ShapeDeserializer) readWrappedMapKey(ks, vs *smithy.Schema) (string, bool, error) {
+	for {
+		start, a, err := d.nextStart()
+		if err != nil {
+			return "", false, err
+		}
+		if !a {
+			d.pop()
+			return "", false, nil
+		}
+
+		// unlike lists the old codegen actually DID check that the element was
+		// named "entry", skipping if it wasn't
+		if strings.EqualFold(start.Name.Local, "entry") {
+			return d.readEntry(ks, vs)
+		}
+
+		if err := d.skip(); err != nil {
+			return "", false, err
+		}
+	}
+}
+
+func (d *ShapeDeserializer) readFlatMapKey(ks, vs *smithy.Schema) (string, bool, error) {
+	ctx := d.top()
+	if ctx.first {
+		ctx.first = false
+		return d.readEntry(ks, vs)
+	}
+
+	expectName := xmlMemberName(ctx.schema)
+	for {
+		tok, err := d.token()
+		if err != nil {
+			return "", false, err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if strings.EqualFold(t.Name.Local, expectName) {
+				return d.readEntry(ks, vs)
+			}
+
+			d.peeked = t
+			d.pop()
+			return "", false, nil
+		case xml.EndElement:
+			d.peeked = t
+			d.pop()
+			return "", false, nil
+		}
+	}
+}
+
+func (d *ShapeDeserializer) readEntry(ks, vs *smithy.Schema) (string, bool, error) {
+	ctx := d.top()
+
+	kname := "key"
+	if xn, ok := smithy.SchemaTrait[*traits.XMLName](ks); ok {
+		kname = xn.Name
+	}
+
+	vname := "value"
+	if xn, ok := smithy.SchemaTrait[*traits.XMLName](vs); ok {
+		vname = xn.Name
+	}
+
+	var key string
+	for {
+		child, found, err := d.nextStart()
+		if err != nil {
+			return "", false, err
+		}
+		if !found {
+			break
+		}
+
+		switch {
+		case strings.EqualFold(child.Name.Local, kname):
+			key, err = d.chardata()
+			if err != nil {
+				return "", false, err
+			}
+		case strings.EqualFold(child.Name.Local, vname):
+			ctx.inEntry = true
+			return key, true, nil
+		default:
+			if err := d.skip(); err != nil {
+				return "", false, err
+			}
+		}
+	}
+
+	return key, true, nil
+}
+
+// ReadNil implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadNil(_ *smithy.Schema) (bool, error) {
+	return false, nil
+}
+
+// ReadBool implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadBool(_ *smithy.Schema, v *bool) error {
+	text, err := d.chardata()
+	if err != nil {
+		return err
+	}
+
+	b, err := strconv.ParseBool(text)
+	if err != nil {
+		return fmt.Errorf("parse bool %q: %w", text, err)
+	}
+
+	*v = b
+	return nil
+}
+
+// ReadBoolPtr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadBoolPtr(s *smithy.Schema, v **bool) error {
+	return readPtr(d, s, v, d.ReadBool)
+}
+
+// ReadInt8 implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt8(s *smithy.Schema, v *int8) error {
+	n, err := d.readInt(8)
+	if err != nil {
+		return err
+	}
+
+	*v = int8(n)
+	return nil
+}
+
+// ReadInt16 implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt16(s *smithy.Schema, v *int16) error {
+	n, err := d.readInt(16)
+	if err != nil {
+		return err
+	}
+
+	*v = int16(n)
+	return nil
+}
+
+// ReadInt32 implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt32(s *smithy.Schema, v *int32) error {
+	n, err := d.readInt(32)
+	if err != nil {
+		return err
+	}
+
+	*v = int32(n)
+	return nil
+}
+
+// ReadInt64 implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt64(s *smithy.Schema, v *int64) error {
+	n, err := d.readInt(64)
+	if err != nil {
+		return err
+	}
+
+	*v = n
+	return nil
+}
+
+// ReadInt8Ptr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt8Ptr(s *smithy.Schema, v **int8) error {
+	return readPtr(d, s, v, d.ReadInt8)
+}
+
+// ReadInt16Ptr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt16Ptr(s *smithy.Schema, v **int16) error {
+	return readPtr(d, s, v, d.ReadInt16)
+}
+
+// ReadInt32Ptr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt32Ptr(s *smithy.Schema, v **int32) error {
+	return readPtr(d, s, v, d.ReadInt32)
+}
+
+// ReadInt64Ptr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadInt64Ptr(s *smithy.Schema, v **int64) error {
+	return readPtr(d, s, v, d.ReadInt64)
+}
+
+// ReadFloat32 implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadFloat32(s *smithy.Schema, v *float32) error {
+	n, err := d.readFloat()
+	if err != nil {
+		return err
+	}
+
+	*v = float32(n)
+	return nil
+}
+
+// ReadFloat64 implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadFloat64(s *smithy.Schema, v *float64) error {
+	n, err := d.readFloat()
+	if err != nil {
+		return err
+	}
+
+	*v = n
+	return nil
+}
+
+// ReadFloat32Ptr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadFloat32Ptr(s *smithy.Schema, v **float32) error {
+	return readPtr(d, s, v, d.ReadFloat32)
+}
+
+// ReadFloat64Ptr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadFloat64Ptr(s *smithy.Schema, v **float64) error {
+	return readPtr(d, s, v, d.ReadFloat64)
+}
+
+// ReadString implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadString(_ *smithy.Schema, v *string) error {
+	text, err := d.chardata()
+	if err != nil {
+		return err
+	}
+
+	*v = text
+	return nil
+}
+
+// ReadStringPtr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadStringPtr(s *smithy.Schema, v **string) error {
+	return readPtr(d, s, v, d.ReadString)
+}
+
+// ReadTime implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadTime(schema *smithy.Schema, v *time.Time) error {
+	format := "date-time"
+	if t, ok := smithy.SchemaTrait[*traits.TimestampFormat](schema); ok {
+		format = t.Format
+	}
+
+	text, err := d.chardata()
+	if err != nil {
+		return err
+	}
+
+	switch format {
+	case "date-time":
+		t, err := smithytime.ParseDateTime(text)
+		if err != nil {
+			return err
+		}
+		*v = t
+	case "http-date":
+		t, err := smithytime.ParseHTTPDate(text)
+		if err != nil {
+			return err
+		}
+		*v = t
+	case "epoch-seconds":
+		n, err := strconv.ParseFloat(text, 64)
+		if err != nil {
+			return err
+		}
+		*v = smithytime.ParseEpochSeconds(n)
+	default:
+		return fmt.Errorf("unknown timestamp format: %s", format)
+	}
+
+	return nil
+}
+
+// ReadTimePtr implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadTimePtr(schema *smithy.Schema, v **time.Time) error {
+	return readPtr(d, schema, v, d.ReadTime)
+}
+
+// ReadBlob implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadBlob(s *smithy.Schema, v *[]byte) error {
+	text, err := d.chardata()
+	if err != nil {
+		return err
+	}
+
+	if text == "" {
+		return nil
+	}
+
+	b, err := base64.StdEncoding.DecodeString(text)
+	if err != nil {
+		return fmt.Errorf("decode base64 blob: %w", err)
+	}
+	*v = b
+	return nil
+}
+
+// ReadUnion implements [smithy.ShapeDeserializer].
+func (d *ShapeDeserializer) ReadUnion(s *smithy.Schema) (*smithy.Schema, error) {
+	start, ok, err := d.nextStart()
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+
+	member := findMember(s, start.Name.Local)
+	if member == nil {
+		if err := d.skip(); err != nil {
+			return nil, err
+		}
+		return d.ReadUnion(s)
+	}
+
+	return member, nil
+}
+
+// ReadDocument is unimplemented for XML.
+func (d *ShapeDeserializer) ReadDocument(_ *smithy.Schema, _ *document.Value) error {
+	return fmt.Errorf("Document not supported")
+}
+
+func readPtr[T any](d *ShapeDeserializer, s *smithy.Schema, v **T, read func(*smithy.Schema, *T) error) error {
+	if *v == nil {
+		*v = new(T)
+	}
+	return read(s, *v)
+}
+
+func (d *ShapeDeserializer) token() (xml.Token, error) {
+	if d.peeked != nil {
+		tok := d.peeked
+		d.peeked = nil
+		return tok, nil
+	}
+
+	return d.dec.Token()
+}
+
+func (d *ShapeDeserializer) chardata() (string, error) {
+	// a single "inner XML" node can be multiple xml.CharData so we need to
+	// accumulate them
+	var buf strings.Builder
+
+	for {
+		tok, err := d.token()
+		if err != nil {
+			return "", err
+		}
+
+		switch t := tok.(type) {
+		case xml.CharData:
+			buf.Write(t)
+
+		// IMPORTANT: also consumes the closing tag AFTER the chardata, so
+		// future ReadWhatevers don't have to think about that
+		case xml.EndElement:
+			return buf.String(), nil
+
+		default:
+			return "", fmt.Errorf("unexpected token %T", tok)
+		}
+	}
+}
+
+// there is xml.Decoder.Skip but this is a special case to assume we already
+// consumed the start element and to handle any peeked tokens
+func (d *ShapeDeserializer) skip() error {
+	depth := 1
+	for depth > 0 {
+		tok, err := d.token()
+		if err != nil {
+			return err
+		}
+
+		switch tok.(type) {
+		case xml.StartElement:
+			depth++
+		case xml.EndElement:
+			depth--
+		}
+	}
+
+	return nil
+}
+
+func (d *ShapeDeserializer) nextStart() (xml.StartElement, bool, error) {
+	for {
+		tok, err := d.token()
+		if err != nil {
+			return xml.StartElement{}, false, err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			return t, true, nil
+		case xml.EndElement: // ie. the end of the struct/list/map
+			return xml.StartElement{}, false, nil
+		default:
+			continue
+		}
+	}
+}
+
+func (d *ShapeDeserializer) readInt(bits int) (int64, error) {
+	text, err := d.chardata()
+	if err != nil {
+		return 0, err
+	}
+
+	return strconv.ParseInt(text, 10, bits)
+}
+
+func (d *ShapeDeserializer) readFloat() (float64, error) {
+	text, err := d.chardata()
+	if err != nil {
+		return 0, err
+	}
+
+	switch {
+	case strings.EqualFold(text, "NaN"):
+		return math.NaN(), nil
+	case strings.EqualFold(text, "Infinity"):
+		return math.Inf(1), nil
+	case strings.EqualFold(text, "-Infinity"):
+		return math.Inf(-1), nil
+	default:
+		return strconv.ParseFloat(text, 64)
+	}
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/DefaultTraitGenerators.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/DefaultTraitGenerators.java
@@ -5,6 +5,7 @@ import static software.amazon.smithy.go.codegen.SmithyGoDependency.SMITHY_TRAITS
 import java.util.HashMap;
 import java.util.Map;
 import software.amazon.smithy.aws.traits.protocols.AwsQueryErrorTrait;
+import software.amazon.smithy.aws.traits.protocols.Ec2QueryNameTrait;
 import software.amazon.smithy.go.codegen.trait.BackfilledInputOutputTrait;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.EventHeaderTrait;
@@ -83,6 +84,8 @@ public class DefaultTraitGenerators {
         GENERATORS.put(AwsQueryErrorTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("AWSQueryError"),
                 "ErrorCode", AwsQueryErrorTrait::getCode,
                 "StatusCode", AwsQueryErrorTrait::getHttpResponseCode));
+        GENERATORS.put(Ec2QueryNameTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("EC2QueryName"),
+                "Name", Ec2QueryNameTrait::getValue));
 
         // Codegen-internal traits
         GENERATORS.put(BackfilledInputOutputTrait.ID, new SimpleTraitGenerator<>(SMITHY_TRAITS.struct("UnitShape")));

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -31,6 +31,8 @@ import java.util.stream.Stream;
 import software.amazon.smithy.aws.traits.protocols.AwsJson1_0Trait;
 import software.amazon.smithy.aws.traits.protocols.AwsJson1_1Trait;
 import software.amazon.smithy.aws.traits.protocols.AwsQueryCompatibleTrait;
+import software.amazon.smithy.aws.traits.protocols.AwsQueryTrait;
+import software.amazon.smithy.aws.traits.protocols.Ec2QueryTrait;
 import software.amazon.smithy.aws.traits.protocols.RestJson1Trait;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -48,6 +50,7 @@ import software.amazon.smithy.go.codegen.integration.GoIntegration;
 import software.amazon.smithy.go.codegen.integration.OperationMetricsStruct;
 import software.amazon.smithy.go.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.protocol.traits.Rpcv2CborTrait;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.ServiceShape;
@@ -284,6 +287,16 @@ final class ServiceGenerator implements Runnable {
                     service.hasTrait(AwsQueryCompatibleTrait.class)
                             ? goTemplate("$T", SmithyGoDependency.SMITHY_HTTP_PROTOCOLS_RPCV2.valueSymbol("UseQueryCompatible"))
                             : emptyGoTemplate()
+            );
+        } else if (preferred.equals(AwsQueryTrait.ID)) {
+            return goTemplate("$T($S)",
+                    SmithyGoDependency.SMITHY_AWS_PROTOCOLS_AWSQUERY.func("New"),
+                    service.getVersion()
+            );
+        } else if (preferred.equals(Ec2QueryTrait.ID)) {
+            return goTemplate("$T($S)",
+                    SmithyGoDependency.SMITHY_AWS_PROTOCOLS_EC2QUERY.func("New"),
+                    service.getVersion()
             );
         } else {
             throw new CodegenException("unsupported schema-serde protocol " + preferred);

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SimpleTraitGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SimpleTraitGenerator.java
@@ -4,6 +4,7 @@ import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.traits.Trait;
@@ -47,6 +48,12 @@ class SimpleTraitGenerator<T extends Trait> implements TraitGenerator {
     public Writable render(Trait trait) {
         return goTemplate("&$T{$W}", symbol, Writable.map(mappings.entrySet(), entry -> {
             var value = entry.getValue().apply((T) trait);
+            if (value instanceof Optional<?> opt) {
+                if (opt.isEmpty()) {
+                    return GoWriter.emptyGoTemplate();
+                }
+                value = opt.get();
+            }
             return goTemplate("$L: $L,", entry.getKey(), formatValue(value));
         }));
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -85,6 +85,8 @@ public final class SmithyGoDependency {
     public static final GoDependency SMITHY_AWS_PROTOCOLS = relativePackage( "github.com/aws/smithy-go/aws-protocols", null, "v1.0.0", null);
     public static final GoDependency SMITHY_AWS_PROTOCOLS_JSON10 = relativePackage( "github.com/aws/smithy-go/aws-protocols", "awsjson10", "v1.0.0", null);
     public static final GoDependency SMITHY_AWS_PROTOCOLS_RESTJSON1 = relativePackage( "github.com/aws/smithy-go/aws-protocols", "restjson1", "v1.0.0", null);
+    public static final GoDependency SMITHY_AWS_PROTOCOLS_AWSQUERY = relativePackage( "github.com/aws/smithy-go/aws-protocols", "awsquery", "v1.0.0", null);
+    public static final GoDependency SMITHY_AWS_PROTOCOLS_EC2QUERY = relativePackage( "github.com/aws/smithy-go/aws-protocols", "ec2query", "v1.0.0", null);
 
     public static final GoDependency SMITHY_HTTP_PROTOCOLS = relativePackage( "github.com/aws/smithy-go/smithy-http-protocols", null, "v1.0.0", null);
     public static final GoDependency SMITHY_HTTP_PROTOCOLS_RPCV2 = relativePackage( "github.com/aws/smithy-go/smithy-http-protocols", "rpcv2", "v1.0.0", null);

--- a/eventstream/no_event_stream.go
+++ b/eventstream/no_event_stream.go
@@ -1,0 +1,36 @@
+package eventstream
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/aws/smithy-go"
+)
+
+// NoEventStream implements the event stream methods of
+// [github.com/aws/smithy-go/transport/http.ClientProtocol] for protocols
+// that do not support event streams.
+type NoEventStream struct{}
+
+// HasInitialEventMessage returns false.
+func (NoEventStream) HasInitialEventMessage() bool { return false }
+
+// SerializeEventMessage returns an error.
+func (NoEventStream) SerializeEventMessage(_, _ *smithy.Schema, _ smithy.Serializable, _ io.Writer) error {
+	return fmt.Errorf("event streams are not supported by this protocol")
+}
+
+// DeserializeEventMessage returns an error.
+func (NoEventStream) DeserializeEventMessage(_ *smithy.Schema, _ *smithy.TypeRegistry, _ io.Reader) (smithy.Deserializable, error) {
+	return nil, fmt.Errorf("event streams are not supported by this protocol")
+}
+
+// SerializeInitialRequest returns an error.
+func (NoEventStream) SerializeInitialRequest(_ *smithy.Schema, _ smithy.Serializable, _ io.Writer) error {
+	return fmt.Errorf("event streams are not supported by this protocol")
+}
+
+// DeserializeInitialResponse returns an error.
+func (NoEventStream) DeserializeInitialResponse(_ *smithy.Schema, _ io.Reader, _ smithy.Deserializable) error {
+	return fmt.Errorf("event streams are not supported by this protocol")
+}

--- a/serde.go
+++ b/serde.go
@@ -196,6 +196,11 @@ func ReadStruct(d ShapeDeserializer, schema *Schema, memberFn func(*Schema) erro
 			return nil
 		}
 
+		// TODO(serde2): err check should be first. ran into this with XML
+		// because of how that shape deserializer operates on innerXML, you get
+		// a guaranteed EOF in the end, but I have explicitly swallowed that
+		// EOF there when it's on the outer struct since that's how that
+		// deserializer has to work
 		if err != nil {
 			return err
 		}

--- a/trait.go
+++ b/trait.go
@@ -6,3 +6,7 @@ package smithy
 type Trait interface {
 	TraitID() string
 }
+
+// TODO(serde2): investigate performance tradeoff of using an "indexed" map for
+// the known traits (basically the ones defined here) since the rest- and
+// xml-based protocols do a ton of trait lookup (which translates to map lookup)

--- a/traits/traits.go
+++ b/traits/traits.go
@@ -47,6 +47,14 @@ type AWSQueryError struct {
 // TraitID identifies the trait.
 func (*AWSQueryError) TraitID() string { return "aws.protocols#awsQueryError" }
 
+// EC2QueryName represents aws.protocols#ec2QueryName.
+type EC2QueryName struct {
+	Name string
+}
+
+// TraitID identifies the trait.
+func (*EC2QueryName) TraitID() string { return "aws.protocols#ec2QueryName" }
+
 // UnitShape is a synthetic trait applied to input/output shapes that were
 // backfilled from Unit. It indicates the shape has no defined members and
 // should be treated as absent for protocol serialization purposes.


### PR DESCRIPTION
awsquery and ec2query protocols

The combination of query serializer and xml deserializer are probably the most complicated these will get (due to query's prefixing and xml traits/flattening).

`@xmlAttribute` isn't implemented yet, that will be added in the next PR for restxml.