### PR TITLE
Expand JMESPath truthy check by allowing bare collections to be evaluated

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGenerator.java
@@ -114,8 +114,40 @@ public class GoJmespathExpressionGenerator {
         }
     }
 
+    /**
+     * Converts a variable to a boolean per JMESPath truthiness rules. A value is falsey if it is:
+     * empty list, empty map, empty string, false, or null. Numbers and structs are always truthy.
+     * https://jmespath.org/specification.html#or-expressions
+     */
+    private Variable toBooleanVariable(Variable v) {
+        if (v.shape.isBooleanShape()) {
+            return v;
+        }
+        var ident = nextIdent();
+        if (v.shape instanceof CollectionShape || v.shape instanceof MapShape) {
+            writer.write("$L := len($L) > 0", ident, v.ident);
+        } else if (v.shape instanceof StringShape) {
+            if (isPointable(v.type)) {
+                writer.write("$L := $L != nil && *$L != \"\"", ident, v.ident, v.ident);
+            } else {
+                writer.write("$L := $L != \"\"", ident, v.ident);
+            }
+        } else if (v.shape instanceof NumberShape) {
+            if (isPointable(v.type)) {
+                writer.write("$L := $L != nil", ident, v.ident);
+            } else {
+                writer.write("$L := true", ident);
+            }
+        } else if (isNilable(v.type)) {
+            writer.write("$L := $L != nil", ident, v.ident);
+        } else {
+            writer.write("$L := true", ident);
+        }
+        return new Variable(BOOL_SHAPE, ident, GoUniverseTypes.Bool);
+    }
+
     private Variable visitNot(NotExpression expr, Variable current) {
-        var inner = visit(expr.getExpression(), current);
+        var inner = toBooleanVariable(visit(expr.getExpression(), current));
         var ident = nextIdent();
         writer.write("$L := !$L", ident, inner.ident);
         return new Variable(BOOL_SHAPE, ident, GoUniverseTypes.Bool);
@@ -159,7 +191,7 @@ public class GoJmespathExpressionGenerator {
         var ident = nextIdent();
         writer.write("var $L $T", ident, type);
         writer.openBlock("for _, v := range $L {", "}", unfiltered.ident, () -> {
-            var filterResult = visit(expr.getComparison(), new Variable(member, "v", type));
+            var filterResult = toBooleanVariable(visit(expr.getComparison(), new Variable(member, "v", type)));
             writer.write("""
                     if $1L {
                         $2L = append($2L, v)
@@ -170,16 +202,16 @@ public class GoJmespathExpressionGenerator {
     }
 
     private Variable visitAnd(AndExpression expr, Variable current) {
-        var left = visit(expr.getLeft(), current);
-        var right = visit(expr.getRight(), current);
+        var left = toBooleanVariable(visit(expr.getLeft(), current));
+        var right = toBooleanVariable(visit(expr.getRight(), current));
         var ident = nextIdent();
         writer.write("$L := $L && $L", ident, left.ident, right.ident);
         return new Variable(BOOL_SHAPE, ident, GoUniverseTypes.Bool);
     }
 
     private Variable visitOr(OrExpression expr, Variable current) {
-        var left = visit(expr.getLeft(), current);
-        var right = visit(expr.getRight(), current);
+        var left = toBooleanVariable(visit(expr.getLeft(), current));
+        var right = toBooleanVariable(visit(expr.getRight(), current));
         var ident = nextIdent();
         writer.write("$L := $L || $L", ident, left.ident, right.ident);
         return new Variable(BOOL_SHAPE, ident, GoUniverseTypes.Bool);

--- a/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGeneratorTest.java
+++ b/codegen/smithy-go-codegen/src/test/java/software/amazon/smithy/go/codegen/GoJmespathExpressionGeneratorTest.java
@@ -654,4 +654,50 @@ public class GoJmespathExpressionGeneratorTest {
                 }else { v3 = (v1 == nil && v2 != nil) || (v1 != nil && v2 == nil) }
                 """));
     }
+
+    @Test
+    public void testFilterBareListFieldTruthiness() {
+        var expr = "objectList[?innerObjectList && key == 'foo']";
+
+        var writer = testWriter();
+        var generator = new GoJmespathExpressionGenerator(testContext(), writer);
+        var actual = generator.generate(JmespathExpression.parse(expr), new GoJmespathExpressionGenerator.Variable(
+                TEST_MODEL.expectShape(ShapeId.from("smithy.go.test#Struct")),
+                "input"
+        ));
+        assertThat(actual.shape(), Matchers.equalTo(TEST_MODEL.expectShape(ShapeId.from("smithy.go.test#ObjectList"))));
+        // list truthiness: len(x) > 0
+        assertThat(writer.toString(), Matchers.containsString("len(v3) > 0"));
+        // should compile as a valid && expression
+        assertThat(writer.toString(), Matchers.containsString("&&"));
+    }
+
+    @Test
+    public void testFilterBareStringFieldTruthiness() {
+        var expr = "objectList[?key && length(innerObjectList) > `0`]";
+
+        var writer = testWriter();
+        var generator = new GoJmespathExpressionGenerator(testContext(), writer);
+        generator.generate(JmespathExpression.parse(expr), new GoJmespathExpressionGenerator.Variable(
+                TEST_MODEL.expectShape(ShapeId.from("smithy.go.test#Struct")),
+                "input"
+        ));
+        // string ptr truthiness: x != nil && *x != ""
+        assertThat(writer.toString(), Matchers.containsString("!= nil && *"));
+        assertThat(writer.toString(), Matchers.containsString("!= \"\""));
+    }
+
+    @Test
+    public void testNotBareListFieldTruthiness() {
+        var expr = "objectList[?!(innerObjectList && key == 'foo')]";
+
+        var writer = testWriter();
+        var generator = new GoJmespathExpressionGenerator(testContext(), writer);
+        generator.generate(JmespathExpression.parse(expr), new GoJmespathExpressionGenerator.Variable(
+                TEST_MODEL.expectShape(ShapeId.from("smithy.go.test#Struct")),
+                "input"
+        ));
+        // list truthiness inside negation
+        assertThat(writer.toString(), Matchers.containsString("len(v3) > 0"));
+    }
 }


### PR DESCRIPTION
When a bare FieldExpression (e.g. `myList` where the data type is a list) appears in a boolean context - inside `&&`, `||`, `!`, or as a filter predicate - the generator previously emitted the raw Go value directly. Go slices, maps, and pointers can't be used with `&&`/`||`/`!` operators, causing compilation failures.

For example, if you have a waiter with the following expression

```
services[?!(myList && length(myList) == 1)]
```

The filter predicate uses `myList` as a bare field in an && expression. Before this fix, the generator would produce (a bit simplified):

```go
v3 := v.myList               // []types.SomeList
v4 := len(v3) == 1           // length(myList) == 1
v5 := v3 && v4               // ❌ compile error: slices can't be used with &&
```

After this fix, the generator recognizes that v3 is a list and applies JMESPath truthiness — a list is truthy if non-empty:

```go
v3 := v.myList              // []types.SomeList
v4 := len(v3) > 0           // truthiness check for list
v5 := len(v3) == 1          // length(myList) == 1
v6 := v4 && v5              // ✅ both operands are bool
```
## Changes
Adds a `toBooleanVariable()` helper that converts a variable to a boolean based on [JMESPath truthiness rules](jmespath.org/specification.html#or-expression)

| Shape type | Generated Go check |
|---|---|
| List/Map | `len(x) > 0` |
| String (pointer) | `x != nil && *x != ""` |
| String (value) | `x != ""` |
| Number (pointer) | `x != nil` |
| Number (value) | `true` |
| Boolean | passthrough |
| Other nilable | `x != nil` |
| Other | `true` |

Similar C++ SDK fix in aws/aws-sdk-cpp#3801

## Testing
Added new tests for this. This currently doesn't change the code on the SDK since we don't have waiters that use this, but it unblocks services from using them