### PR TITLE
Use GoDependency to add SDK dependencies on codegen instead of relying on go mod tidy

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/EventStreamProtocolTestGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/EventStreamProtocolTestGenerator.java
@@ -12,6 +12,7 @@ import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.go.codegen.GoCodegenContext;
 import software.amazon.smithy.go.codegen.GoDelegator;
+import software.amazon.smithy.go.codegen.GoDependency;
 import software.amazon.smithy.go.codegen.GoSettings;
 import software.amazon.smithy.go.codegen.GoWriter;
 import software.amazon.smithy.go.codegen.ShapeValueGenerator;
@@ -40,6 +41,16 @@ import software.amazon.smithy.protocoltests.traits.eventstream.EventType;
  */
 public class EventStreamProtocolTestGenerator {
     private static final Logger LOGGER = Logger.getLogger(EventStreamProtocolTestGenerator.class.getName());
+
+    private static final GoDependency AWS_EVENTSTREAM = GoDependency.moduleDependency(
+            "github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream",
+            "github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream",
+            "v0.0.0", "eventstream");
+
+    private static final GoDependency AWS_CREDENTIALS = GoDependency.moduleDependency(
+            "github.com/aws/aws-sdk-go-v2/credentials",
+            "github.com/aws/aws-sdk-go-v2/credentials",
+            "v0.0.0", "credentials");
 
     private static final Set<String> SKIP_TESTS = Set.of(
             // SDK does not validate required fields on responses client-side.
@@ -131,7 +142,7 @@ public class EventStreamProtocolTestGenerator {
         writer.addUseImports(SmithyGoDependency.STRINGS);
         writer.addUseImports(SmithyGoDependency.SYNC);
         // FUTURE(serde2): event stream runtime goes over to smithy so this will go away
-        writer.addImport("github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream", "eventstream");
+        writer.addUseImports(AWS_EVENTSTREAM);
 
         writer.write("""
                 // eventstreamMockHTTPClient implements aws.HTTPClient for event stream testing.
@@ -256,7 +267,7 @@ public class EventStreamProtocolTestGenerator {
                 .anyMatch(tc ->
                         tc.getEvents().stream().anyMatch(e -> e.getType() == EventType.REQUEST));
         if (hasResponseEvents || hasRequestEvents) {
-            writer.addImport("github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream", "eventstream");
+            writer.addUseImports(AWS_EVENTSTREAM);
         }
 
         boolean needsTime = testCases.stream().anyMatch(tc ->
@@ -334,7 +345,7 @@ public class EventStreamProtocolTestGenerator {
             writer.write("");
 
             // Create client with mock — provide fake creds for signing
-            writer.addImport("github.com/aws/aws-sdk-go-v2/credentials", "credentials");
+            writer.addUseImports(AWS_CREDENTIALS);
             writer.openBlock("client := New(Options{", "})", () -> {
                 writer.write("HTTPClient: mock,");
                 writer.write("Credentials: credentials.NewStaticCredentialsProvider(\"AKID\", \"SECRET\", \"SESSION\"),");


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We currently add some dependencies by just using `writer.addImport("github.com/aws/aws-sdk-go-v2/credentials", "credentials");`. This causes these dependencies to not be written on the generated `go.mod`, but only show up when we run `go mod tidy`. Due to how the `generate` target is structured [on the SDK](https://github.com/aws/aws-sdk-go-v2/blob/main/Makefile#L79), this happens after we do codegen 
```
generate: smithy-generate smithy-generate-protocol-tests update-requires (...) tidy-modules-.
```

Our release worklow also rewrites all things that depend on the SDK on `gen-repo-mod-replace` target to use a `replace` directive, like

```
module github.com/aws/aws-sdk-go-v2/internal/protocoltest/awsrestjson

go 1.24

require (
	github.com/aws/aws-sdk-go-v2 v1.41.7 // this version points to what is about to be released, which currently does not exist since we are just releasing it
	// ...
)

replace github.com/aws/aws-sdk-go-v2 => ../../../ // but because we are doing this replace, we can build it
```

If the dependency does not appear on go.mod at that point, it only gets resolved during `go mod tidy`, which resolves to the newly bumped version and fails to resolve that version.

This PR adds them with `addUseImports`, which causes them to appear on `go.mod` instead

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
