### PR TITLE
serde2: drop readptr shenanigans

### DIFF
--- a/aws-protocols/internal/httpbinding/deserializer.go
+++ b/aws-protocols/internal/httpbinding/deserializer.go
@@ -3,6 +3,7 @@ package httpbinding
 import (
 	"encoding/base64"
 	"fmt"
+	"math/big"
 	"net/http"
 	"strconv"
 	"strings"
@@ -149,26 +150,6 @@ func (d *ShapeDeserializer) ReadString(s *smithy.Schema, v *string) error {
 	return d.body.ReadString(s, v)
 }
 
-// ReadStringPtr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadStringPtr(s *smithy.Schema, v **string) error {
-	if d.inBindings {
-		if _, ok := isHTTPHeader(s); ok {
-			hv, err := d.readHeaderString(s)
-			if err != nil {
-				return err
-			}
-			*v = &hv
-			return nil
-		}
-		if _, ok := smithy.SchemaTrait[*traits.HTTPPayload](s); ok {
-			val := string(d.payload)
-			*v = &val
-			return nil
-		}
-	}
-	return d.body.ReadStringPtr(s, v)
-}
-
 // ReadBool implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadBool(s *smithy.Schema, v *bool) error {
 	if !d.inBindings {
@@ -193,19 +174,6 @@ func (d *ShapeDeserializer) ReadBool(s *smithy.Schema, v *bool) error {
 	return nil
 }
 
-// ReadBoolPtr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadBoolPtr(s *smithy.Schema, v **bool) error {
-	if !d.inBindings {
-		return d.body.ReadBoolPtr(s, v)
-	}
-	var vv bool
-	if err := d.ReadBool(s, &vv); err != nil {
-		return err
-	}
-	*v = &vv
-	return nil
-}
-
 // ReadInt8 implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadInt8(s *smithy.Schema, v *int8) error {
 	if !d.inBindings {
@@ -214,38 +182,12 @@ func (d *ShapeDeserializer) ReadInt8(s *smithy.Schema, v *int8) error {
 	return readHeaderInt[int8](d, s, v)
 }
 
-// ReadInt8Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadInt8Ptr(s *smithy.Schema, v **int8) error {
-	if !d.inBindings {
-		return d.body.ReadInt8Ptr(s, v)
-	}
-	var vv int8
-	if err := d.ReadInt8(s, &vv); err != nil {
-		return err
-	}
-	*v = &vv
-	return nil
-}
-
 // ReadInt16 implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadInt16(s *smithy.Schema, v *int16) error {
 	if !d.inBindings {
 		return d.body.ReadInt16(s, v)
 	}
 	return readHeaderInt[int16](d, s, v)
-}
-
-// ReadInt16Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadInt16Ptr(s *smithy.Schema, v **int16) error {
-	if !d.inBindings {
-		return d.body.ReadInt16Ptr(s, v)
-	}
-	var vv int16
-	if err := d.ReadInt16(s, &vv); err != nil {
-		return err
-	}
-	*v = &vv
-	return nil
 }
 
 // ReadInt32 implements [smithy.ShapeDeserializer].
@@ -266,38 +208,12 @@ func (d *ShapeDeserializer) ReadInt32(s *smithy.Schema, v *int32) error {
 	return readHeaderInt[int32](d, s, v)
 }
 
-// ReadInt32Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadInt32Ptr(s *smithy.Schema, v **int32) error {
-	if !d.inBindings {
-		return d.body.ReadInt32Ptr(s, v)
-	}
-	var vv int32
-	if err := d.ReadInt32(s, &vv); err != nil {
-		return err
-	}
-	*v = &vv
-	return nil
-}
-
 // ReadInt64 implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadInt64(s *smithy.Schema, v *int64) error {
 	if !d.inBindings {
 		return d.body.ReadInt64(s, v)
 	}
 	return readHeaderInt[int64](d, s, v)
-}
-
-// ReadInt64Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadInt64Ptr(s *smithy.Schema, v **int64) error {
-	if !d.inBindings {
-		return d.body.ReadInt64Ptr(s, v)
-	}
-	var vv int64
-	if err := d.ReadInt64(s, &vv); err != nil {
-		return err
-	}
-	*v = &vv
-	return nil
 }
 
 // ReadFloat32 implements [smithy.ShapeDeserializer].
@@ -308,38 +224,12 @@ func (d *ShapeDeserializer) ReadFloat32(s *smithy.Schema, v *float32) error {
 	return readHeaderFloat[float32](d, s, v)
 }
 
-// ReadFloat32Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadFloat32Ptr(s *smithy.Schema, v **float32) error {
-	if !d.inBindings {
-		return d.body.ReadFloat32Ptr(s, v)
-	}
-	var vv float32
-	if err := d.ReadFloat32(s, &vv); err != nil {
-		return err
-	}
-	*v = &vv
-	return nil
-}
-
 // ReadFloat64 implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadFloat64(s *smithy.Schema, v *float64) error {
 	if !d.inBindings {
 		return d.body.ReadFloat64(s, v)
 	}
 	return readHeaderFloat[float64](d, s, v)
-}
-
-// ReadFloat64Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadFloat64Ptr(s *smithy.Schema, v **float64) error {
-	if !d.inBindings {
-		return d.body.ReadFloat64Ptr(s, v)
-	}
-	var vv float64
-	if err := d.ReadFloat64(s, &vv); err != nil {
-		return err
-	}
-	*v = &vv
-	return nil
 }
 
 // ReadTime implements [smithy.ShapeDeserializer].
@@ -356,27 +246,6 @@ func (d *ShapeDeserializer) ReadTime(s *smithy.Schema, v *time.Time) error {
 		return nil
 	}
 	return d.body.ReadTime(s, v)
-}
-
-// ReadTimePtr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadTimePtr(s *smithy.Schema, v **time.Time) error {
-	if d.inHeaderList {
-		var val time.Time
-		if err := d.ReadTime(s, &val); err != nil {
-			return err
-		}
-		*v = &val
-		return nil
-	}
-	if d.inBindings {
-		t, err := d.readHeaderTime(s)
-		if err != nil {
-			return err
-		}
-		*v = &t
-		return nil
-	}
-	return d.body.ReadTimePtr(s, v)
 }
 
 func (d *ShapeDeserializer) readHeaderTime(s *smithy.Schema) (time.Time, error) {
@@ -614,4 +483,14 @@ func readHeaderFloat[T floatn](d *ShapeDeserializer, s *smithy.Schema, v *T) err
 
 	*v = T(n)
 	return nil
+}
+
+// ReadBigInt is unimplemented and will return an error.
+func (d *ShapeDeserializer) ReadBigInt(_ *smithy.Schema, _ *big.Int) error {
+	return fmt.Errorf("unimplemented")
+}
+
+// ReadBigFloat is unimplemented and will return an error.
+func (d *ShapeDeserializer) ReadBigFloat(_ *smithy.Schema, _ *big.Float) error {
+	return fmt.Errorf("unimplemented")
 }

--- a/aws-protocols/internal/json/shape_deserializer.go
+++ b/aws-protocols/internal/json/shape_deserializer.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math"
+	"math/big"
 	"strconv"
 	"strings"
 	"time"
@@ -120,26 +121,6 @@ func (d *ShapeDeserializer) ReadInt64(s *smithy.Schema, v *int64) error {
 	return err
 }
 
-// ReadInt8Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadInt8Ptr(s *smithy.Schema, v **int8) error {
-	return readPtr(d, s, v, d.ReadInt8)
-}
-
-// ReadInt16Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadInt16Ptr(s *smithy.Schema, v **int16) error {
-	return readPtr(d, s, v, d.ReadInt16)
-}
-
-// ReadInt32Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadInt32Ptr(s *smithy.Schema, v **int32) error {
-	return readPtr(d, s, v, d.ReadInt32)
-}
-
-// ReadInt64Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadInt64Ptr(s *smithy.Schema, v **int64) error {
-	return readPtr(d, s, v, d.ReadInt64)
-}
-
 func (d *ShapeDeserializer) readInt(min, max int64) (int64, error) {
 	tok, err := d.next()
 	if err != nil {
@@ -174,16 +155,6 @@ func (d *ShapeDeserializer) ReadFloat64(s *smithy.Schema, v *float64) error {
 	n, err := d.readFloat()
 	*v = n
 	return err
-}
-
-// ReadFloat32Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadFloat32Ptr(s *smithy.Schema, v **float32) error {
-	return readPtr(d, s, v, d.ReadFloat32)
-}
-
-// ReadFloat64Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadFloat64Ptr(s *smithy.Schema, v **float64) error {
-	return readPtr(d, s, v, d.ReadFloat64)
 }
 
 func (d *ShapeDeserializer) readFloat() (float64, error) {
@@ -231,11 +202,6 @@ func (d *ShapeDeserializer) ReadBool(s *smithy.Schema, v *bool) error {
 	}
 }
 
-// ReadBoolPtr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadBoolPtr(s *smithy.Schema, v **bool) error {
-	return readPtr(d, s, v, d.ReadBool)
-}
-
 // ReadString implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadString(s *smithy.Schema, v *string) error {
 	tok, err := d.next()
@@ -257,11 +223,6 @@ func (d *ShapeDeserializer) ReadString(s *smithy.Schema, v *string) error {
 
 	*v = sv
 	return nil
-}
-
-// ReadStringPtr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadStringPtr(s *smithy.Schema, v **string) error {
-	return readPtr(d, s, v, d.ReadString)
 }
 
 // ReadTime implements [smithy.ShapeDeserializer].
@@ -304,11 +265,6 @@ func (d *ShapeDeserializer) ReadTime(schema *smithy.Schema, v *time.Time) error 
 	default:
 		return fmt.Errorf("unknown timestamp format: %s", format)
 	}
-}
-
-// ReadTimePtr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadTimePtr(schema *smithy.Schema, v **time.Time) error {
-	return readPtr(d, schema, v, d.ReadTime)
 }
 
 // ReadBlob implements [smithy.ShapeDeserializer].
@@ -455,6 +411,12 @@ func (d *ShapeDeserializer) ReadStructMember() (*smithy.Schema, error) {
 		return d.ReadStructMember()
 	}
 
+	if isNil, err := d.ReadNil(member); err != nil {
+		return nil, err
+	} else if isNil {
+		return d.ReadStructMember()
+	}
+
 	return member, nil
 }
 
@@ -532,17 +494,6 @@ func (d *ShapeDeserializer) ReadDocument(schema *smithy.Schema, v *document.Valu
 	return nil
 }
 
-func readPtr[T any](d *ShapeDeserializer, s *smithy.Schema, v **T, read func(*smithy.Schema, *T) error) error {
-	if isNil, err := d.ReadNil(s); isNil || err != nil {
-		return err
-	}
-
-	if *v == nil {
-		*v = new(T)
-	}
-	return read(s, *v)
-}
-
 func unquote(tok []byte) (string, error) {
 	if s, ok := stdlib.UnquoteBytes(tok); ok {
 		return string(s), nil
@@ -575,3 +526,13 @@ func isLCB(tok []byte) bool { return tok[0] == '{' }
 func isRCB(tok []byte) bool { return tok[0] == '}' }
 func isLSB(tok []byte) bool { return tok[0] == '[' }
 func isRSB(tok []byte) bool { return tok[0] == ']' }
+
+// ReadBigInt is unimplemented and will return an error.
+func (d *ShapeDeserializer) ReadBigInt(_ *smithy.Schema, _ *big.Int) error {
+	return fmt.Errorf("unimplemented")
+}
+
+// ReadBigFloat is unimplemented and will return an error.
+func (d *ShapeDeserializer) ReadBigFloat(_ *smithy.Schema, _ *big.Float) error {
+	return fmt.Errorf("unimplemented")
+}

--- a/aws-protocols/internal/xml/shape_deserializer.go
+++ b/aws-protocols/internal/xml/shape_deserializer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
+	"math/big"
 	"math"
 	"strconv"
 	"strings"
@@ -417,11 +418,6 @@ func (d *ShapeDeserializer) ReadBool(_ *smithy.Schema, v *bool) error {
 	return nil
 }
 
-// ReadBoolPtr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadBoolPtr(s *smithy.Schema, v **bool) error {
-	return readPtr(d, s, v, d.ReadBool)
-}
-
 // ReadInt8 implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadInt8(s *smithy.Schema, v *int8) error {
 	n, err := d.readInt(8)
@@ -466,26 +462,6 @@ func (d *ShapeDeserializer) ReadInt64(s *smithy.Schema, v *int64) error {
 	return nil
 }
 
-// ReadInt8Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadInt8Ptr(s *smithy.Schema, v **int8) error {
-	return readPtr(d, s, v, d.ReadInt8)
-}
-
-// ReadInt16Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadInt16Ptr(s *smithy.Schema, v **int16) error {
-	return readPtr(d, s, v, d.ReadInt16)
-}
-
-// ReadInt32Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadInt32Ptr(s *smithy.Schema, v **int32) error {
-	return readPtr(d, s, v, d.ReadInt32)
-}
-
-// ReadInt64Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadInt64Ptr(s *smithy.Schema, v **int64) error {
-	return readPtr(d, s, v, d.ReadInt64)
-}
-
 // ReadFloat32 implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadFloat32(s *smithy.Schema, v *float32) error {
 	n, err := d.readFloat()
@@ -508,16 +484,6 @@ func (d *ShapeDeserializer) ReadFloat64(s *smithy.Schema, v *float64) error {
 	return nil
 }
 
-// ReadFloat32Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadFloat32Ptr(s *smithy.Schema, v **float32) error {
-	return readPtr(d, s, v, d.ReadFloat32)
-}
-
-// ReadFloat64Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadFloat64Ptr(s *smithy.Schema, v **float64) error {
-	return readPtr(d, s, v, d.ReadFloat64)
-}
-
 // ReadString implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadString(_ *smithy.Schema, v *string) error {
 	text, err := d.chardata()
@@ -527,11 +493,6 @@ func (d *ShapeDeserializer) ReadString(_ *smithy.Schema, v *string) error {
 
 	*v = text
 	return nil
-}
-
-// ReadStringPtr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadStringPtr(s *smithy.Schema, v **string) error {
-	return readPtr(d, s, v, d.ReadString)
 }
 
 // ReadTime implements [smithy.ShapeDeserializer].
@@ -570,11 +531,6 @@ func (d *ShapeDeserializer) ReadTime(schema *smithy.Schema, v *time.Time) error 
 	}
 
 	return nil
-}
-
-// ReadTimePtr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadTimePtr(schema *smithy.Schema, v **time.Time) error {
-	return readPtr(d, schema, v, d.ReadTime)
 }
 
 // ReadBlob implements [smithy.ShapeDeserializer].
@@ -626,13 +582,6 @@ func (d *ShapeDeserializer) ReadUnion(s *smithy.Schema) (*smithy.Schema, error) 
 // ReadDocument is unimplemented for XML.
 func (d *ShapeDeserializer) ReadDocument(_ *smithy.Schema, _ *document.Value) error {
 	return fmt.Errorf("Document not supported")
-}
-
-func readPtr[T any](d *ShapeDeserializer, s *smithy.Schema, v **T, read func(*smithy.Schema, *T) error) error {
-	if *v == nil {
-		*v = new(T)
-	}
-	return read(s, *v)
 }
 
 func (d *ShapeDeserializer) token() (xml.Token, error) {
@@ -769,4 +718,14 @@ func stripPrefix(name string) string {
 		return after
 	}
 	return name
+}
+
+// ReadBigInt is unimplemented and will return an error.
+func (d *ShapeDeserializer) ReadBigInt(_ *smithy.Schema, _ *big.Int) error {
+	return fmt.Errorf("unimplemented")
+}
+
+// ReadBigFloat is unimplemented and will return an error.
+func (d *ShapeDeserializer) ReadBigFloat(_ *smithy.Schema, _ *big.Float) error {
+	return fmt.Errorf("unimplemented")
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/StructureDeserializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/StructureDeserializer.java
@@ -57,21 +57,21 @@ public class StructureDeserializer implements Writable {
 
     private void renderMember(GoWriter writer, MemberShape member, Shape target, String ident) {
         var schemaName = SchemaGenerator.getMemberSchemaRef(shape, member, ctx.service());
-        var ptrSuffix = nilIndex.isNillable(member) ? "Ptr" : "";
+        var isNillable = nilIndex.isNillable(member);
         switch (target.getType()) {
             case BYTE ->
-                    writer.write("return d.ReadInt8$L($L, &$L)", ptrSuffix, schemaName, ident);
+                    writeReadScalar(writer, isNillable, ident, schemaName, "ReadInt8", "int8");
             case SHORT ->
-                    writer.write("return d.ReadInt16$L($L, &$L)", ptrSuffix, schemaName, ident);
+                    writeReadScalar(writer, isNillable, ident, schemaName, "ReadInt16", "int16");
             case INTEGER ->
-                    writer.write("return d.ReadInt32$L($L, &$L)", ptrSuffix, schemaName, ident);
+                    writeReadScalar(writer, isNillable, ident, schemaName, "ReadInt32", "int32");
             case LONG ->
-                    writer.write("return d.ReadInt64$L($L, &$L)", ptrSuffix, schemaName, ident);
+                    writeReadScalar(writer, isNillable, ident, schemaName, "ReadInt64", "int64");
 
             case FLOAT ->
-                    writer.write("return d.ReadFloat32$L($L, &$L)", ptrSuffix, schemaName, ident);
+                    writeReadScalar(writer, isNillable, ident, schemaName, "ReadFloat32", "float32");
             case DOUBLE ->
-                    writer.write("return d.ReadFloat64$L($L, &$L)", ptrSuffix, schemaName, ident);
+                    writeReadScalar(writer, isNillable, ident, schemaName, "ReadFloat64", "float64");
 
             case STRING, ENUM -> {
                     if (ShapeUtil.isEnum(target)) {
@@ -83,7 +83,7 @@ public class StructureDeserializer implements Writable {
                                 $2L = $3T(ev)
                                 return nil""", schemaName, ident, ctx.symbolProvider().toSymbol(target));
                     } else {
-                        writer.write("return d.ReadString$L($L, &$L)", ptrSuffix, schemaName, ident);
+                        writeReadScalar(writer, isNillable, ident, schemaName, "ReadString", "string");
                     }
             }
             case INT_ENUM ->
@@ -95,9 +95,9 @@ public class StructureDeserializer implements Writable {
                             $2L = $3T(ev)
                             return nil""", schemaName, ident, ctx.symbolProvider().toSymbol(target));
             case BOOLEAN ->
-                    writer.write("return d.ReadBool$L($L, &$L)", ptrSuffix, schemaName, ident);
+                    writeReadScalar(writer, isNillable, ident, schemaName, "ReadBool", "bool");
             case TIMESTAMP ->
-                    writer.write("return d.ReadTime$L($L, &$L)", ptrSuffix, schemaName, ident);
+                    writeReadScalar(writer, isNillable, ident, schemaName, "ReadTime", "time.Time");
             case BLOB ->
                     writer.write("return d.ReadBlob($L, &$L)", schemaName, ident);
 
@@ -132,6 +132,15 @@ public class StructureDeserializer implements Writable {
 
             // invalid in this context
             case MEMBER, SERVICE, RESOURCE, OPERATION -> throw new UnsupportedShapeException(target.getType());
+        }
+    }
+
+    private void writeReadScalar(GoWriter writer, boolean isNillable, String ident, String schemaName,
+                                 String readMethod, String goType) {
+        if (isNillable) {
+            writer.write("$1L = new($4L)\nreturn d.$3L($2L, $1L)", ident, schemaName, readMethod, goType);
+        } else {
+            writer.write("return d.$3L($2L, &$1L)", ident, schemaName, readMethod);
         }
     }
 }

--- a/eventstream/deserializer.go
+++ b/eventstream/deserializer.go
@@ -2,6 +2,7 @@ package eventstream
 
 import (
 	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/aws/smithy-go"
@@ -115,18 +116,6 @@ func (d *ShapeDeserializer) ReadString(s *smithy.Schema, v *string) error {
 	return d.inner.ReadString(s, v)
 }
 
-func (d *ShapeDeserializer) ReadStringPtr(s *smithy.Schema, v **string) error {
-	if d.inBindings && isEventHeader(s) && d.Message.Headers.Get(s.MemberName()) == nil {
-		return nil
-	}
-	var val string
-	if err := d.ReadString(s, &val); err != nil {
-		return err
-	}
-	*v = &val
-	return nil
-}
-
 func (d *ShapeDeserializer) ReadBool(s *smithy.Schema, v *bool) error {
 	if d.inBindings && isEventHeader(s) {
 		hv := d.Message.Headers.Get(s.MemberName())
@@ -141,18 +130,6 @@ func (d *ShapeDeserializer) ReadBool(s *smithy.Schema, v *bool) error {
 		return nil
 	}
 	return d.inner.ReadBool(s, v)
-}
-
-func (d *ShapeDeserializer) ReadBoolPtr(s *smithy.Schema, v **bool) error {
-	if d.inBindings && isEventHeader(s) && d.Message.Headers.Get(s.MemberName()) == nil {
-		return nil
-	}
-	var val bool
-	if err := d.ReadBool(s, &val); err != nil {
-		return err
-	}
-	*v = &val
-	return nil
 }
 
 func (d *ShapeDeserializer) readHeaderInt64(name string) (int64, bool, error) {
@@ -194,35 +171,11 @@ func (d *ShapeDeserializer) ReadInt8(s *smithy.Schema, v *int8) error {
 	return d.inner.ReadInt8(s, v)
 }
 
-func (d *ShapeDeserializer) ReadInt8Ptr(s *smithy.Schema, v **int8) error {
-	if d.inBindings && isEventHeader(s) && d.Message.Headers.Get(s.MemberName()) == nil {
-		return nil
-	}
-	var val int8
-	if err := d.ReadInt8(s, &val); err != nil {
-		return err
-	}
-	*v = &val
-	return nil
-}
-
 func (d *ShapeDeserializer) ReadInt16(s *smithy.Schema, v *int16) error {
 	if d.inBindings && isEventHeader(s) {
 		return readEventHeaderInt(d, s, v)
 	}
 	return d.inner.ReadInt16(s, v)
-}
-
-func (d *ShapeDeserializer) ReadInt16Ptr(s *smithy.Schema, v **int16) error {
-	if d.inBindings && isEventHeader(s) && d.Message.Headers.Get(s.MemberName()) == nil {
-		return nil
-	}
-	var val int16
-	if err := d.ReadInt16(s, &val); err != nil {
-		return err
-	}
-	*v = &val
-	return nil
 }
 
 func (d *ShapeDeserializer) ReadInt32(s *smithy.Schema, v *int32) error {
@@ -232,18 +185,6 @@ func (d *ShapeDeserializer) ReadInt32(s *smithy.Schema, v *int32) error {
 	return d.inner.ReadInt32(s, v)
 }
 
-func (d *ShapeDeserializer) ReadInt32Ptr(s *smithy.Schema, v **int32) error {
-	if d.inBindings && isEventHeader(s) && d.Message.Headers.Get(s.MemberName()) == nil {
-		return nil
-	}
-	var val int32
-	if err := d.ReadInt32(s, &val); err != nil {
-		return err
-	}
-	*v = &val
-	return nil
-}
-
 func (d *ShapeDeserializer) ReadInt64(s *smithy.Schema, v *int64) error {
 	if d.inBindings && isEventHeader(s) {
 		return readEventHeaderInt(d, s, v)
@@ -251,32 +192,12 @@ func (d *ShapeDeserializer) ReadInt64(s *smithy.Schema, v *int64) error {
 	return d.inner.ReadInt64(s, v)
 }
 
-func (d *ShapeDeserializer) ReadInt64Ptr(s *smithy.Schema, v **int64) error {
-	if d.inBindings && isEventHeader(s) && d.Message.Headers.Get(s.MemberName()) == nil {
-		return nil
-	}
-	var val int64
-	if err := d.ReadInt64(s, &val); err != nil {
-		return err
-	}
-	*v = &val
-	return nil
-}
-
 func (d *ShapeDeserializer) ReadFloat32(s *smithy.Schema, v *float32) error {
 	return d.inner.ReadFloat32(s, v)
 }
 
-func (d *ShapeDeserializer) ReadFloat32Ptr(s *smithy.Schema, v **float32) error {
-	return d.inner.ReadFloat32Ptr(s, v)
-}
-
 func (d *ShapeDeserializer) ReadFloat64(s *smithy.Schema, v *float64) error {
 	return d.inner.ReadFloat64(s, v)
-}
-
-func (d *ShapeDeserializer) ReadFloat64Ptr(s *smithy.Schema, v **float64) error {
-	return d.inner.ReadFloat64Ptr(s, v)
 }
 
 func (d *ShapeDeserializer) ReadBlob(s *smithy.Schema, v *[]byte) error {
@@ -317,18 +238,6 @@ func (d *ShapeDeserializer) ReadTime(s *smithy.Schema, v *time.Time) error {
 	return d.inner.ReadTime(s, v)
 }
 
-func (d *ShapeDeserializer) ReadTimePtr(s *smithy.Schema, v **time.Time) error {
-	if d.inBindings && isEventHeader(s) && d.Message.Headers.Get(s.MemberName()) == nil {
-		return nil
-	}
-	var val time.Time
-	if err := d.ReadTime(s, &val); err != nil {
-		return err
-	}
-	*v = &val
-	return nil
-}
-
 func (d *ShapeDeserializer) ReadList(s *smithy.Schema) error {
 	return d.inner.ReadList(s)
 }
@@ -361,4 +270,14 @@ func isEventBound(schema *smithy.Schema) bool {
 	_, h := smithy.SchemaTrait[*traits.EventHeader](schema)
 	_, p := smithy.SchemaTrait[*traits.EventPayload](schema)
 	return h || p
+}
+
+// ReadBigInt is unimplemented and will return an error.
+func (d *ShapeDeserializer) ReadBigInt(_ *smithy.Schema, _ *big.Int) error {
+	return fmt.Errorf("unimplemented")
+}
+
+// ReadBigFloat is unimplemented and will return an error.
+func (d *ShapeDeserializer) ReadBigFloat(_ *smithy.Schema, _ *big.Float) error {
+	return fmt.Errorf("unimplemented")
 }

--- a/serde.go
+++ b/serde.go
@@ -23,7 +23,13 @@ import (
 //	}
 //
 //	func (v *PutItemInput) SerializeMembers(s smithy.ShapeSerializer) {
-//		// TODO(serde2)
+//		if v.TableName != nil {
+//			s.WriteString(schemas.PutItemInput_TableName, *v.TableName)
+//		}
+//		if v.Item != nil {
+//			serializeAttributeMap(s, schemas.PutItemInput_Item, v.Item)
+//		}
+//		// ...
 //	}
 type ShapeSerializer interface {
 	Bytes() []byte
@@ -64,54 +70,27 @@ type ShapeDeserializer interface {
 	ReadInt16(*Schema, *int16) error
 	ReadInt32(*Schema, *int32) error
 	ReadInt64(*Schema, *int64) error
-
-	ReadInt8Ptr(*Schema, **int8) error
-	ReadInt16Ptr(*Schema, **int16) error
-	ReadInt32Ptr(*Schema, **int32) error
-	ReadInt64Ptr(*Schema, **int64) error
-
 	ReadFloat32(*Schema, *float32) error
 	ReadFloat64(*Schema, *float64) error
-
-	ReadFloat32Ptr(*Schema, **float32) error
-	ReadFloat64Ptr(*Schema, **float64) error
-
 	ReadBool(*Schema, *bool) error
-	ReadBoolPtr(*Schema, **bool) error
-
 	ReadString(*Schema, *string) error
-	ReadStringPtr(*Schema, **string) error
-
-	ReadTime(*Schema, *time.Time) error
-	ReadTimePtr(*Schema, **time.Time) error
-
 	ReadBlob(*Schema, *[]byte) error
+	ReadTime(*Schema, *time.Time) error
+	ReadBigInt(*Schema, *big.Int) error
+	ReadBigFloat(*Schema, *big.Float) error
+	ReadNil(*Schema) (bool, error)
+
+	ReadStruct(*Schema) error
+	ReadStructMember() (*Schema, error)
+
+	ReadUnion(*Schema) (*Schema, error)
+	ReadDocument(*Schema, *document.Value) error
 
 	ReadList(*Schema) error
-	// returns true if there's another item in the list, false at the end and
-	// an error if a decode error is encountered. use other deserializer
-	// methods to read the expected type from the deserializer
 	ReadListItem(*Schema) (hasMoreElements bool, err error)
 
 	ReadMap(*Schema) error
-	// the bool will be true if there's another key in the list and the string
-	// will have the value of that key, with any decode error in the error. use
-	// other deserializer methods to read the expected type.
 	ReadMapKey(*Schema) (key string, hasMoreElements bool, err error)
-
-	ReadStruct(*Schema) error
-	// returns the member schema for the given struct, nil when there are no
-	// more members, with any decode error in the error. use other deserializer
-	// methods to read the expected type.
-	ReadStructMember() (*Schema, error)
-
-	// returns the schema for the variant that the union is
-	ReadUnion(*Schema) (*Schema, error)
-
-	// returns true if the next value is null (and consumes it)
-	ReadNil(*Schema) (bool, error)
-
-	ReadDocument(*Schema, *document.Value) error
 }
 
 // Serializable is an entity that can describe itself to a ShapeSerializer to

--- a/smithy-http-protocols/internal/cbor/shape_deserializer.go
+++ b/smithy-http-protocols/internal/cbor/shape_deserializer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/big"
 	"time"
 
 	"github.com/aws/smithy-go"
@@ -218,26 +219,6 @@ func (d *ShapeDeserializer) ReadInt64(s *smithy.Schema, v *int64) error {
 	return readInt(d, v, math.MinInt64, math.MaxInt64)
 }
 
-// ReadInt8Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadInt8Ptr(s *smithy.Schema, v **int8) error {
-	return readPtr(d, s, v, d.ReadInt8)
-}
-
-// ReadInt16Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadInt16Ptr(s *smithy.Schema, v **int16) error {
-	return readPtr(d, s, v, d.ReadInt16)
-}
-
-// ReadInt32Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadInt32Ptr(s *smithy.Schema, v **int32) error {
-	return readPtr(d, s, v, d.ReadInt32)
-}
-
-// ReadInt64Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadInt64Ptr(s *smithy.Schema, v **int64) error {
-	return readPtr(d, s, v, d.ReadInt64)
-}
-
 // ReadFloat32 implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadFloat32(s *smithy.Schema, v *float32) error {
 	return readFloat(d, v)
@@ -246,16 +227,6 @@ func (d *ShapeDeserializer) ReadFloat32(s *smithy.Schema, v *float32) error {
 // ReadFloat64 implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadFloat64(s *smithy.Schema, v *float64) error {
 	return readFloat(d, v)
-}
-
-// ReadFloat32Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadFloat32Ptr(s *smithy.Schema, v **float32) error {
-	return readPtr(d, s, v, d.ReadFloat32)
-}
-
-// ReadFloat64Ptr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadFloat64Ptr(s *smithy.Schema, v **float64) error {
-	return readPtr(d, s, v, d.ReadFloat64)
 }
 
 // ReadBool implements [smithy.ShapeDeserializer].
@@ -279,11 +250,6 @@ func (d *ShapeDeserializer) ReadBool(s *smithy.Schema, v *bool) error {
 	default:
 		return fmt.Errorf("expected bool, got minor %d", minor)
 	}
-}
-
-// ReadBoolPtr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadBoolPtr(s *smithy.Schema, v **bool) error {
-	return readPtr(d, s, v, d.ReadBool)
 }
 
 // ReadString implements [smithy.ShapeDeserializer].
@@ -330,11 +296,6 @@ func (d *ShapeDeserializer) ReadString(s *smithy.Schema, v *string) error {
 	return nil
 }
 
-// ReadStringPtr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadStringPtr(s *smithy.Schema, v **string) error {
-	return readPtr(d, s, v, d.ReadString)
-}
-
 // ReadTime implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadTime(schema *smithy.Schema, v *time.Time) error {
 	if d.eof() {
@@ -375,11 +336,6 @@ func (d *ShapeDeserializer) ReadTime(schema *smithy.Schema, v *time.Time) error 
 	default:
 		return fmt.Errorf("unexpected major type %d in timestamp tag", major)
 	}
-}
-
-// ReadTimePtr implements [smithy.ShapeDeserializer].
-func (d *ShapeDeserializer) ReadTimePtr(schema *smithy.Schema, v **time.Time) error {
-	return readPtr(d, schema, v, d.ReadTime)
 }
 
 // ReadBlob implements [smithy.ShapeDeserializer].
@@ -555,6 +511,12 @@ func (d *ShapeDeserializer) ReadStructMember() (*smithy.Schema, error) {
 		return d.ReadStructMember()
 	}
 
+	if isNil, err := d.ReadNil(member); err != nil {
+		return nil, err
+	} else if isNil {
+		return d.ReadStructMember()
+	}
+
 	return member, nil
 }
 
@@ -701,16 +663,6 @@ func (d *ShapeDeserializer) skipIndefiniteBytes() error {
 	return nil
 }
 
-func readPtr[T any](d *ShapeDeserializer, s *smithy.Schema, v **T, read func(*smithy.Schema, *T) error) error {
-	if isNil, err := d.ReadNil(s); isNil || err != nil {
-		return err
-	}
-	if *v == nil {
-		*v = new(T)
-	}
-	return read(s, *v)
-}
-
 type tint interface {
 	int8 | int16 | int32 | int64
 }
@@ -764,4 +716,14 @@ func GetProtocolErrorInfo(p []byte) (typ, message string, err error) {
 	}
 
 	return typ, message, nil
+}
+
+// ReadBigInt is unimplemented and will return an error.
+func (d *ShapeDeserializer) ReadBigInt(_ *smithy.Schema, _ *big.Int) error {
+	return fmt.Errorf("unimplemented")
+}
+
+// ReadBigFloat is unimplemented and will return an error.
+func (d *ShapeDeserializer) ReadBigFloat(_ *smithy.Schema, _ *big.Float) error {
+	return fmt.Errorf("unimplemented")
 }


### PR DESCRIPTION
same deal as #663 

relates #458

only relevant change here is that the two formats w/ nulls (json and cbor, cbor may not even need it but i did it anyway) will now just check for nil themselves in ReadStructMember. so basically the "read member" hook is _only_ ever called if there's a value

also, the deserializer was missing bignums, like the serializer they are "unimplemented" for now