### PR TITLE
serde2: drop writeptr shenanigans and optimize allocs on loop deserialize

### DIFF
--- a/aws-protocols/internal/httpbinding/serializer.go
+++ b/aws-protocols/internal/httpbinding/serializer.go
@@ -55,9 +55,7 @@ type ShapeSerializer struct {
 }
 
 // ShapeSerializerOptions configures a ShapeSerializer.
-type ShapeSerializerOptions struct {
-	WriteZeroValues bool
-}
+type ShapeSerializerOptions struct{}
 
 // NewShapeSerializer creates a ShapeSerializer for the given operation schema
 // and request. It handles the initial setup from use of an
@@ -143,16 +141,6 @@ func (s *ShapeSerializer) setBody(body io.Reader, contentType string) error {
 	}
 	*s.request = *sreq
 	return nil
-}
-
-// withWriteZero allows temporarily setting to true the ShapeSerializer `options.WriteZeroValues`
-// This is useful for writing pointer values that have an empty value, like `&""`, which would be skipped
-// otherwise if `options.WriteZeroValues` would be set to false
-func (s *ShapeSerializer) withWriteZero(fn func()) {
-	prev := s.options.WriteZeroValues
-	s.options.WriteZeroValues = true
-	fn()
-	s.options.WriteZeroValues = prev
 }
 
 type mapBindingMode int
@@ -283,9 +271,6 @@ func (s *ShapeSerializer) WriteString(schema *smithy.Schema, v string) {
 	}
 
 	bt, bn := s.resolveBinding(schema)
-	if v == "" && !s.options.WriteZeroValues && bt != bindLabel {
-		return
-	}
 	switch bt {
 	case bindHeaderList:
 		escaped := v
@@ -312,18 +297,7 @@ func (s *ShapeSerializer) WriteString(schema *smithy.Schema, v string) {
 			s.httpPayloadContentType = "text/plain"
 			return
 		}
-		if s.options.WriteZeroValues {
-			s.input.WriteStringPtr(schema, &v)
-		} else {
-			s.input.WriteString(schema, v)
-		}
-	}
-}
-
-// WriteStringPtr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteStringPtr(schema *smithy.Schema, v *string) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteString(schema, *v) })
+		s.input.WriteString(schema, v)
 	}
 }
 
@@ -343,18 +317,7 @@ func (s *ShapeSerializer) WriteBool(schema *smithy.Schema, v bool) {
 	case bindQuery:
 		s.encoder.SetQuery(bn).Boolean(v)
 	default:
-		if s.options.WriteZeroValues {
-			s.input.WriteBoolPtr(schema, &v)
-		} else {
-			s.input.WriteBool(schema, v)
-		}
-	}
-}
-
-// WriteBoolPtr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteBoolPtr(schema *smithy.Schema, v *bool) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteBool(schema, *v) })
+		s.input.WriteBool(schema, v)
 	}
 }
 
@@ -374,18 +337,7 @@ func (s *ShapeSerializer) WriteInt8(schema *smithy.Schema, v int8) {
 	case bindQuery:
 		s.encoder.SetQuery(bn).Byte(v)
 	default:
-		if s.options.WriteZeroValues {
-			s.input.WriteInt8Ptr(schema, &v)
-		} else {
-			s.input.WriteInt8(schema, v)
-		}
-	}
-}
-
-// WriteInt8Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt8Ptr(schema *smithy.Schema, v *int8) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteInt8(schema, *v) })
+		s.input.WriteInt8(schema, v)
 	}
 }
 
@@ -405,18 +357,7 @@ func (s *ShapeSerializer) WriteInt16(schema *smithy.Schema, v int16) {
 	case bindQuery:
 		s.encoder.SetQuery(bn).Short(v)
 	default:
-		if s.options.WriteZeroValues {
-			s.input.WriteInt16Ptr(schema, &v)
-		} else {
-			s.input.WriteInt16(schema, v)
-		}
-	}
-}
-
-// WriteInt16Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt16Ptr(schema *smithy.Schema, v *int16) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteInt16(schema, *v) })
+		s.input.WriteInt16(schema, v)
 	}
 }
 
@@ -436,18 +377,7 @@ func (s *ShapeSerializer) WriteInt32(schema *smithy.Schema, v int32) {
 	case bindQuery:
 		s.encoder.SetQuery(bn).Integer(v)
 	default:
-		if s.options.WriteZeroValues {
-			s.input.WriteInt32Ptr(schema, &v)
-		} else {
-			s.input.WriteInt32(schema, v)
-		}
-	}
-}
-
-// WriteInt32Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt32Ptr(schema *smithy.Schema, v *int32) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteInt32(schema, *v) })
+		s.input.WriteInt32(schema, v)
 	}
 }
 
@@ -467,18 +397,7 @@ func (s *ShapeSerializer) WriteInt64(schema *smithy.Schema, v int64) {
 	case bindQuery:
 		s.encoder.SetQuery(bn).Long(v)
 	default:
-		if s.options.WriteZeroValues {
-			s.input.WriteInt64Ptr(schema, &v)
-		} else {
-			s.input.WriteInt64(schema, v)
-		}
-	}
-}
-
-// WriteInt64Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt64Ptr(schema *smithy.Schema, v *int64) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteInt64(schema, *v) })
+		s.input.WriteInt64(schema, v)
 	}
 }
 
@@ -498,18 +417,7 @@ func (s *ShapeSerializer) WriteFloat32(schema *smithy.Schema, v float32) {
 	case bindQuery:
 		s.encoder.SetQuery(bn).Float(v)
 	default:
-		if s.options.WriteZeroValues {
-			s.input.WriteFloat32Ptr(schema, &v)
-		} else {
-			s.input.WriteFloat32(schema, v)
-		}
-	}
-}
-
-// WriteFloat32Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteFloat32Ptr(schema *smithy.Schema, v *float32) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteFloat32(schema, *v) })
+		s.input.WriteFloat32(schema, v)
 	}
 }
 
@@ -529,18 +437,7 @@ func (s *ShapeSerializer) WriteFloat64(schema *smithy.Schema, v float64) {
 	case bindQuery:
 		s.encoder.SetQuery(bn).Double(v)
 	default:
-		if s.options.WriteZeroValues {
-			s.input.WriteFloat64Ptr(schema, &v)
-		} else {
-			s.input.WriteFloat64(schema, v)
-		}
-	}
-}
-
-// WriteFloat64Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteFloat64Ptr(schema *smithy.Schema, v *float64) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteFloat64(schema, *v) })
+		s.input.WriteFloat64(schema, v)
 	}
 }
 
@@ -579,13 +476,6 @@ func (s *ShapeSerializer) WriteTime(schema *smithy.Schema, v time.Time) {
 		s.encoder.SetQuery(bn).String(formatTimestamp(schema, "date-time", v))
 	default:
 		s.input.WriteTime(schema, v)
-	}
-}
-
-// WriteTimePtr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteTimePtr(schema *smithy.Schema, v *time.Time) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteTime(schema, *v) })
 	}
 }
 
@@ -714,14 +604,14 @@ func (s *ShapeSerializer) WriteNil(schema *smithy.Schema) {
 	s.input.WriteNil(schema)
 }
 
-// WriteBigInteger implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteBigInteger(schema *smithy.Schema, v big.Int) {
-	s.input.WriteBigInteger(schema, v)
+// WriteBigInt implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteBigInt(schema *smithy.Schema, v *big.Int) {
+	s.input.WriteBigInt(schema, v)
 }
 
-// WriteBigDecimal implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteBigDecimal(schema *smithy.Schema, v big.Float) {
-	s.input.WriteBigDecimal(schema, v)
+// WriteBigFloat implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteBigFloat(schema *smithy.Schema, v *big.Float) {
+	s.input.WriteBigFloat(schema, v)
 }
 
 // WriteDocument implements [smithy.ShapeSerializer].

--- a/aws-protocols/internal/json/shape_serializer.go
+++ b/aws-protocols/internal/json/shape_serializer.go
@@ -23,12 +23,6 @@ type ShapeSerializer struct {
 
 // Options configures JSON shape serialization and deserialization.
 type Options struct {
-	// Controls whether scalar zero values (numbers, strings, bools) are
-	// written. If false (the default), zero values are not encoded.
-	//
-	// Pointer write methods are NOT affected by this option.
-	WriteZeroValues bool
-
 	// Controls whether the @jsonName trait is used to
 	// determine JSON object keys. If false (the default), the member
 	// name is used as-is.
@@ -59,86 +53,8 @@ func (s *ShapeSerializer) Bytes() []byte {
 	return s.root.Bytes()
 }
 
-// WriteInt8Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt8Ptr(schema *smithy.Schema, v *int8) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteInt8(schema, *v) })
-	}
-}
-
-// WriteInt16Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt16Ptr(schema *smithy.Schema, v *int16) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteInt16(schema, *v) })
-	}
-}
-
-// WriteInt32Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt32Ptr(schema *smithy.Schema, v *int32) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteInt32(schema, *v) })
-	}
-}
-
-// WriteInt64Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt64Ptr(schema *smithy.Schema, v *int64) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteInt64(schema, *v) })
-	}
-}
-
-// WriteFloat32Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteFloat32Ptr(schema *smithy.Schema, v *float32) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteFloat32(schema, *v) })
-	}
-}
-
-// WriteFloat64Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteFloat64Ptr(schema *smithy.Schema, v *float64) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteFloat64(schema, *v) })
-	}
-}
-
-// WriteBoolPtr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteBoolPtr(schema *smithy.Schema, v *bool) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteBool(schema, *v) })
-	}
-}
-
-// WriteStringPtr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteStringPtr(schema *smithy.Schema, v *string) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteString(schema, *v) })
-	}
-}
-
-func (s *ShapeSerializer) withWriteZero(fn func()) {
-	prev := s.opts.WriteZeroValues
-	s.opts.WriteZeroValues = true
-	fn()
-	s.opts.WriteZeroValues = prev
-}
-
-func (s *ShapeSerializer) skipZeroValue() bool {
-	if s.opts.WriteZeroValues {
-		return false
-	}
-	switch s.head.Top().(type) {
-	case *smithyjson.Array, smithyjson.Value:
-		return false
-	default:
-		return true
-	}
-}
-
 // WriteBool implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteBool(schema *smithy.Schema, v bool) {
-	if !v && s.skipZeroValue() {
-		return
-	}
 	switch enc := s.head.Top().(type) {
 	case *smithyjson.Object:
 		enc.Key(s.jsonMemberName(schema)).Boolean(v)
@@ -154,9 +70,6 @@ func (s *ShapeSerializer) WriteBool(schema *smithy.Schema, v bool) {
 
 // WriteInt8 implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteInt8(schema *smithy.Schema, v int8) {
-	if v == 0 && s.skipZeroValue() {
-		return
-	}
 	switch enc := s.head.Top().(type) {
 	case *smithyjson.Object:
 		enc.Key(s.jsonMemberName(schema)).Byte(v)
@@ -172,9 +85,6 @@ func (s *ShapeSerializer) WriteInt8(schema *smithy.Schema, v int8) {
 
 // WriteInt16 implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteInt16(schema *smithy.Schema, v int16) {
-	if v == 0 && s.skipZeroValue() {
-		return
-	}
 	switch enc := s.head.Top().(type) {
 	case *smithyjson.Object:
 		enc.Key(s.jsonMemberName(schema)).Short(v)
@@ -190,9 +100,6 @@ func (s *ShapeSerializer) WriteInt16(schema *smithy.Schema, v int16) {
 
 // WriteInt32 implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteInt32(schema *smithy.Schema, v int32) {
-	if v == 0 && s.skipZeroValue() {
-		return
-	}
 	switch enc := s.head.Top().(type) {
 	case *smithyjson.Object:
 		enc.Key(s.jsonMemberName(schema)).Integer(v)
@@ -208,9 +115,6 @@ func (s *ShapeSerializer) WriteInt32(schema *smithy.Schema, v int32) {
 
 // WriteInt64 implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteInt64(schema *smithy.Schema, v int64) {
-	if v == 0 && s.skipZeroValue() {
-		return
-	}
 	switch enc := s.head.Top().(type) {
 	case *smithyjson.Object:
 		enc.Key(s.jsonMemberName(schema)).Long(v)
@@ -226,10 +130,6 @@ func (s *ShapeSerializer) WriteInt64(schema *smithy.Schema, v int64) {
 
 // WriteFloat32 implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteFloat32(schema *smithy.Schema, v float32) {
-	if v == 0 && s.skipZeroValue() {
-		return
-	}
-
 	var jv smithyjson.Value
 	switch enc := s.head.Top().(type) {
 	case *smithyjson.Object:
@@ -255,10 +155,6 @@ func (s *ShapeSerializer) WriteFloat32(schema *smithy.Schema, v float32) {
 	}
 }
 func (s *ShapeSerializer) WriteFloat64(schema *smithy.Schema, v float64) {
-	if v == 0 && s.skipZeroValue() {
-		return
-	}
-
 	var jv smithyjson.Value
 	switch enc := s.head.Top().(type) {
 	case *smithyjson.Object:
@@ -286,9 +182,6 @@ func (s *ShapeSerializer) WriteFloat64(schema *smithy.Schema, v float64) {
 
 // WriteString implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteString(schema *smithy.Schema, v string) {
-	if v == "" && s.skipZeroValue() {
-		return
-	}
 	switch enc := s.head.Top().(type) {
 	case *smithyjson.Object:
 		enc.Key(s.jsonMemberName(schema)).String(v)
@@ -304,10 +197,6 @@ func (s *ShapeSerializer) WriteString(schema *smithy.Schema, v string) {
 
 // WriteBlob implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteBlob(schema *smithy.Schema, v []byte) {
-	if v == nil { // we don't write null so skipZeroValue is irrelevant
-		return
-	}
-
 	switch enc := s.head.Top().(type) {
 	case *smithyjson.Object:
 		enc.Key(s.jsonMemberName(schema)).Base64EncodeBytes(v)
@@ -398,13 +287,6 @@ func (s *ShapeSerializer) WriteTime(schema *smithy.Schema, v time.Time) {
 	}
 }
 
-// WriteTimePtr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteTimePtr(schema *smithy.Schema, v *time.Time) {
-	if v != nil {
-		s.WriteTime(schema, *v)
-	}
-}
-
 // WriteUnion implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteUnion(schema, variant *smithy.Schema, v smithy.Serializable) {
 	switch enc := s.head.Top().(type) {
@@ -466,13 +348,13 @@ func (s *ShapeSerializer) WriteNil(schema *smithy.Schema) {
 	}
 }
 
-// WriteBigInteger is unimplemented and will panic.
-func (s *ShapeSerializer) WriteBigInteger(schema *smithy.Schema, v big.Int) {
+// WriteBigInt is unimplemented and will panic.
+func (s *ShapeSerializer) WriteBigInt(schema *smithy.Schema, v *big.Int) {
 	panic("unimplemented")
 }
 
-// WriteBigDecimal is unimplemented and will panic.
-func (s *ShapeSerializer) WriteBigDecimal(schema *smithy.Schema, v big.Float) {
+// WriteBigFloat is unimplemented and will panic.
+func (s *ShapeSerializer) WriteBigFloat(schema *smithy.Schema, v *big.Float) {
 	panic("unimplemented")
 }
 

--- a/aws-protocols/internal/query/shape_serializer.go
+++ b/aws-protocols/internal/query/shape_serializer.go
@@ -63,8 +63,6 @@ type kv struct {
 
 // ShapeSerializerOptions configures a ShapeSerializer.
 type ShapeSerializerOptions struct {
-	WriteZeroValues bool
-
 	// Adjusts serialization for the ec2Query protocol:
 	//  - Member names resolve via @ec2QueryName, then @xmlName
 	//    capitalized, then member name capitalized (instead of @xmlName
@@ -116,29 +114,6 @@ func (s *ShapeSerializer) top() ctxKind {
 		return ctxKindNone
 	}
 	return t.kind
-}
-
-func (s *ShapeSerializer) withWriteZero(fn func()) {
-	prev := s.opts.WriteZeroValues
-	s.opts.WriteZeroValues = true
-	fn()
-	s.opts.WriteZeroValues = prev
-}
-
-func (s *ShapeSerializer) skipZeroValue() bool {
-	if s.opts.WriteZeroValues {
-		return false
-	}
-	if s.stack.Len() == 0 {
-		return false
-	}
-
-	switch s.top() {
-	case ctxKindList, ctxKindMapValue:
-		return false
-	default:
-		return true
-	}
 }
 
 func (s *ShapeSerializer) memberName(schema *smithy.Schema) string {
@@ -214,60 +189,8 @@ func (s *ShapeSerializer) bufferMapEntry(key, value string) bool {
 	return false
 }
 
-// WriteInt8Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt8Ptr(schema *smithy.Schema, v *int8) {
-	writePtr(s, schema, v, (*ShapeSerializer).WriteInt8)
-}
-
-// WriteInt16Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt16Ptr(schema *smithy.Schema, v *int16) {
-	writePtr(s, schema, v, (*ShapeSerializer).WriteInt16)
-}
-
-// WriteInt32Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt32Ptr(schema *smithy.Schema, v *int32) {
-	writePtr(s, schema, v, (*ShapeSerializer).WriteInt32)
-}
-
-// WriteInt64Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt64Ptr(schema *smithy.Schema, v *int64) {
-	writePtr(s, schema, v, (*ShapeSerializer).WriteInt64)
-}
-
-// WriteFloat32Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteFloat32Ptr(schema *smithy.Schema, v *float32) {
-	writePtr(s, schema, v, (*ShapeSerializer).WriteFloat32)
-}
-
-// WriteFloat64Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteFloat64Ptr(schema *smithy.Schema, v *float64) {
-	writePtr(s, schema, v, (*ShapeSerializer).WriteFloat64)
-}
-
-// WriteBoolPtr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteBoolPtr(schema *smithy.Schema, v *bool) {
-	writePtr(s, schema, v, (*ShapeSerializer).WriteBool)
-}
-
-// WriteStringPtr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteStringPtr(schema *smithy.Schema, v *string) {
-	writePtr(s, schema, v, (*ShapeSerializer).WriteString)
-}
-
-func writePtr[T any](s *ShapeSerializer, schema *smithy.Schema, v *T, write func(*ShapeSerializer, *smithy.Schema, T)) {
-	if v == nil {
-		return
-	}
-
-	s.withWriteZero(func() { write(s, schema, *v) })
-}
-
 // WriteBool implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteBool(schema *smithy.Schema, v bool) {
-	if !v && s.skipZeroValue() {
-		return
-	}
-
 	if v {
 		s.writeValue(s.resolveKey(schema), "true")
 	} else {
@@ -294,18 +217,10 @@ func (s *ShapeSerializer) WriteFloat32(schema *smithy.Schema, v float32) { write
 func (s *ShapeSerializer) WriteFloat64(schema *smithy.Schema, v float64) { writeFloat(s, schema, v) }
 
 func writeInt[T int8 | int16 | int32 | int64](s *ShapeSerializer, schema *smithy.Schema, v T) {
-	if v == 0 && s.skipZeroValue() {
-		return
-	}
-
 	s.writeValue(s.resolveKey(schema), strconv.FormatInt(int64(v), 10))
 }
 
 func writeFloat[T float32 | float64](s *ShapeSerializer, schema *smithy.Schema, v T) {
-	if v == 0 && s.skipZeroValue() {
-		return
-	}
-
 	s.writeValue(s.resolveKey(schema), formatFloat(float64(v)))
 }
 
@@ -324,10 +239,6 @@ func formatFloat(v float64) string {
 
 // WriteString implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteString(schema *smithy.Schema, v string) {
-	if v == "" && s.skipZeroValue() {
-		return
-	}
-
 	s.writeValue(s.resolveKey(schema), v)
 }
 
@@ -360,13 +271,6 @@ func (s *ShapeSerializer) WriteTime(schema *smithy.Schema, v time.Time) {
 	}
 
 	s.writeValue(s.resolveKey(schema), sv)
-}
-
-// WriteTimePtr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteTimePtr(schema *smithy.Schema, v *time.Time) {
-	if v != nil {
-		s.WriteTime(schema, *v)
-	}
 }
 
 // WriteStruct implements [smithy.ShapeSerializer].
@@ -551,13 +455,13 @@ func (s *ShapeSerializer) CloseMap() {
 	s.currPrefix = ctx.prefix
 }
 
-// WriteBigInteger is unimplemented.
-func (s *ShapeSerializer) WriteBigInteger(_ *smithy.Schema, _ big.Int) {
+// WriteBigInt is unimplemented.
+func (s *ShapeSerializer) WriteBigInt(_ *smithy.Schema, _ *big.Int) {
 	panic("query: BigInteger not supported")
 }
 
-// WriteBigDecimal is unimplemented.
-func (s *ShapeSerializer) WriteBigDecimal(_ *smithy.Schema, _ big.Float) {
+// WriteBigFloat is unimplemented.
+func (s *ShapeSerializer) WriteBigFloat(_ *smithy.Schema, _ *big.Float) {
 	panic("query: BigDecimal not supported")
 }
 

--- a/aws-protocols/internal/xml/shape_serializer.go
+++ b/aws-protocols/internal/xml/shape_serializer.go
@@ -86,34 +86,6 @@ func (s *ShapeSerializer) WriteInt64(schema *smithy.Schema, v int64) {
 	s.writeScalar(schema, strconv.FormatInt(v, 10))
 }
 
-// WriteInt8Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt8Ptr(schema *smithy.Schema, v *int8) {
-	if v != nil {
-		s.WriteInt8(schema, *v)
-	}
-}
-
-// WriteInt16Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt16Ptr(schema *smithy.Schema, v *int16) {
-	if v != nil {
-		s.WriteInt16(schema, *v)
-	}
-}
-
-// WriteInt32Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt32Ptr(schema *smithy.Schema, v *int32) {
-	if v != nil {
-		s.WriteInt32(schema, *v)
-	}
-}
-
-// WriteInt64Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt64Ptr(schema *smithy.Schema, v *int64) {
-	if v != nil {
-		s.WriteInt64(schema, *v)
-	}
-}
-
 // WriteFloat32 implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteFloat32(schema *smithy.Schema, v float32) {
 	s.writeScalar(schema, formatFloat(float64(v), 32))
@@ -124,30 +96,9 @@ func (s *ShapeSerializer) WriteFloat64(schema *smithy.Schema, v float64) {
 	s.writeScalar(schema, formatFloat(v, 64))
 }
 
-// WriteFloat32Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteFloat32Ptr(schema *smithy.Schema, v *float32) {
-	if v != nil {
-		s.WriteFloat32(schema, *v)
-	}
-}
-
-// WriteFloat64Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteFloat64Ptr(schema *smithy.Schema, v *float64) {
-	if v != nil {
-		s.WriteFloat64(schema, *v)
-	}
-}
-
 // WriteBool implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteBool(schema *smithy.Schema, v bool) {
 	s.writeScalar(schema, strconv.FormatBool(v))
-}
-
-// WriteBoolPtr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteBoolPtr(schema *smithy.Schema, v *bool) {
-	if v != nil {
-		s.WriteBool(schema, *v)
-	}
 }
 
 // WriteString implements [smithy.ShapeSerializer].
@@ -155,21 +106,13 @@ func (s *ShapeSerializer) WriteString(schema *smithy.Schema, v string) {
 	s.writeScalar(schema, v)
 }
 
-// WriteStringPtr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteStringPtr(schema *smithy.Schema, v *string) {
-	if v == nil {
-		return
-	}
-	s.WriteString(schema, *v)
-}
-
-// WriteBigInteger is unimplemented.
-func (s *ShapeSerializer) WriteBigInteger(_ *smithy.Schema, _ big.Int) {
+// WriteBigInt is unimplemented.
+func (s *ShapeSerializer) WriteBigInt(_ *smithy.Schema, _ *big.Int) {
 	panic("BigInteger not supported")
 }
 
-// WriteBigDecimal is unimplemented.
-func (s *ShapeSerializer) WriteBigDecimal(_ *smithy.Schema, _ big.Float) {
+// WriteBigFloat is unimplemented.
+func (s *ShapeSerializer) WriteBigFloat(_ *smithy.Schema, _ *big.Float) {
 	panic("BigDecimal not supported")
 }
 
@@ -195,13 +138,6 @@ func (s *ShapeSerializer) WriteTime(schema *smithy.Schema, v time.Time) {
 		s.writeScalar(schema, strconv.FormatFloat(smithytime.FormatEpochSeconds(v), 'f', -1, 64))
 	default:
 		s.writeScalar(schema, smithytime.FormatDateTime(v))
-	}
-}
-
-// WriteTimePtr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteTimePtr(schema *smithy.Schema, v *time.Time) {
-	if v != nil {
-		s.WriteTime(schema, *v)
 	}
 }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/ListDeserializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/ListDeserializer.java
@@ -39,8 +39,9 @@ public class ListDeserializer implements Writable {
     private void renderDense(GoWriter writer) {
         writer.writeGoTemplate("""
                 func deserialize$shapeName:L(d smithy.ShapeDeserializer, s *smithy.Schema, v *$symbol:T) error {
+                    var vv $memberSymbol:T
                     return smithy.ReadList(d, s, func() error {
-                        var vv $memberSymbol:T
+                        $zeroValue:W
                         if err := $deserializeMember:W; err != nil {
                             return err
                         }
@@ -59,6 +60,7 @@ public class ListDeserializer implements Writable {
                     case DOCUMENT -> SmithyGoDependency.SMITHY_DOCUMENT.valueSymbol("Value");
                     default -> ctx.symbolProvider().toSymbol(member);
                 },
+                "zeroValue", renderZeroValue(),
                 "deserializeMember", renderDeserializeMember(),
                 "cast", renderDenseCast()
         ));
@@ -67,6 +69,7 @@ public class ListDeserializer implements Writable {
     private void renderSparse(GoWriter writer) {
         writer.writeGoTemplate("""
                 func deserialize$shapeName:L(d smithy.ShapeDeserializer, s *smithy.Schema, v *$symbol:T) error {
+                    var vv $memberSymbol:T
                     return smithy.ReadList(d, s, func() error {
                         if isNil, err := d.ReadNil(s.ListMember()); err != nil {
                             return err
@@ -75,7 +78,7 @@ public class ListDeserializer implements Writable {
                             return nil
                         }
 
-                        var vv $memberSymbol:T
+                        $zeroValue:W
                         if err := $deserializeMember:W; err != nil {
                             return err
                         }
@@ -94,9 +97,18 @@ public class ListDeserializer implements Writable {
                     case DOCUMENT -> SmithyGoDependency.SMITHY_DOCUMENT.valueSymbol("Value");
                     default -> ctx.symbolProvider().toSymbol(member);
                 },
+                "zeroValue", renderZeroValue(),
                 "deserializeMember", renderDeserializeMember(),
                 "cast", renderSparseCast()
         ));
+    }
+
+    private Writable renderZeroValue() {
+        return switch (member.getType()) {
+            case STRUCTURE ->
+                    goTemplate("vv = $T{}", ctx.symbolProvider().toSymbol(member));
+            default -> goTemplate("");
+        };
     }
 
     private Writable renderSparseCast() {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/MapDeserializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/MapDeserializer.java
@@ -40,8 +40,9 @@ public class MapDeserializer implements Writable {
         writer.writeGoTemplate("""
                 func deserialize$shapeName:L(d smithy.ShapeDeserializer, s *smithy.Schema, v *$symbol:T) error {
                     *v = make($symbol:T)
+                    var vv $valueSymbol:T
                     return smithy.ReadMap(d, s, func(k string) error {
-                        var vv $valueSymbol:T
+                        $zeroValue:W
                         if err := $deserializeValue:W; err != nil {
                             return err
                         }
@@ -60,6 +61,7 @@ public class MapDeserializer implements Writable {
                     case DOCUMENT -> SmithyGoDependency.SMITHY_DOCUMENT.valueSymbol("Value");
                     default -> ctx.symbolProvider().toSymbol(value);
                 },
+                "zeroValue", renderZeroValue(),
                 "deserializeValue", renderDeserializeValue(),
                 "cast", renderDenseCast()
         ));
@@ -69,6 +71,7 @@ public class MapDeserializer implements Writable {
         writer.writeGoTemplate("""
                 func deserialize$shapeName:L(d smithy.ShapeDeserializer, s *smithy.Schema, v *$symbol:T) error {
                     *v = make($symbol:T)
+                    var vv $valueSymbol:T
                     return smithy.ReadMap(d, s, func(k string) error {
                         if isNil, err := d.ReadNil(s.MapValue()); err != nil {
                             return err
@@ -77,7 +80,7 @@ public class MapDeserializer implements Writable {
                             return nil
                         }
 
-                        var vv $valueSymbol:T
+                        $zeroValue:W
                         if err := $deserializeValue:W; err != nil {
                             return err
                         }
@@ -96,9 +99,18 @@ public class MapDeserializer implements Writable {
                     case DOCUMENT -> SmithyGoDependency.SMITHY_DOCUMENT.valueSymbol("Value");
                     default -> ctx.symbolProvider().toSymbol(value);
                 },
+                "zeroValue", renderZeroValue(),
                 "deserializeValue", renderDeserializeValue(),
                 "cast", renderSparseCast()
         ));
+    }
+
+    private Writable renderZeroValue() {
+        return switch (value.getType()) {
+            case STRUCTURE ->
+                    goTemplate("vv = $T{}", ctx.symbolProvider().toSymbol(value));
+            default -> goTemplate("");
+        };
     }
 
     private Writable renderSparseCast() {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/StructureSerializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/StructureSerializer.java
@@ -63,42 +63,42 @@ public final class StructureSerializer implements Writable {
 
     private void generateSerializeMember(GoWriter writer, MemberShape member, Shape target, String ident) {
         var schemaName = SchemaGenerator.getMemberSchemaRef(shape, member, ctx.service());
-        var ptrSuffix = nilIndex.isNillable(member) ? "Ptr" : "";
+        var isNillable = nilIndex.isNillable(member);
         switch (target.getType()) {
             case BYTE ->
-                    writer.write("s.WriteInt8$L($L, $L)", ptrSuffix, schemaName, ident);
+                    writeScalar(writer, isNillable, ident, "0", "WriteInt8", schemaName);
             case SHORT ->
-                    writer.write("s.WriteInt16$L($L, $L)", ptrSuffix, schemaName, ident);
+                    writeScalar(writer, isNillable, ident, "0", "WriteInt16", schemaName);
             case INTEGER ->
-                    writer.write("s.WriteInt32$L($L, $L)", ptrSuffix, schemaName, ident);
+                    writeScalar(writer, isNillable, ident, "0", "WriteInt32", schemaName);
             case LONG ->
-                    writer.write("s.WriteInt64$L($L, $L)", ptrSuffix, schemaName, ident);
+                    writeScalar(writer, isNillable, ident, "0", "WriteInt64", schemaName);
 
             case FLOAT ->
-                    writer.write("s.WriteFloat32$L($L, $L)", ptrSuffix, schemaName, ident);
+                    writeScalar(writer, isNillable, ident, "0", "WriteFloat32", schemaName);
             case DOUBLE ->
-                    writer.write("s.WriteFloat64$L($L, $L)", ptrSuffix, schemaName, ident);
+                    writeScalar(writer, isNillable, ident, "0", "WriteFloat64", schemaName);
 
             case STRING, ENUM -> {
-                    if (ShapeUtil.isEnum(target)) {
-                        writer.write("s.WriteString($L, string($L))", schemaName, ident);
-                    } else {
-                        writer.write("s.WriteString$L($L, $L)", ptrSuffix, schemaName, ident);
-                    }
+                if (ShapeUtil.isEnum(target)) {
+                    writer.write("if $1L != \"\" { s.WriteString($2L, string($1L)) }", ident, schemaName);
+                } else {
+                    writeScalar(writer, isNillable, ident, "\"\"", "WriteString", schemaName);
+                }
             }
             case INT_ENUM ->
-                    writer.write("s.WriteInt32($L, int32($L))", schemaName, ident);
+                    writer.write("if $1L != 0 { s.WriteInt32($2L, int32($1L)) }", ident, schemaName);
             case BOOLEAN ->
-                    writer.write("s.WriteBool$L($L, $L)", ptrSuffix, schemaName, ident);
+                    writeScalar(writer, isNillable, ident, "false", "WriteBool", schemaName);
             case TIMESTAMP ->
-                    writer.write("s.WriteTime$L($L, $L)", ptrSuffix, schemaName, ident);
+                    writeScalar(writer, isNillable, ident, "", "WriteTime", schemaName);
             case BLOB ->
                     writer.write("s.WriteBlob($L, $L)", schemaName, ident);
 
             case LIST, SET, MAP, UNION ->
                     writer.write("serialize$L(s, $L, $L)", target.getId().getName(), schemaName, ident);
             case STRUCTURE ->
-                    writer.write("if ($2L != nil) { s.WriteStruct($1L)\n$2L.SerializeMembers(s)\ns.CloseStruct() }", schemaName, ident);
+                    writer.write("if $2L != nil { s.WriteStruct($1L)\n$2L.SerializeMembers(s)\ns.CloseStruct() }", schemaName, ident);
             case DOCUMENT -> {
                 writer.addUseImports(SmithyGoDependency.SMITHY_DOCUMENT);
                 writer.write("s.WriteDocument($L, &smithydocument.Opaque{Value: $L})", schemaName, ident);
@@ -109,6 +109,22 @@ public final class StructureSerializer implements Writable {
 
             // invalid in this context
             case MEMBER, SERVICE, RESOURCE, OPERATION -> throw new CodegenException("invalid shape " + target.getType());
+        }
+    }
+
+    // Generates a nil-guarded (pointer) or zero-guarded (value) scalar write.
+    // writeMethod is e.g. "WriteInt32". schemaName is the schema ref. ident is
+    // the Go expression for the member value (e.g. "v.Foo").
+    private void writeScalar(GoWriter writer, boolean isNillable, String ident, String zeroValue,
+                             String writeMethod, String schemaName) {
+        if (isNillable) {
+            writer.write("if $1L != nil { s.$3L($2L, *$1L) }", ident, schemaName, writeMethod);
+        } else {
+            if (zeroValue.isEmpty()) {
+                writer.write("if !$1L.IsZero() { s.$3L($2L, $1L) }", ident, schemaName, writeMethod);
+            } else {
+                writer.write("if $1L != " + zeroValue + " { s.$3L($2L, $1L) }", ident, schemaName, writeMethod);
+            }
         }
     }
 }

--- a/eventstream/serializer.go
+++ b/eventstream/serializer.go
@@ -48,13 +48,6 @@ func (s *ShapeSerializer) WriteBool(schema *smithy.Schema, v bool) {
 	s.inner.WriteBool(schema, v)
 }
 
-// WriteBoolPtr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteBoolPtr(schema *smithy.Schema, v *bool) {
-	if v != nil {
-		s.WriteBool(schema, *v)
-	}
-}
-
 // WriteInt8 implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteInt8(schema *smithy.Schema, v int8) {
 	if isEventHeader(schema) {
@@ -62,13 +55,6 @@ func (s *ShapeSerializer) WriteInt8(schema *smithy.Schema, v int8) {
 		return
 	}
 	s.inner.WriteInt8(schema, v)
-}
-
-// WriteInt8Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt8Ptr(schema *smithy.Schema, v *int8) {
-	if v != nil {
-		s.WriteInt8(schema, *v)
-	}
 }
 
 // WriteInt16 implements [smithy.ShapeSerializer].
@@ -80,13 +66,6 @@ func (s *ShapeSerializer) WriteInt16(schema *smithy.Schema, v int16) {
 	s.inner.WriteInt16(schema, v)
 }
 
-// WriteInt16Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt16Ptr(schema *smithy.Schema, v *int16) {
-	if v != nil {
-		s.WriteInt16(schema, *v)
-	}
-}
-
 // WriteInt32 implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteInt32(schema *smithy.Schema, v int32) {
 	if isEventHeader(schema) {
@@ -94,13 +73,6 @@ func (s *ShapeSerializer) WriteInt32(schema *smithy.Schema, v int32) {
 		return
 	}
 	s.inner.WriteInt32(schema, v)
-}
-
-// WriteInt32Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt32Ptr(schema *smithy.Schema, v *int32) {
-	if v != nil {
-		s.WriteInt32(schema, *v)
-	}
 }
 
 // WriteInt64 implements [smithy.ShapeSerializer].
@@ -112,31 +84,14 @@ func (s *ShapeSerializer) WriteInt64(schema *smithy.Schema, v int64) {
 	s.inner.WriteInt64(schema, v)
 }
 
-// WriteInt64Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt64Ptr(schema *smithy.Schema, v *int64) {
-	if v != nil {
-		s.WriteInt64(schema, *v)
-	}
-}
-
 // WriteFloat32 implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteFloat32(schema *smithy.Schema, v float32) {
 	s.inner.WriteFloat32(schema, v)
 }
 
-// WriteFloat32Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteFloat32Ptr(schema *smithy.Schema, v *float32) {
-	s.inner.WriteFloat32Ptr(schema, v)
-}
-
 // WriteFloat64 implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteFloat64(schema *smithy.Schema, v float64) {
 	s.inner.WriteFloat64(schema, v)
-}
-
-// WriteFloat64Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteFloat64Ptr(schema *smithy.Schema, v *float64) {
-	s.inner.WriteFloat64Ptr(schema, v)
 }
 
 // WriteString implements [smithy.ShapeSerializer].
@@ -151,13 +106,6 @@ func (s *ShapeSerializer) WriteString(schema *smithy.Schema, v string) {
 		return
 	}
 	s.inner.WriteString(schema, v)
-}
-
-// WriteStringPtr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteStringPtr(schema *smithy.Schema, v *string) {
-	if v != nil {
-		s.WriteString(schema, *v)
-	}
 }
 
 // WriteBlob implements [smithy.ShapeSerializer].
@@ -183,11 +131,14 @@ func (s *ShapeSerializer) WriteTime(schema *smithy.Schema, v time.Time) {
 	s.inner.WriteTime(schema, v)
 }
 
-// WriteTimePtr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteTimePtr(schema *smithy.Schema, v *time.Time) {
-	if v != nil {
-		s.WriteTime(schema, *v)
-	}
+// WriteBigInt implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteBigInt(schema *smithy.Schema, v *big.Int) {
+	s.inner.WriteBigInt(schema, v)
+}
+
+// WriteBigFloat implements [smithy.ShapeSerializer].
+func (s *ShapeSerializer) WriteBigFloat(schema *smithy.Schema, v *big.Float) {
+	s.inner.WriteBigFloat(schema, v)
 }
 
 // WriteStruct implements [smithy.ShapeSerializer].
@@ -231,16 +182,6 @@ func (s *ShapeSerializer) WriteKey(schema *smithy.Schema, key string) {
 // CloseMap implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) CloseMap() {
 	s.inner.CloseMap()
-}
-
-// WriteBigInteger implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteBigInteger(schema *smithy.Schema, v big.Int) {
-	s.inner.WriteBigInteger(schema, v)
-}
-
-// WriteBigDecimal implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteBigDecimal(schema *smithy.Schema, v big.Float) {
-	s.inner.WriteBigDecimal(schema, v)
 }
 
 // WriteDocument implements [smithy.ShapeSerializer].

--- a/serde.go
+++ b/serde.go
@@ -12,6 +12,19 @@ import (
 // ShapeSerializer implements the marshaling of an in-code representation of a
 // shape to an unspecified data format, which is determined by the
 // implementation.
+//
+// A ShapeSerializer is consumed by the **code-generated** Serialize() method
+// of a modeled structure. For example:
+//
+//	func (v *PutItemInput) Serialize(s smithy.ShapeSerializer) {
+//		s.WriteStruct(schemas.PutItemInput)
+//		v.SerializeMembers(s)
+//		s.CloseStruct()
+//	}
+//
+//	func (v *PutItemInput) SerializeMembers(s smithy.ShapeSerializer) {
+//		// TODO(serde2)
+//	}
 type ShapeSerializer interface {
 	Bytes() []byte
 
@@ -19,34 +32,21 @@ type ShapeSerializer interface {
 	WriteInt16(*Schema, int16)
 	WriteInt32(*Schema, int32)
 	WriteInt64(*Schema, int64)
-	WriteInt8Ptr(*Schema, *int8)
-	WriteInt16Ptr(*Schema, *int16)
-	WriteInt32Ptr(*Schema, *int32)
-	WriteInt64Ptr(*Schema, *int64)
-
 	WriteFloat32(*Schema, float32)
 	WriteFloat64(*Schema, float64)
-	WriteFloat32Ptr(*Schema, *float32)
-	WriteFloat64Ptr(*Schema, *float64)
-
 	WriteBool(*Schema, bool)
-	WriteBoolPtr(*Schema, *bool)
-
 	WriteString(*Schema, string)
-	WriteStringPtr(*Schema, *string)
-
-	WriteBigInteger(*Schema, big.Int)
-	WriteBigDecimal(*Schema, big.Float)
+	WriteBigInt(*Schema, *big.Int)
+	WriteBigFloat(*Schema, *big.Float)
 	WriteBlob(*Schema, []byte)
 	WriteTime(*Schema, time.Time)
-	WriteTimePtr(*Schema, *time.Time)
+
+	WriteUnion(schema, variant *Schema, v Serializable)
+	WriteDocument(*Schema, document.Value)
+	WriteNil(*Schema)
 
 	WriteStruct(*Schema)
 	CloseStruct()
-
-	WriteUnion(schema, variant *Schema, v Serializable)
-
-	WriteNil(*Schema)
 
 	WriteList(*Schema)
 	CloseList()
@@ -54,8 +54,6 @@ type ShapeSerializer interface {
 	WriteMap(*Schema)
 	WriteKey(*Schema, string)
 	CloseMap()
-
-	WriteDocument(*Schema, document.Value)
 }
 
 // ShapeDeserializer implements the unmarshaling from some unspecified data

--- a/smithy-http-protocols/internal/cbor/shape_serializer.go
+++ b/smithy-http-protocols/internal/cbor/shape_serializer.go
@@ -24,9 +24,7 @@ type ShapeSerializer struct {
 }
 
 // ShapeSerializerOptions configures ShapeSerializer.
-type ShapeSerializerOptions struct {
-	WriteZeroValues bool
-}
+type ShapeSerializerOptions struct{}
 
 var _ smithy.ShapeSerializer = (*ShapeSerializer)(nil)
 
@@ -69,89 +67,8 @@ func (s *ShapeSerializer) pop() {
 	s.head = s.head[:len(s.head)-1]
 }
 
-// WriteInt8Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt8Ptr(schema *smithy.Schema, v *int8) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteInt8(schema, *v) })
-	}
-}
-
-// WriteInt16Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt16Ptr(schema *smithy.Schema, v *int16) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteInt16(schema, *v) })
-	}
-}
-
-// WriteInt32Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt32Ptr(schema *smithy.Schema, v *int32) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteInt32(schema, *v) })
-	}
-}
-
-// WriteInt64Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteInt64Ptr(schema *smithy.Schema, v *int64) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteInt64(schema, *v) })
-	}
-}
-
-// WriteFloat32Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteFloat32Ptr(schema *smithy.Schema, v *float32) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteFloat32(schema, *v) })
-	}
-}
-
-// WriteFloat64Ptr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteFloat64Ptr(schema *smithy.Schema, v *float64) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteFloat64(schema, *v) })
-	}
-}
-
-// WriteBoolPtr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteBoolPtr(schema *smithy.Schema, v *bool) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteBool(schema, *v) })
-	}
-}
-
-// WriteStringPtr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteStringPtr(schema *smithy.Schema, v *string) {
-	if v != nil {
-		s.withWriteZero(func() { s.WriteString(schema, *v) })
-	}
-}
-
-func (s *ShapeSerializer) withWriteZero(fn func()) {
-	prev := s.opts.WriteZeroValues
-	s.opts.WriteZeroValues = true
-	fn()
-	s.opts.WriteZeroValues = prev
-}
-
-func (s *ShapeSerializer) skipZeroValue() bool {
-	if s.opts.WriteZeroValues {
-		return false
-	}
-	if len(s.head) == 0 {
-		return false
-	}
-	switch s.top() {
-	case ctxList, ctxMapValue:
-		return false
-	default:
-		return true
-	}
-}
-
 // WriteBool implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteBool(schema *smithy.Schema, v bool) {
-	if !v && s.skipZeroValue() {
-		return
-	}
 	s.writeKey(schema)
 	if v {
 		s.buf = append(s.buf, compose(majorType7, major7True))
@@ -174,45 +91,30 @@ func (s *ShapeSerializer) writeUint(v uint64) {
 
 // WriteInt8 implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteInt8(schema *smithy.Schema, v int8) {
-	if v == 0 && s.skipZeroValue() {
-		return
-	}
 	s.writeKey(schema)
 	s.writeInt(int64(v))
 }
 
 // WriteInt16 implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteInt16(schema *smithy.Schema, v int16) {
-	if v == 0 && s.skipZeroValue() {
-		return
-	}
 	s.writeKey(schema)
 	s.writeInt(int64(v))
 }
 
 // WriteInt32 implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteInt32(schema *smithy.Schema, v int32) {
-	if v == 0 && s.skipZeroValue() {
-		return
-	}
 	s.writeKey(schema)
 	s.writeInt(int64(v))
 }
 
 // WriteInt64 implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteInt64(schema *smithy.Schema, v int64) {
-	if v == 0 && s.skipZeroValue() {
-		return
-	}
 	s.writeKey(schema)
 	s.writeInt(v)
 }
 
 // WriteFloat32 implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteFloat32(schema *smithy.Schema, v float32) {
-	if v == 0 && !math.Signbit(float64(v)) && s.skipZeroValue() {
-		return
-	}
 	s.writeKey(schema)
 	s.buf = append(s.buf, compose(majorType7, major7Float32))
 	s.buf = binary.BigEndian.AppendUint32(s.buf, math.Float32bits(v))
@@ -220,9 +122,6 @@ func (s *ShapeSerializer) WriteFloat32(schema *smithy.Schema, v float32) {
 
 // WriteFloat64 implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteFloat64(schema *smithy.Schema, v float64) {
-	if v == 0 && !math.Signbit(v) && s.skipZeroValue() {
-		return
-	}
 	s.writeKey(schema)
 	s.buf = append(s.buf, compose(majorType7, major7Float64))
 	s.buf = binary.BigEndian.AppendUint64(s.buf, math.Float64bits(v))
@@ -230,9 +129,6 @@ func (s *ShapeSerializer) WriteFloat64(schema *smithy.Schema, v float64) {
 
 // WriteString implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteString(schema *smithy.Schema, v string) {
-	if v == "" && s.skipZeroValue() {
-		return
-	}
 	s.writeKey(schema)
 	s.writeTextString(v)
 }
@@ -308,13 +204,6 @@ func (s *ShapeSerializer) WriteTime(schema *smithy.Schema, v time.Time) {
 	s.buf = binary.BigEndian.AppendUint64(s.buf, math.Float64bits(epoch))
 }
 
-// WriteTimePtr implements [smithy.ShapeSerializer].
-func (s *ShapeSerializer) WriteTimePtr(schema *smithy.Schema, v *time.Time) {
-	if v != nil {
-		s.WriteTime(schema, *v)
-	}
-}
-
 // WriteUnion implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteUnion(schema, variant *smithy.Schema, v smithy.Serializable) {
 	s.writeKey(schema)
@@ -352,13 +241,13 @@ func (s *ShapeSerializer) WriteNil(schema *smithy.Schema) {
 	s.buf = append(s.buf, compose(majorType7, major7Nil))
 }
 
-// WriteBigInteger is unimplemented and will panic.
-func (s *ShapeSerializer) WriteBigInteger(schema *smithy.Schema, v big.Int) {
+// WriteBigInt is unimplemented and will panic.
+func (s *ShapeSerializer) WriteBigInt(schema *smithy.Schema, v *big.Int) {
 	panic("unimplemented")
 }
 
-// WriteBigDecimal is unimplemented and will panic.
-func (s *ShapeSerializer) WriteBigDecimal(schema *smithy.Schema, v big.Float) {
+// WriteBigFloat is unimplemented and will panic.
+func (s *ShapeSerializer) WriteBigFloat(schema *smithy.Schema, v *big.Float) {
 	panic("unimplemented")
 }
 


### PR DESCRIPTION
relates #458 

Turns out the writeptr split is not necessary at all if we just generate the "don't serialize value types if zero" checks in SerializeMembers. In dynamodb the compiled output actually shrunk somewhat, I think because all the runtime stuff for pointers going away, but in practice it probably is like a 0.1% artifact size increase or something to generate the branches inline.

Also fixed an issue where we were reallocating every loop iteration for deserializing list/map values (i just moved the temporary to outside the loop, so it only allocates once).

Double-checked all protocol tests on this one, all still good.