### PR TITLE
serde2: misc fixes

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -289,9 +289,9 @@ public final class OperationGenerator implements Runnable {
             writer.write("if err != nil { return err }");
         } else {
             writer.addUseImports(SmithyGoDependency.SMITHY);
-            var opSchemaName = "schemas." + SchemaGenerator.getSchemaName(operation, service);
-            var inputSchemaName = "schemas." + SchemaGenerator.getSchemaName(input, service);
-            var outputSchemaName = "schemas." + SchemaGenerator.getSchemaName(output, service);
+            var opSchemaName = SchemaGenerator.getSchemaRef(operation, service);
+            var inputSchemaName = SchemaGenerator.getSchemaRef(input, service);
+            var outputSchemaName = SchemaGenerator.getSchemaRef(output, service);
             var opSchema = String.format("smithy.NewOperationSchema(%s, %s, %s)",
                     opSchemaName, inputSchemaName, outputSchemaName);
             writer.write("""

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SchemaGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SchemaGenerator.java
@@ -5,6 +5,7 @@ import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
 
 import java.util.Map;
 import software.amazon.smithy.go.codegen.util.ShapeUtil;
+import software.amazon.smithy.model.loader.Prelude;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -30,6 +31,9 @@ public class SchemaGenerator implements Writable {
     private static final String SYNTHETIC_NAMESPACE = "smithy.go.synthetic";
 
     public static String getSchemaName(Shape shape, ServiceShape service) {
+        if (Prelude.isPublicPreludeShape(shape)) {
+            return "smithyprelude." + shape.getId().getName();
+        }
         var name = shape.getId().getName(service);
         if (shape.getId().getNamespace().equals(SYNTHETIC_NAMESPACE)) {
             name = "SmithyGoSynthetic_" + name;
@@ -43,8 +47,28 @@ public class SchemaGenerator implements Writable {
         return String.format("%s_%s", getSchemaName(shape, service), member.getMemberName());
     }
 
+    // Returns the schema reference for use outside the schemas package (e.g. in
+    // serde generators). Prelude shapes are already package-qualified, local
+    // shapes get the "schemas." prefix.
+    public static String getSchemaRef(Shape shape, ServiceShape service) {
+        if (Prelude.isPublicPreludeShape(shape)) {
+            return getSchemaName(shape, service);
+        }
+        return "schemas." + getSchemaName(shape, service);
+    }
+
+    public static String getMemberSchemaRef(Shape shape, MemberShape member, ServiceShape service) {
+        if (Prelude.isPublicPreludeShape(shape)) {
+            return getSchemaName(shape, service) + "_" + member.getMemberName();
+        }
+        return "schemas." + getMemberSchemaName(shape, member, service);
+    }
+
     @Override
     public void accept(GoWriter writer) {
+        if (Prelude.isPublicPreludeShape(shape)) {
+            return;
+        }
         var service = ctx.service();
         writer.addUseImports(SmithyGoDependency.SMITHY);
         writer.writeGoTemplate("""
@@ -66,7 +90,7 @@ public class SchemaGenerator implements Writable {
     }
 
     public void acceptMembersInit(GoWriter writer) {
-        if (shape.members().isEmpty()) {
+        if (shape.members().isEmpty() || Prelude.isPublicPreludeShape(shape)) {
             return;
         }
         writer.writeGoTemplate("""
@@ -88,6 +112,20 @@ public class SchemaGenerator implements Writable {
         var target = ctx.model().expectShape(member.getTarget());
         var service = ctx.service();
         var memberTraits = member.getAllTraits().values();
+
+        if (Prelude.isPublicPreludeShape(target)) {
+            return goTemplate("""
+                            $preludeImport:D$ident:L = $schema:L.AddMember($name:S, $target:L$traits:W)
+                            """,
+                    Map.of(
+                            "preludeImport", SmithyGoDependency.SMITHY_PRELUDE,
+                            "ident", getMemberSchemaName(shape, member, service),
+                            "schema", getSchemaName(shape, service),
+                            "name", member.getMemberName(),
+                            "target", getSchemaName(target, service),
+                            "traits", renderVariadicTraits(memberTraits)
+                    ));
+        }
 
         return goTemplate("""
                         $ident:L = $schema:L.AddMember($name:S, $target:L$traits:W)

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -299,7 +299,7 @@ final class ServiceGenerator implements Runnable {
                     service.getVersion()
             );
         } else {
-            throw new CodegenException("unsupported schema-serde protocol " + preferred);
+            return goTemplate("nil");
         }
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -71,6 +71,7 @@ public final class SmithyGoDependency {
     public static final GoDependency SMITHY_TESTING = smithy("testing", "smithytesting");
     public static final GoDependency SMITHY_WAITERS = smithy("waiter", "smithywaiter");
     public static final GoDependency SMITHY_DOCUMENT = smithy("document", "smithydocument");
+    public static final GoDependency SMITHY_PRELUDE = smithy("prelude", "smithyprelude");
     public static final GoDependency SMITHY_DOCUMENT_JSON = smithy("document/json", "smithydocumentjson");
     public static final GoDependency SMITHY_DOCUMENT_CBOR = smithy("document/cbor", "smithydocumentcbor");
     public static final GoDependency SMITHY_SYNC = smithy("sync", "smithysync");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/UnionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/UnionGenerator.java
@@ -28,6 +28,7 @@ import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.SimpleShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.go.codegen.util.ShapeUtil;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -113,7 +114,7 @@ public class UnionGenerator {
     private void generateMemberSerializer(GoWriter writer, MemberShape member, String memberName, Shape target) {
         writer.addUseImports(SmithyGoDependency.SMITHY);
         writer.addImport(ctx.settings().getModuleName() + "/schemas", "schemas");
-        var schemaName = "schemas." + SchemaGenerator.getMemberSchemaName(shape, member, ctx.service());
+        var schemaName = SchemaGenerator.getMemberSchemaRef(shape, member, ctx.service());
         writer.openBlock("func (v *$L) Serialize(s smithy.ShapeSerializer) {", "}", memberName, () -> {
             switch (target.getType()) {
                 case BYTE -> writer.write("s.WriteInt8($L, v.Value)", schemaName);
@@ -123,10 +124,15 @@ public class UnionGenerator {
                 case FLOAT -> writer.write("s.WriteFloat32($L, v.Value)", schemaName);
                 case DOUBLE -> writer.write("s.WriteFloat64($L, v.Value)", schemaName);
                 case BOOLEAN -> writer.write("s.WriteBool($L, v.Value)", schemaName);
-                case STRING -> writer.write("s.WriteString($L, v.Value)", schemaName);
+                case STRING, ENUM -> {
+                    if (ShapeUtil.isEnum(target)) {
+                        writer.write("s.WriteString($L, string(v.Value))", schemaName);
+                    } else {
+                        writer.write("s.WriteString($L, v.Value)", schemaName);
+                    }
+                }
                 case BLOB -> writer.write("s.WriteBlob($L, v.Value)", schemaName);
                 case TIMESTAMP -> writer.write("s.WriteTime($L, v.Value)", schemaName);
-                case ENUM -> writer.write("s.WriteString($L, string(v.Value))", schemaName);
                 case INT_ENUM -> writer.write("s.WriteInt32($L, int32(v.Value))", schemaName);
                 case BIG_INTEGER -> writer.write("s.WriteBigInteger($L, v.Value)", schemaName);
                 case BIG_DECIMAL -> writer.write("s.WriteBigDecimal($L, v.Value)", schemaName);
@@ -144,7 +150,7 @@ public class UnionGenerator {
     private void generateMemberDeserializer(GoWriter writer, MemberShape member, String memberName, Shape target) {
         writer.addUseImports(SmithyGoDependency.SMITHY);
         writer.addImport(ctx.settings().getModuleName() + "/schemas", "schemas");
-        var schemaName = "schemas." + SchemaGenerator.getMemberSchemaName(shape, member, ctx.service());
+        var schemaName = SchemaGenerator.getMemberSchemaRef(shape, member, ctx.service());
         writer.openBlock("func (v *$L) Deserialize(d smithy.ShapeDeserializer) error {", "}", memberName, () -> {
             switch (target.getType()) {
                 case BYTE -> writer.write("return d.ReadInt8($L, &v.Value)", schemaName);
@@ -154,15 +160,18 @@ public class UnionGenerator {
                 case FLOAT -> writer.write("return d.ReadFloat32($L, &v.Value)", schemaName);
                 case DOUBLE -> writer.write("return d.ReadFloat64($L, &v.Value)", schemaName);
                 case BOOLEAN -> writer.write("return d.ReadBool($L, &v.Value)", schemaName);
-                case STRING -> writer.write("return d.ReadString($L, &v.Value)", schemaName);
+                case STRING, ENUM -> {
+                    if (ShapeUtil.isEnum(target)) {
+                        writer.write("var s string");
+                        writer.write("if err := d.ReadString($L, &s); err != nil { return err }", schemaName);
+                        writer.write("v.Value = $T(s)", symbolProvider.toSymbol(target));
+                        writer.write("return nil");
+                    } else {
+                        writer.write("return d.ReadString($L, &v.Value)", schemaName);
+                    }
+                }
                 case BLOB -> writer.write("return d.ReadBlob($L, &v.Value)", schemaName);
                 case TIMESTAMP -> writer.write("return d.ReadTime($L, &v.Value)", schemaName);
-                case ENUM -> {
-                    writer.write("var s string");
-                    writer.write("if err := d.ReadString($L, &s); err != nil { return err }", schemaName);
-                    writer.write("v.Value = $T(s)", symbolProvider.toSymbol(target));
-                    writer.write("return nil");
-                }
                 case INT_ENUM -> {
                     writer.write("var i int32");
                     writer.write("if err := d.ReadInt32($L, &i); err != nil { return err }", schemaName);

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/ListDeserializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/ListDeserializer.java
@@ -53,7 +53,8 @@ public class ListDeserializer implements Writable {
                 "shapeName", shape.getId().getName(),
                 "symbol", ctx.symbolProvider().toSymbol(shape),
                 "memberSymbol", switch (member.getType()) {
-                    case ENUM -> GoUniverseTypes.String;
+                    case STRING, ENUM -> ShapeUtil.isEnum(member)
+                            ? GoUniverseTypes.String : ctx.symbolProvider().toSymbol(member);
                     case INT_ENUM -> GoUniverseTypes.Int32;
                     case DOCUMENT -> SmithyGoDependency.SMITHY_DOCUMENT.valueSymbol("Value");
                     default -> ctx.symbolProvider().toSymbol(member);
@@ -87,7 +88,8 @@ public class ListDeserializer implements Writable {
                 "shapeName", shape.getId().getName(),
                 "symbol", ctx.symbolProvider().toSymbol(shape),
                 "memberSymbol", switch (member.getType()) {
-                    case ENUM -> GoUniverseTypes.String;
+                    case STRING, ENUM -> ShapeUtil.isEnum(member)
+                            ? GoUniverseTypes.String : ctx.symbolProvider().toSymbol(member);
                     case INT_ENUM -> GoUniverseTypes.Int32;
                     case DOCUMENT -> SmithyGoDependency.SMITHY_DOCUMENT.valueSymbol("Value");
                     default -> ctx.symbolProvider().toSymbol(member);
@@ -99,11 +101,13 @@ public class ListDeserializer implements Writable {
 
     private Writable renderSparseCast() {
         return switch (member.getType()) {
-            case ENUM, INT_ENUM -> goTemplate("""
+            case STRING, ENUM, INT_ENUM -> ShapeUtil.isEnum(member)
+                    ? goTemplate("""
                     func() $T {
                         ev := $T(vv)
                         return &ev
-                    }()""", ctx.symbolProvider().toSymbol(member));
+                    }()""", ctx.symbolProvider().toSymbol(member))
+                    : goTemplate("&vv");
 
             // don't need the address-of
             case BLOB, LIST, SET, MAP, UNION ->
@@ -117,7 +121,9 @@ public class ListDeserializer implements Writable {
 
     private Writable renderDenseCast() {
         return switch (member.getType()) {
-            case ENUM, INT_ENUM -> goTemplate("$T(vv)", ctx.symbolProvider().toSymbol(member));
+            case STRING, ENUM, INT_ENUM -> ShapeUtil.isEnum(member)
+                    ? goTemplate("$T(vv)", ctx.symbolProvider().toSymbol(member))
+                    : goTemplate("vv");
             case DOCUMENT -> renderDocumentCast();
             default -> goTemplate("vv");
         };

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/ListSerializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/ListSerializer.java
@@ -82,10 +82,10 @@ public class ListSerializer implements Writable {
             case DOUBLE ->
                     wrapNilCheck(goTemplate("s.WriteFloat64(schema.ListMember(), *vv)"));
 
-            case STRING ->
-                    wrapNilCheck(goTemplate("s.WriteString(schema.ListMember(), *vv)"));
-            case ENUM ->
-                    wrapNilCheck(goTemplate("s.WriteString(schema.ListMember(), string(*vv))"));
+            case STRING, ENUM ->
+                    ShapeUtil.isEnum(member)
+                            ? wrapNilCheck(goTemplate("s.WriteString(schema.ListMember(), string(*vv))"))
+                            : wrapNilCheck(goTemplate("s.WriteString(schema.ListMember(), *vv)"));
             case BOOLEAN ->
                     wrapNilCheck(goTemplate("s.WriteBool(schema.ListMember(), *vv)"));
             case TIMESTAMP ->

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/MapDeserializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/MapDeserializer.java
@@ -54,7 +54,8 @@ public class MapDeserializer implements Writable {
                 "shapeName", shape.getId().getName(),
                 "symbol", ctx.symbolProvider().toSymbol(shape),
                 "valueSymbol", switch (value.getType()) {
-                    case ENUM -> GoUniverseTypes.String;
+                    case STRING, ENUM -> ShapeUtil.isEnum(value)
+                            ? GoUniverseTypes.String : ctx.symbolProvider().toSymbol(value);
                     case INT_ENUM -> GoUniverseTypes.Int32;
                     case DOCUMENT -> SmithyGoDependency.SMITHY_DOCUMENT.valueSymbol("Value");
                     default -> ctx.symbolProvider().toSymbol(value);
@@ -89,7 +90,8 @@ public class MapDeserializer implements Writable {
                 "shapeName", shape.getId().getName(),
                 "symbol", ctx.symbolProvider().toSymbol(shape),
                 "valueSymbol", switch (value.getType()) {
-                    case ENUM -> GoUniverseTypes.String;
+                    case STRING, ENUM -> ShapeUtil.isEnum(value)
+                            ? GoUniverseTypes.String : ctx.symbolProvider().toSymbol(value);
                     case INT_ENUM -> GoUniverseTypes.Int32;
                     case DOCUMENT -> SmithyGoDependency.SMITHY_DOCUMENT.valueSymbol("Value");
                     default -> ctx.symbolProvider().toSymbol(value);
@@ -101,11 +103,13 @@ public class MapDeserializer implements Writable {
 
     private Writable renderSparseCast() {
         return switch (value.getType()) {
-            case ENUM, INT_ENUM -> goTemplate("""
+            case STRING, ENUM, INT_ENUM -> ShapeUtil.isEnum(value)
+                    ? goTemplate("""
                     func() $T {
                         ev := $T(vv)
                         return &ev
-                    }()""", ctx.symbolProvider().toSymbol(value));
+                    }()""", ctx.symbolProvider().toSymbol(value))
+                    : goTemplate("&vv");
 
             // don't need the address-of
             case BLOB, LIST, SET, MAP, UNION ->
@@ -119,7 +123,9 @@ public class MapDeserializer implements Writable {
 
     private Writable renderDenseCast() {
         return switch (value.getType()) {
-            case ENUM, INT_ENUM -> goTemplate("$T(vv)", ctx.symbolProvider().toSymbol(value));
+            case STRING, ENUM, INT_ENUM -> ShapeUtil.isEnum(value)
+                    ? goTemplate("$T(vv)", ctx.symbolProvider().toSymbol(value))
+                    : goTemplate("vv");
             case DOCUMENT -> renderDocumentCast();
             default -> goTemplate("vv");
         };

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/MapSerializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/MapSerializer.java
@@ -83,10 +83,10 @@ public class MapSerializer implements Writable {
             case DOUBLE ->
                     wrapNilCheck(goTemplate("s.WriteFloat64(schema.MapValue(), *vv)"));
 
-            case STRING ->
-                    wrapNilCheck(goTemplate("s.WriteString(schema.MapValue(), *vv)"));
-            case ENUM ->
-                    wrapNilCheck(goTemplate("s.WriteString(schema.MapValue(), string(*vv))"));
+            case STRING, ENUM ->
+                    ShapeUtil.isEnum(value)
+                            ? wrapNilCheck(goTemplate("s.WriteString(schema.MapValue(), string(*vv))"))
+                            : wrapNilCheck(goTemplate("s.WriteString(schema.MapValue(), *vv)"));
             case BOOLEAN ->
                     wrapNilCheck(goTemplate("s.WriteBool(schema.MapValue(), *vv)"));
             case TIMESTAMP ->

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/Serde2EventStreamMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/Serde2EventStreamMiddleware.java
@@ -132,7 +132,7 @@ public class Serde2EventStreamMiddleware extends DeserializeStepMiddleware {
 
     private Writable writerSetup(UnionShape inputEventStream) {
         var service = ctx.service();
-        var schemaName = "schemas." + SchemaGenerator.getSchemaName(inputEventStream, service);
+        var schemaName = SchemaGenerator.getSchemaRef(inputEventStream, service);
         var adapterName = EventStreamGenerator.getEventStreamWriterAdapterName(service, inputEventStream);
 
         return goTemplate("""
@@ -178,7 +178,7 @@ public class Serde2EventStreamMiddleware extends DeserializeStepMiddleware {
 
     private Writable readerSetup(UnionShape outputEventStream) {
         var service = ctx.service();
-        var schemaName = "schemas." + SchemaGenerator.getSchemaName(outputEventStream, service);
+        var schemaName = SchemaGenerator.getSchemaRef(outputEventStream, service);
         var adapterConstructor = EventStreamGenerator
                 .getEventStreamReaderAdapterConstructor(service, outputEventStream);
 
@@ -202,7 +202,7 @@ public class Serde2EventStreamMiddleware extends DeserializeStepMiddleware {
 
     private Writable initialRequest() {
         var inputShape = ctx.model().expectShape(operation.getInputShape());
-        var inputSchemaName = "schemas." + SchemaGenerator.getSchemaName(inputShape, ctx.service());
+        var inputSchemaName = SchemaGenerator.getSchemaRef(inputShape, ctx.service());
 
         return goTemplate("""
                 if m.options.Protocol.HasInitialEventMessage() {
@@ -223,7 +223,7 @@ public class Serde2EventStreamMiddleware extends DeserializeStepMiddleware {
     }
 
     private Writable initialResponse(software.amazon.smithy.model.shapes.Shape outputShape) {
-        var outputSchemaName = "schemas." + SchemaGenerator.getSchemaName(outputShape, ctx.service());
+        var outputSchemaName = SchemaGenerator.getSchemaRef(outputShape, ctx.service());
 
         return goTemplate("""
                 if m.options.Protocol.HasInitialEventMessage() {
@@ -338,7 +338,7 @@ public class Serde2EventStreamMiddleware extends DeserializeStepMiddleware {
 
     private Writable v2ReaderSetup(UnionShape outputEventStream) {
         var service = ctx.service();
-        var schemaName = "schemas." + SchemaGenerator.getSchemaName(outputEventStream, service);
+        var schemaName = SchemaGenerator.getSchemaRef(outputEventStream, service);
         var adapterConstructor = EventStreamGenerator
                 .getEventStreamReaderAdapterConstructor(service, outputEventStream);
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/StructureDeserializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/StructureDeserializer.java
@@ -9,6 +9,7 @@ import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.go.codegen.UnsupportedShapeException;
 import software.amazon.smithy.go.codegen.Writable;
 import software.amazon.smithy.go.codegen.knowledge.GoPointableIndex;
+import software.amazon.smithy.go.codegen.util.ShapeUtil;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
@@ -38,10 +39,10 @@ public class StructureDeserializer implements Writable {
                 .sorted(Comparator.comparing(MemberShape::getMemberName))
                 .toList();
         writer.openBlock("func (v *$L) Deserialize(d smithy.ShapeDeserializer) error {", "}", symbol.getName(), () -> {
-            writer.openBlock("return smithy.ReadStruct(d, schemas.$L, func(s *smithy.Schema) error {", "})", SchemaGenerator.getSchemaName(shape, ctx.service()), () -> {
+            writer.openBlock("return smithy.ReadStruct(d, $L, func(s *smithy.Schema) error {", "})", SchemaGenerator.getSchemaRef(shape, ctx.service()), () -> {
                 writer.openBlock("switch s {", "}", () -> {
                     for (var member : members) {
-                        writer.write("case schemas.$L:", SchemaGenerator.getMemberSchemaName(shape, member, ctx.service()));
+                        writer.write("case $L:", SchemaGenerator.getMemberSchemaRef(shape, member, ctx.service()));
                         renderMember(writer, member, ctx.model().expectShape(member.getTarget()), "v." + ctx.symbolProvider().toMemberName(member));
                     }
                 });
@@ -51,50 +52,53 @@ public class StructureDeserializer implements Writable {
     }
 
     private void renderMember(GoWriter writer, MemberShape member, Shape target, String ident) {
-        var schemaName = SchemaGenerator.getMemberSchemaName(shape, member, ctx.service());
+        var schemaName = SchemaGenerator.getMemberSchemaRef(shape, member, ctx.service());
         var ptrSuffix = nilIndex.isNillable(member) ? "Ptr" : "";
         switch (target.getType()) {
             case BYTE ->
-                    writer.write("return d.ReadInt8$L(schemas.$L, &$L)", ptrSuffix, schemaName, ident);
+                    writer.write("return d.ReadInt8$L($L, &$L)", ptrSuffix, schemaName, ident);
             case SHORT ->
-                    writer.write("return d.ReadInt16$L(schemas.$L, &$L)", ptrSuffix, schemaName, ident);
+                    writer.write("return d.ReadInt16$L($L, &$L)", ptrSuffix, schemaName, ident);
             case INTEGER ->
-                    writer.write("return d.ReadInt32$L(schemas.$L, &$L)", ptrSuffix, schemaName, ident);
+                    writer.write("return d.ReadInt32$L($L, &$L)", ptrSuffix, schemaName, ident);
             case LONG ->
-                    writer.write("return d.ReadInt64$L(schemas.$L, &$L)", ptrSuffix, schemaName, ident);
+                    writer.write("return d.ReadInt64$L($L, &$L)", ptrSuffix, schemaName, ident);
 
             case FLOAT ->
-                    writer.write("return d.ReadFloat32$L(schemas.$L, &$L)", ptrSuffix, schemaName, ident);
+                    writer.write("return d.ReadFloat32$L($L, &$L)", ptrSuffix, schemaName, ident);
             case DOUBLE ->
-                    writer.write("return d.ReadFloat64$L(schemas.$L, &$L)", ptrSuffix, schemaName, ident);
+                    writer.write("return d.ReadFloat64$L($L, &$L)", ptrSuffix, schemaName, ident);
 
-            case STRING ->
-                    writer.write("return d.ReadString$L(schemas.$L, &$L)", ptrSuffix, schemaName, ident);
-            case ENUM ->
-                    writer.write("""
-                            var ev string
-                            if err := d.ReadString(schemas.$1L, &ev); err != nil {
-                                return err
-                            }
-                            $2L = $3T(ev)
-                            return nil""", schemaName, ident, ctx.symbolProvider().toSymbol(target));
+            case STRING, ENUM -> {
+                    if (ShapeUtil.isEnum(target)) {
+                        writer.write("""
+                                var ev string
+                                if err := d.ReadString($1L, &ev); err != nil {
+                                    return err
+                                }
+                                $2L = $3T(ev)
+                                return nil""", schemaName, ident, ctx.symbolProvider().toSymbol(target));
+                    } else {
+                        writer.write("return d.ReadString$L($L, &$L)", ptrSuffix, schemaName, ident);
+                    }
+            }
             case INT_ENUM ->
                     writer.write("""
                             var ev int32
-                            if err := d.ReadInt32(schemas.$1L, &ev); err != nil {
+                            if err := d.ReadInt32($1L, &ev); err != nil {
                                 return err
                             }
                             $2L = $3T(ev)
                             return nil""", schemaName, ident, ctx.symbolProvider().toSymbol(target));
             case BOOLEAN ->
-                    writer.write("return d.ReadBool$L(schemas.$L, &$L)", ptrSuffix, schemaName, ident);
+                    writer.write("return d.ReadBool$L($L, &$L)", ptrSuffix, schemaName, ident);
             case TIMESTAMP ->
-                    writer.write("return d.ReadTime$L(schemas.$L, &$L)", ptrSuffix, schemaName, ident);
+                    writer.write("return d.ReadTime$L($L, &$L)", ptrSuffix, schemaName, ident);
             case BLOB ->
-                    writer.write("return d.ReadBlob(schemas.$L, &$L)", schemaName, ident);
+                    writer.write("return d.ReadBlob($L, &$L)", schemaName, ident);
 
             case LIST, SET, MAP, UNION ->
-                    writer.write("return deserialize$L(d, schemas.$L, &$L)", target.getId().getName(), schemaName, ident);
+                    writer.write("return deserialize$L(d, $L, &$L)", target.getId().getName(), schemaName, ident);
             case STRUCTURE -> {
                 if (nilIndex.isNillable(member)) {
                     writer.write("""
@@ -110,7 +114,7 @@ public class StructureDeserializer implements Writable {
                 writer.addUseImports(SmithyGoDependency.SMITHY_DOCUMENT);
                 writer.write("""
                         var dv smithydocument.Value
-                        if err := d.ReadDocument(schemas.$L, &dv); err != nil {
+                        if err := d.ReadDocument($L, &dv); err != nil {
                             return err
                         }
                         if ov, ok := dv.(smithydocument.Opaque); ok {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/StructureSerializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/StructureSerializer.java
@@ -40,7 +40,7 @@ public final class StructureSerializer implements Writable {
                 .sorted(Comparator.comparing(MemberShape::getMemberName))
                 .toList();
         writer.addUseImports(SmithyGoDependency.SMITHY);
-        var schemaRef = "schemas." + SchemaGenerator.getSchemaName(shape, ctx.service());
+        var schemaRef = SchemaGenerator.getSchemaRef(shape, ctx.service());
         writer.openBlock("func (v *$L) Serialize(s smithy.ShapeSerializer) {", "}", symbol.getName(), () -> {
             writer.write("s.WriteStruct($L)", schemaRef);
             writer.write("v.SerializeMembers(s)");
@@ -58,7 +58,7 @@ public final class StructureSerializer implements Writable {
     }
 
     private void generateSerializeMember(GoWriter writer, MemberShape member, Shape target, String ident) {
-        var schemaName = "schemas." + SchemaGenerator.getMemberSchemaName(shape, member, ctx.service());
+        var schemaName = SchemaGenerator.getMemberSchemaRef(shape, member, ctx.service());
         var ptrSuffix = nilIndex.isNillable(member) ? "Ptr" : "";
         switch (target.getType()) {
             case BYTE ->
@@ -75,10 +75,13 @@ public final class StructureSerializer implements Writable {
             case DOUBLE ->
                     writer.write("s.WriteFloat64$L($L, $L)", ptrSuffix, schemaName, ident);
 
-            case STRING ->
-                    writer.write("s.WriteString$L($L, $L)", ptrSuffix, schemaName, ident);
-            case ENUM ->
-                    writer.write("s.WriteString($L, string($L))", schemaName, ident);
+            case STRING, ENUM -> {
+                    if (ShapeUtil.isEnum(target)) {
+                        writer.write("s.WriteString($L, string($L))", schemaName, ident);
+                    } else {
+                        writer.write("s.WriteString$L($L, $L)", ptrSuffix, schemaName, ident);
+                    }
+            }
             case INT_ENUM ->
                     writer.write("s.WriteInt32($L, int32($L))", schemaName, ident);
             case BOOLEAN ->

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/UnionDeserializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/UnionDeserializer.java
@@ -52,13 +52,13 @@ public class UnionDeserializer implements Writable {
             var unionSymbol = ctx.symbolProvider().toSymbol(shape);
             for (var member : members) {
                 var memberName = ctx.symbolProvider().toMemberName(member);
-                var variantSchema = SchemaGenerator.getMemberSchemaName(shape, member, ctx.service());
+                var variantSchema = SchemaGenerator.getMemberSchemaRef(shape, member, ctx.service());
                 
                 var memberSymbol = unionSymbol.toBuilder()
                         .name(memberName)
                         .build();
                 
-                w.write("case schemas.$L:", variantSchema);
+                w.write("case $L:", variantSchema);
                 w.indent();
                 w.write("vv := &$T{}", memberSymbol);
                 w.write("*v = vv");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/UnionSerializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/UnionSerializer.java
@@ -53,9 +53,9 @@ public class UnionSerializer implements Writable {
                         .name(ctx.symbolProvider().toMemberName(member))
                         .namespace(ctx.settings().getModuleName() + "/types", ".")
                         .build();
-                var variantSchema = SchemaGenerator.getMemberSchemaName(shape, member, ctx.service());
+                var variantSchema = SchemaGenerator.getMemberSchemaRef(shape, member, ctx.service());
                 w.write("case *$T:", variantSymbol);
-                w.write("    s.WriteUnion(schema, schemas.$L, vv)", variantSchema);
+                w.write("    s.WriteUnion(schema, $L, vv)", variantSchema);
             }
         };
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/util/ShapeUtil.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/util/ShapeUtil.java
@@ -29,6 +29,7 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.UnitTypeTrait;
 
 public final class ShapeUtil {
@@ -81,5 +82,11 @@ public final class ShapeUtil {
 
     public static Shape expectMember(Model model, MapShape shape) {
         return model.expectShape(shape.getValue().getTarget());
+    }
+
+    // Returns true for both IDL2 enum shapes and IDL1 string + @enum shapes.
+    public static boolean isEnum(Shape shape) {
+        return shape.getType() == ShapeType.ENUM
+                || (shape.getType() == ShapeType.STRING && shape.hasTrait(EnumTrait.class));
     }
 }

--- a/prelude/prelude.go
+++ b/prelude/prelude.go
@@ -1,0 +1,31 @@
+// Package prelude defines schemas for the Smithy prelude shapes.
+package prelude
+
+import "github.com/aws/smithy-go"
+
+// All shapes in the prelude.
+var (
+	String    = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "String"}, smithy.ShapeTypeString, 0)
+	Blob      = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "Blob"}, smithy.ShapeTypeBlob, 0)
+	Boolean   = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "Boolean"}, smithy.ShapeTypeBoolean, 0)
+	Byte      = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "Byte"}, smithy.ShapeTypeByte, 0)
+	Short     = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "Short"}, smithy.ShapeTypeShort, 0)
+	Integer   = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "Integer"}, smithy.ShapeTypeInteger, 0)
+	Long      = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "Long"}, smithy.ShapeTypeLong, 0)
+	Float     = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "Float"}, smithy.ShapeTypeFloat, 0)
+	Double    = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "Double"}, smithy.ShapeTypeDouble, 0)
+	Timestamp = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "Timestamp"}, smithy.ShapeTypeTimestamp, 0)
+	Document  = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "Document"}, smithy.ShapeTypeDocument, 0)
+	Unit      = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "Unit"}, smithy.ShapeTypeStructure, 0)
+
+	PrimitiveBoolean = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "PrimitiveBoolean"}, smithy.ShapeTypeBoolean, 0)
+	PrimitiveByte    = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "PrimitiveByte"}, smithy.ShapeTypeByte, 0)
+	PrimitiveShort   = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "PrimitiveShort"}, smithy.ShapeTypeShort, 0)
+	PrimitiveInteger = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "PrimitiveInteger"}, smithy.ShapeTypeInteger, 0)
+	PrimitiveLong    = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "PrimitiveLong"}, smithy.ShapeTypeLong, 0)
+	PrimitiveFloat   = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "PrimitiveFloat"}, smithy.ShapeTypeFloat, 0)
+	PrimitiveDouble  = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "PrimitiveDouble"}, smithy.ShapeTypeDouble, 0)
+
+	BigInteger = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "BigInteger"}, smithy.ShapeTypeBigInteger, 0)
+	BigDecimal = smithy.NewSchema(smithy.ShapeID{Namespace: "smithy.api", Name: "BigDecimal"}, smithy.ShapeTypeBigDecimal, 0)
+)


### PR DESCRIPTION
* members in services targeting prelude shapes were causing duped primtiive schemas to get generated - added support for those in the runtime which the generator now references
* we still need to handle the old idl1 convention of string shape + `@enum` trait (see #649) everywhere

every downstream service now compiles w/ schema-serde _except_
* s3 (shocker) because of some custom deserialization middleware
* sagemakerruntimehttp2 because it's in a weird state from not generating any operations

i don't expect schema-serde to come online for either of those any time soon, they will likely be the last, so i've just left those alone for now