### PR TITLE
serde2: get the endpoint/auth generators out of the protocol generator

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -33,6 +33,10 @@ import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.go.codegen.GoSettings.ArtifactType;
+import software.amazon.smithy.go.codegen.auth.AuthGenerator;
+import software.amazon.smithy.go.codegen.endpoints.EndpointResolutionGenerator;
+import software.amazon.smithy.go.codegen.endpoints.FnGenerator;
+import software.amazon.smithy.go.codegen.endpoints.FnProvider;
 import software.amazon.smithy.go.codegen.integration.GoIntegration;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.go.codegen.integration.RuntimeClientPlugin;
@@ -381,33 +385,21 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
             }
         }
 
-        // This is all stuff that we'll still need to do but it DEPENDS on ProtocolGenerator right now
-        //
-        // TODO: With serde/schema decoupling, protocol generators are going away. Endpoint/auth resolution is going to
-        //       need to be decoupled from that and I don't really know how yet. Probably just separate integrations /
-        //       integration hooks.
-        if (protocolGenerator != null) {
-            ProtocolGenerator.GenerationContext.Builder contextBuilder = ProtocolGenerator.GenerationContext.builder()
-                    .protocolName(protocolGenerator.getProtocolName())
-                    .integrations(integrations)
-                    .model(model)
-                    .service(service)
-                    .settings(settings)
-                    .symbolProvider(symbolProvider)
-                    .delegator(writers);
+        {
+            FnProvider fnProvider = integrations.stream()
+                    .map(GoIntegration::getEndpointFnProvider)
+                    .filter(java.util.Objects::nonNull)
+                    .findFirst()
+                    .orElse(new FnGenerator.DefaultFnProvider());
+            var endpointGenerator = new EndpointResolutionGenerator(fnProvider);
             writers.useFileWriter("endpoints.go", settings.getModuleName(), writer -> {
-                ProtocolGenerator.GenerationContext context = contextBuilder.writer(writer).build();
-                protocolGenerator.generateEndpointResolution(context);
+                endpointGenerator.generate(ctx, writer);
             });
-
-            writers.useFileWriter("auth.go", settings.getModuleName(), writer -> {
-                ProtocolGenerator.GenerationContext context = contextBuilder.writer(writer).build();
-                protocolGenerator.generateAuth(context);
-            });
-
             writers.useFileWriter("endpoints_test.go", settings.getModuleName(), writer -> {
-                ProtocolGenerator.GenerationContext context = contextBuilder.writer(writer).build();
-                protocolGenerator.generateEndpointResolutionTests(context);
+                endpointGenerator.generateTests(ctx, writer);
+            });
+            writers.useFileWriter("auth.go", settings.getModuleName(), writer -> {
+                new AuthGenerator(ctx, writer).generate();
             });
         }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthGenerator.java
@@ -15,35 +15,25 @@
 
 package software.amazon.smithy.go.codegen.auth;
 
-import software.amazon.smithy.codegen.core.CodegenException;
-import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
+import software.amazon.smithy.go.codegen.GoCodegenContext;
+import software.amazon.smithy.go.codegen.GoWriter;
 
-/**
- * Entry point into smithy client auth generation.
- */
 public class AuthGenerator {
-    private final ProtocolGenerator.GenerationContext context;
+    private final GoCodegenContext ctx;
+    private final GoWriter writer;
 
-    public AuthGenerator(ProtocolGenerator.GenerationContext context) {
-        this.context = context;
+    public AuthGenerator(GoCodegenContext ctx, GoWriter writer) {
+        this.ctx = ctx;
+        this.writer = writer;
     }
 
     public void generate() {
-        if (context.getWriter().isEmpty()) {
-            throw new CodegenException("writer is required");
-        }
-
-        context.getWriter().get()
-                .write("$W\n", new AuthParametersGenerator(context).generate())
-                .write("$W\n", new AuthParametersResolverGenerator(context).generate())
-                .write("$W\n", getResolverGenerator().generate())
-                .write("$W\n", new ResolveAuthSchemeMiddlewareGenerator(context).generate())
-                .write("$W\n", new GetIdentityMiddlewareGenerator(context).generate())
-                .write("$W\n", new SignRequestMiddlewareGenerator(context).generate());
-    }
-
-    // TODO(i&a): allow consuming generators to overwrite
-    private AuthSchemeResolverGenerator getResolverGenerator() {
-        return new AuthSchemeResolverGenerator(context);
+        writer
+                .write("$W\n", new AuthParametersGenerator(ctx).generate())
+                .write("$W\n", new AuthParametersResolverGenerator(ctx).generate())
+                .write("$W\n", new AuthSchemeResolverGenerator(ctx).generate())
+                .write("$W\n", new ResolveAuthSchemeMiddlewareGenerator().generate())
+                .write("$W\n", new GetIdentityMiddlewareGenerator().generate())
+                .write("$W\n", new SignRequestMiddlewareGenerator().generate());
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParametersGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParametersGenerator.java
@@ -20,9 +20,9 @@ import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
 
 import java.util.ArrayList;
 import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.GoCodegenContext;
 import software.amazon.smithy.go.codegen.SymbolUtils;
 import software.amazon.smithy.go.codegen.Writable;
-import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.MapUtils;
 
@@ -37,14 +37,14 @@ public class AuthParametersGenerator {
 
     public static final Symbol STRUCT_SYMBOL = SymbolUtils.createPointableSymbolBuilder(STRUCT_NAME).build();
 
-    private final ProtocolGenerator.GenerationContext context;
+    private final GoCodegenContext ctx;
 
     private final ArrayList<AuthParameter> fields = new ArrayList<>(
             ListUtils.of(AuthParameter.OPERATION)
     );
 
-    public AuthParametersGenerator(ProtocolGenerator.GenerationContext context) {
-        this.context = context;
+    public AuthParametersGenerator(GoCodegenContext ctx) {
+        this.ctx = ctx;
     }
 
     public Writable generate() {
@@ -88,9 +88,9 @@ public class AuthParametersGenerator {
     }
 
     private void loadFields() {
-        for (var integration: context.getIntegrations()) {
+        for (var integration: ctx.integrations()) {
             var plugins = integration.getClientPlugins().stream().filter(it ->
-                    it.matchesService(context.getModel(), context.getService())).toList();
+                    it.matchesService(ctx.model(), ctx.service())).toList();
             for (var plugin: plugins) {
                 fields.addAll(plugin.getAuthParameters());
             }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParametersResolverGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthParametersResolverGenerator.java
@@ -18,9 +18,9 @@ package software.amazon.smithy.go.codegen.auth;
 import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
 
 import java.util.ArrayList;
+import software.amazon.smithy.go.codegen.GoCodegenContext;
 import software.amazon.smithy.go.codegen.GoStdlibTypes;
 import software.amazon.smithy.go.codegen.Writable;
-import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.utils.MapUtils;
 
 /**
@@ -31,12 +31,12 @@ import software.amazon.smithy.utils.MapUtils;
 public class AuthParametersResolverGenerator {
     public static final String FUNC_NAME = "bindAuthResolverParams";
 
-    private final ProtocolGenerator.GenerationContext context;
+    private final GoCodegenContext ctx;
 
     private final ArrayList<AuthParametersResolver> resolvers = new ArrayList<>();
 
-    public AuthParametersResolverGenerator(ProtocolGenerator.GenerationContext context) {
-        this.context = context;
+    public AuthParametersResolverGenerator(GoCodegenContext ctx) {
+        this.ctx = ctx;
     }
 
     public Writable generate() {
@@ -74,9 +74,9 @@ public class AuthParametersResolverGenerator {
     }
 
     private void loadResolvers() {
-        for (var integration: context.getIntegrations()) {
+        for (var integration: ctx.integrations()) {
             var plugins = integration.getClientPlugins().stream().filter(it ->
-                    it.matchesService(context.getModel(), context.getService())).toList();
+                    it.matchesService(ctx.model(), ctx.service())).toList();
             for (var plugin: plugins) {
                 resolvers.addAll(plugin.getAuthParameterResolvers());
             }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthSchemeResolverGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/AuthSchemeResolverGenerator.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import software.amazon.smithy.aws.traits.auth.UnsignedPayloadTrait;
 import software.amazon.smithy.go.codegen.ChainWritable;
+import software.amazon.smithy.go.codegen.GoCodegenContext;
 import software.amazon.smithy.go.codegen.GoStdlibTypes;
 import software.amazon.smithy.go.codegen.Writable;
 import software.amazon.smithy.go.codegen.integration.AuthSchemeDefinition;
@@ -41,15 +42,25 @@ public class AuthSchemeResolverGenerator {
     public static final String INTERFACE_NAME = "AuthSchemeResolver";
     public static final String DEFAULT_NAME = "defaultAuthSchemeResolver";
 
-    private final ProtocolGenerator.GenerationContext context;
+    private final GoCodegenContext ctx;
+    private final ProtocolGenerator.GenerationContext legacyContext;
     private final ServiceIndex serviceIndex;
     private final Map<ShapeId, AuthSchemeDefinition> schemeDefinitions;
 
-    public AuthSchemeResolverGenerator(ProtocolGenerator.GenerationContext context) {
-        this.context = context;
-        this.serviceIndex = ServiceIndex.of(context.getModel());
-        this.schemeDefinitions = context.getIntegrations().stream()
-                .flatMap(it -> it.getClientPlugins(context.getModel(), context.getService()).stream())
+    public AuthSchemeResolverGenerator(GoCodegenContext ctx) {
+        this.ctx = ctx;
+        this.legacyContext = ProtocolGenerator.GenerationContext.builder()
+                .protocolName("")
+                .integrations(ctx.integrations())
+                .model(ctx.model())
+                .service(ctx.service())
+                .settings(ctx.settings())
+                .symbolProvider(ctx.symbolProvider())
+                .delegator((software.amazon.smithy.go.codegen.GoDelegator) ctx.writerDelegator())
+                .build();
+        this.serviceIndex = ServiceIndex.of(ctx.model());
+        this.schemeDefinitions = ctx.integrations().stream()
+                .flatMap(it -> it.getClientPlugins(ctx.model(), ctx.service()).stream())
                 .flatMap(it -> it.getAuthSchemeDefinitions().entrySet().stream())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
@@ -60,10 +71,10 @@ public class AuthSchemeResolverGenerator {
     // 3. it has an unsigned payload
     private boolean hasAuthOverrides(OperationShape operation) {
         var serviceSchemes = serviceIndex
-                .getEffectiveAuthSchemes(context.getService(), ServiceIndex.AuthSchemeMode.NO_AUTH_AWARE)
+                .getEffectiveAuthSchemes(ctx.service(), ServiceIndex.AuthSchemeMode.NO_AUTH_AWARE)
                 .keySet();
         var operationSchemes = serviceIndex
-                .getEffectiveAuthSchemes(context.getService(), operation, ServiceIndex.AuthSchemeMode.NO_AUTH_AWARE)
+                .getEffectiveAuthSchemes(ctx.service(), operation, ServiceIndex.AuthSchemeMode.NO_AUTH_AWARE)
                 .keySet();
         return !serviceSchemes.equals(operationSchemes) || operation.hasTrait(UnsignedPayloadTrait.class);
     }
@@ -136,8 +147,8 @@ public class AuthSchemeResolverGenerator {
 
     private Writable generateOperationAuthOptions() {
         var options = new ChainWritable();
-        TopDownIndex.of(context.getModel())
-                .getContainedOperations(context.getService()).stream()
+        TopDownIndex.of(ctx.model())
+                .getContainedOperations(ctx.service()).stream()
                 .filter(this::hasAuthOverrides)
                 .forEach(it -> {
                     options.add(generateOperationAuthOptionsEntry(it));
@@ -156,12 +167,12 @@ public class AuthSchemeResolverGenerator {
     private Writable generateOperationAuthOptionsEntry(OperationShape operation) {
         var options = new ChainWritable();
         serviceIndex
-                .getEffectiveAuthSchemes(context.getService(), operation, ServiceIndex.AuthSchemeMode.NO_AUTH_AWARE)
+                .getEffectiveAuthSchemes(ctx.service(), operation, ServiceIndex.AuthSchemeMode.NO_AUTH_AWARE)
                 .entrySet().stream()
                 .filter(it -> schemeDefinitions.containsKey(it.getKey()))
                 .forEach(it -> {
                     var definition = schemeDefinitions.get(it.getKey());
-                    options.add(definition.generateOperationOption(context, operation));
+                    options.add(definition.generateOperationOption(legacyContext, operation));
                 });
 
         return options.isEmpty()
@@ -181,12 +192,12 @@ public class AuthSchemeResolverGenerator {
     private Writable generateServiceAuthOptions() {
         var options = new ChainWritable();
         serviceIndex
-                .getEffectiveAuthSchemes(context.getService(), ServiceIndex.AuthSchemeMode.NO_AUTH_AWARE)
+                .getEffectiveAuthSchemes(ctx.service(), ServiceIndex.AuthSchemeMode.NO_AUTH_AWARE)
                 .entrySet().stream()
                 .filter(it -> schemeDefinitions.containsKey(it.getKey()))
                 .forEach(it -> {
                     var definition = schemeDefinitions.get(it.getKey());
-                    options.add(definition.generateServiceOption(context, context.getService()));
+                    options.add(definition.generateServiceOption(legacyContext, ctx.service()));
                 });
 
         return goTemplate("""

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/GetIdentityMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/GetIdentityMiddlewareGenerator.java
@@ -23,17 +23,13 @@ import software.amazon.smithy.go.codegen.GoStdlibTypes;
 import software.amazon.smithy.go.codegen.MiddlewareIdentifier;
 import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.go.codegen.Writable;
-import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.utils.MapUtils;
 
 public class GetIdentityMiddlewareGenerator {
     public static final String MIDDLEWARE_NAME = "getIdentityMiddleware";
     public static final String MIDDLEWARE_ID = "GetIdentity";
 
-    private final ProtocolGenerator.GenerationContext context;
-
-    public GetIdentityMiddlewareGenerator(ProtocolGenerator.GenerationContext context) {
-        this.context = context;
+    public GetIdentityMiddlewareGenerator() {
     }
 
     public static Writable generateAddToProtocolFinalizers() {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/ResolveAuthSchemeMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/ResolveAuthSchemeMiddlewareGenerator.java
@@ -24,17 +24,13 @@ import software.amazon.smithy.go.codegen.GoStdlibTypes;
 import software.amazon.smithy.go.codegen.MiddlewareIdentifier;
 import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.go.codegen.Writable;
-import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.utils.MapUtils;
 
 public class ResolveAuthSchemeMiddlewareGenerator {
     public static final String MIDDLEWARE_NAME = "resolveAuthSchemeMiddleware";
     public static final String MIDDLEWARE_ID = "ResolveAuthScheme";
 
-    private final ProtocolGenerator.GenerationContext context;
-
-    public ResolveAuthSchemeMiddlewareGenerator(ProtocolGenerator.GenerationContext context) {
-        this.context = context;
+    public ResolveAuthSchemeMiddlewareGenerator() {
     }
 
     public static Writable generateAddToProtocolFinalizers() {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/SignRequestMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/SignRequestMiddlewareGenerator.java
@@ -23,17 +23,13 @@ import software.amazon.smithy.go.codegen.MiddlewareIdentifier;
 import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.go.codegen.Writable;
 import software.amazon.smithy.go.codegen.endpoints.EndpointMiddlewareGenerator;
-import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.utils.MapUtils;
 
 public class SignRequestMiddlewareGenerator {
     public static final String MIDDLEWARE_NAME = "signRequestMiddleware";
     public static final String MIDDLEWARE_ID = "Signing";
 
-    private final ProtocolGenerator.GenerationContext context;
-
-    public SignRequestMiddlewareGenerator(ProtocolGenerator.GenerationContext context) {
-        this.context = context;
+    public SignRequestMiddlewareGenerator() {
     }
 
     public static Writable generateAddToProtocolFinalizers() {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointMiddlewareGenerator.java
@@ -19,13 +19,13 @@ import static software.amazon.smithy.go.codegen.GoStackStepMiddlewareGenerator.c
 import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
 import static software.amazon.smithy.go.codegen.SmithyGoDependency.SMITHY_TRACING;
 
+import software.amazon.smithy.go.codegen.GoCodegenContext;
 import software.amazon.smithy.go.codegen.GoStdlibTypes;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.MiddlewareIdentifier;
 import software.amazon.smithy.go.codegen.Writable;
 import software.amazon.smithy.go.codegen.auth.GetIdentityMiddlewareGenerator;
 import software.amazon.smithy.go.codegen.integration.GoIntegration;
-import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
 import software.amazon.smithy.utils.MapUtils;
@@ -38,10 +38,10 @@ public final class EndpointMiddlewareGenerator {
     public static final String MIDDLEWARE_NAME = "resolveEndpointV2Middleware";
     public static final String MIDDLEWARE_ID = "ResolveEndpointV2";
 
-    private final ProtocolGenerator.GenerationContext context;
+    private final GoCodegenContext ctx;
 
-    public EndpointMiddlewareGenerator(ProtocolGenerator.GenerationContext context) {
-        this.context = context;
+    public EndpointMiddlewareGenerator(GoCodegenContext ctx) {
+        this.ctx = ctx;
     }
 
     public static Writable generateAddToProtocolFinalizers() {
@@ -101,8 +101,8 @@ public final class EndpointMiddlewareGenerator {
 
     private Writable generatePreResolutionHooks() {
         return (GoWriter writer) -> {
-            for (GoIntegration integration : context.getIntegrations()) {
-                integration.renderPreEndpointResolutionHook(context.getSettings(), writer, context.getModel());
+            for (GoIntegration integration : ctx.integrations()) {
+                integration.renderPreEndpointResolutionHook(ctx.settings(), writer, ctx.model());
             }
         };
     }
@@ -186,8 +186,8 @@ public final class EndpointMiddlewareGenerator {
 
     private Writable generatePostResolutionHooks() {
         return (GoWriter writer) -> {
-            for (GoIntegration integration : context.getIntegrations()) {
-                integration.renderPostEndpointResolutionHook(context.getSettings(), writer, context.getModel());
+            for (GoIntegration integration : ctx.integrations()) {
+                integration.renderPostEndpointResolutionHook(ctx.settings(), writer, ctx.model());
             }
         };
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointParameterBindingsGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointParameterBindingsGenerator.java
@@ -22,9 +22,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
+import software.amazon.smithy.go.codegen.GoCodegenContext;
 import software.amazon.smithy.go.codegen.GoStdlibTypes;
 import software.amazon.smithy.go.codegen.Writable;
-import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
+import software.amazon.smithy.rulesengine.language.EndpointRuleSet;
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter;
 import software.amazon.smithy.rulesengine.traits.ClientContextParamsTrait;
 import software.amazon.smithy.rulesengine.traits.EndpointBddTrait;
@@ -36,14 +37,14 @@ import software.amazon.smithy.utils.MapUtils;
  * conditionally through EndpointParameterOperationBindingsGenerator.
  */
 public class EndpointParameterBindingsGenerator {
-    private final ProtocolGenerator.GenerationContext context;
+    private final GoCodegenContext ctx;
 
     private final Map<String, Writable> builtinBindings;
 
-    public EndpointParameterBindingsGenerator(ProtocolGenerator.GenerationContext context) {
-        this.context = context;
-        this.builtinBindings = context.getIntegrations().stream()
-                .flatMap(it -> it.getClientPlugins(context.getModel(), context.getService()).stream())
+    public EndpointParameterBindingsGenerator(GoCodegenContext ctx) {
+        this.ctx = ctx;
+        this.builtinBindings = ctx.integrations().stream()
+                .flatMap(it -> it.getClientPlugins(ctx.model(), ctx.service()).stream())
                 .flatMap(it -> it.getEndpointBuiltinBindings().entrySet().stream())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
@@ -70,8 +71,8 @@ public class EndpointParameterBindingsGenerator {
                 """,
                 MapUtils.of(
                         "context", GoStdlibTypes.Context.Context,
-                        "builtinBindings", context.getService().hasTrait(EndpointRuleSetTrait.class)
-                                || context.getService().hasTrait(EndpointBddTrait.class)
+                        "builtinBindings", ctx.service().hasTrait(EndpointRuleSetTrait.class)
+                                || ctx.service().hasTrait(EndpointBddTrait.class)
                                 ? generateBuiltinBindings()
                                 : emptyGoTemplate(),
                         "clientContextBindings", generateClientContextBindings()
@@ -80,15 +81,15 @@ public class EndpointParameterBindingsGenerator {
 
     private Writable generateBuiltinBindings() {
         var bindings = new HashMap<String, Writable>();
-        for (var integration: context.getIntegrations()) {
-            var plugins = integration.getClientPlugins(context.getModel(), context.getService());
+        for (var integration: ctx.integrations()) {
+            var plugins = integration.getClientPlugins(ctx.model(), ctx.service());
             for (var plugin: plugins) {
                 bindings.putAll(plugin.getEndpointBuiltinBindings());
             }
         }
 
         var params = new ArrayList<Parameter>();
-        context.getEndpointRules().getParameters().forEach(params::add);
+        getEndpointRules().getParameters().forEach(params::add);
         var boundBuiltins = params.stream()
                 .filter(it -> it.isBuiltIn() && bindings.containsKey(it.getBuiltIn().get()))
                 .toList();
@@ -115,13 +116,13 @@ public class EndpointParameterBindingsGenerator {
     }
 
     private Writable generateClientContextBindings() {
-        if (!context.getService().hasTrait(ClientContextParamsTrait.class)) {
+        if (!ctx.service().hasTrait(ClientContextParamsTrait.class)) {
             return goTemplate("");
         }
 
         var allParams = new ArrayList<Parameter>();
-        context.getEndpointRules().getParameters().forEach(allParams::add);
-        var contextParams = context.getService().expectTrait(ClientContextParamsTrait.class).getParameters();
+        getEndpointRules().getParameters().forEach(allParams::add);
+        var contextParams = ctx.service().expectTrait(ClientContextParamsTrait.class).getParameters();
         var params = allParams.stream()
                 .filter(it -> contextParams.containsKey(it.getName().getName().getValue()) && !it.isBuiltIn())
                 .toList();
@@ -131,5 +132,17 @@ public class EndpointParameterBindingsGenerator {
                         EndpointParametersGenerator.getExportedParameterName(it));
             });
         };
+    }
+
+    private EndpointRuleSet getEndpointRules() {
+        var service = ctx.service();
+        if (service.hasTrait(EndpointRuleSetTrait.class)) {
+            return EndpointRuleSet.fromNode(service.expectTrait(EndpointRuleSetTrait.class).getRuleSet());
+        }
+        var bddTrait = service.expectTrait(EndpointBddTrait.class);
+        return EndpointRuleSet.builder()
+                .version(bddTrait.getVersion().toString())
+                .parameters(bddTrait.getParameters())
+                .build();
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolutionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolutionGenerator.java
@@ -19,11 +19,11 @@ package software.amazon.smithy.go.codegen.endpoints;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.go.codegen.GoCodegenContext;
+import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.go.codegen.SymbolUtils;
-import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.rulesengine.language.EndpointRuleSet;
 import software.amazon.smithy.rulesengine.traits.EndpointBddTrait;
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
@@ -62,14 +62,8 @@ public class EndpointResolutionGenerator {
         this.newResolverFn = SymbolUtils.createValueSymbolBuilder(NEW_RESOLVER_FUNC_NAME).build();
     }
 
-    public void generate(ProtocolGenerator.GenerationContext context) {
-        if (context.getWriter().isEmpty()) {
-            throw new CodegenException("writer is required");
-        }
-
-        var writer = context.getWriter().get();
-
-        var serviceShape = context.getService();
+    public void generate(GoCodegenContext ctx, GoWriter writer) {
+        var serviceShape = ctx.service();
 
         var parametersGenerator = EndpointParametersGenerator.builder()
                 .parametersType(parametersType)
@@ -85,8 +79,8 @@ public class EndpointResolutionGenerator {
                 .fnProvider(this.fnProvider)
                 .build();
 
-        var bindingGenerator = new EndpointParameterBindingsGenerator(context);
-        var middlewareGenerator = new EndpointMiddlewareGenerator(context);
+        var bindingGenerator = new EndpointParameterBindingsGenerator(ctx);
+        var middlewareGenerator = new EndpointMiddlewareGenerator(ctx);
 
         // Prefer BDD trait over tree-based ruleset when available
         var bddTrait = serviceShape.getTrait(EndpointBddTrait.class);
@@ -118,13 +112,8 @@ public class EndpointResolutionGenerator {
                 .write("$W", middlewareGenerator.generate());
     }
 
-    public void generateTests(ProtocolGenerator.GenerationContext context) {
-        if (context.getWriter().isEmpty()) {
-            throw new CodegenException("writer is required");
-        }
-
-        var writer = context.getWriter().get();
-        var serviceShape = context.getService();
+    public void generateTests(GoCodegenContext ctx, GoWriter writer) {
+        var serviceShape = ctx.service();
         Optional<EndpointRuleSet> ruleset = serviceShape.getTrait(EndpointRuleSetTrait.class)
                 .map((trait) -> EndpointRuleSet.fromNode(trait.getRuleSet()));
         if (ruleset.isEmpty()) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegration.java
@@ -23,6 +23,7 @@ import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.go.codegen.GoCodegenContext;
 import software.amazon.smithy.go.codegen.GoDelegator;
 import software.amazon.smithy.go.codegen.GoSettings;
+import software.amazon.smithy.go.codegen.endpoints.FnProvider;
 import software.amazon.smithy.go.codegen.GoSettings.ArtifactType;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.TriConsumer;
@@ -171,6 +172,14 @@ public interface GoIntegration extends SmithyIntegration<GoSettings, GoWriter, G
      */
     default List<ProtocolGenerator> getProtocolGenerators() {
         return Collections.emptyList();
+    }
+
+    /**
+     * Gets a custom endpoint rule function provider. Returning null (the default) indicates no custom functions.
+     * The returned provider is consulted before the built-in default provider.
+     */
+    default FnProvider getEndpointFnProvider() {
+        return null;
     }
 
     /**

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ProtocolGenerator.java
@@ -29,9 +29,6 @@ import software.amazon.smithy.go.codegen.GoDelegator;
 import software.amazon.smithy.go.codegen.GoSettings;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.Synthetic;
-import software.amazon.smithy.go.codegen.auth.AuthGenerator;
-import software.amazon.smithy.go.codegen.endpoints.EndpointResolutionGenerator;
-import software.amazon.smithy.go.codegen.endpoints.FnGenerator;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.ExpectationNotMetException;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -462,8 +459,6 @@ public interface ProtocolGenerator {
      * @param context the generation context.
      */
     default void generateEndpointResolution(GenerationContext context) {
-        var generator = new EndpointResolutionGenerator(new FnGenerator.DefaultFnProvider());
-        generator.generate(context);
     }
 
     /**
@@ -472,8 +467,6 @@ public interface ProtocolGenerator {
      * @param context the generation context.
      */
     default void generateEndpointResolutionTests(GenerationContext context) {
-        var generator = new EndpointResolutionGenerator(new FnGenerator.DefaultFnProvider());
-        generator.generateTests(context);
     }
 
     /**
@@ -482,7 +475,6 @@ public interface ProtocolGenerator {
      * @param context The generation context.
      */
     default void generateAuth(GenerationContext context) {
-        new AuthGenerator(context).generate();
     }
 
     /**


### PR DESCRIPTION
Protocol generator will end up going away so these need to generate on their own.

The SDK overrode the protocol generators to add aws endpoint rule functions, so I just replaced that with a new integration hook that lets you add a custom one.

The codegen output is identical from before.