### PR TITLE
handle vars in auth scheme id tmpl

### DIFF
--- a/.changelog/788a5ad280e34786801284febfe1cf9c.json
+++ b/.changelog/788a5ad280e34786801284febfe1cf9c.json
@@ -1,0 +1,8 @@
+{
+    "id": "788a5ad2-80e3-4786-8012-84febfe1cf9c",
+    "type": "feature",
+    "description": "Add StringSlice to endpoint rulesfn.",
+    "modules": [
+        "."
+    ]
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/ResolveAuthSchemeMiddlewareGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/auth/ResolveAuthSchemeMiddlewareGenerator.java
@@ -107,7 +107,7 @@ public class ResolveAuthSchemeMiddlewareGenerator {
                         }
 
                         for _, scheme := range m.options.AuthSchemes {
-                            if scheme.SchemeID() != option.SchemeID {
+                            if !matchSchemeID(scheme.SchemeID(), option.SchemeID) {
                                 continue
                             }
 
@@ -118,6 +118,16 @@ public class ResolveAuthSchemeMiddlewareGenerator {
                     }
 
                     return nil, false
+                }
+
+                func matchSchemeID(registered, option string) bool {
+                    if registered == option {
+                        return true
+                    }
+                    if i := strings.LastIndex(registered, "#"); i != -1 {
+                        return registered[i+1:] == option
+                    }
+                    return false
                 }
 
                 func sortAuthOptions(options []$option:P, preferred []string) []$option:P {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/AuthSchemePropertyGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/AuthSchemePropertyGenerator.java
@@ -36,14 +36,6 @@ public class AuthSchemePropertyGenerator {
         this.generator = generator;
     }
 
-    public static String mapEndpointPropertyAuthSchemeName(String name) {
-        return switch (name) {
-            case "sigv4" -> "aws.auth#sigv4";
-            case "sigv4a" -> "aws.auth#sigv4a";
-            default -> name;
-        };
-    }
-
     public Writable generate(Expression expr) {
         return goTemplate("""
                 $T(&out, []$P{
@@ -61,17 +53,17 @@ public class AuthSchemePropertyGenerator {
 
     private Writable generateOption(ExpressionGenerator generator, RecordLiteral scheme) {
         var members = scheme.members();
-        var schemeName = ((StringLiteral) members.get(Identifier.of("name"))).value().expectLiteral();
+        var nameExpr = (StringLiteral) members.get(Identifier.of("name"));
         return goTemplate("""
                 {
-                    SchemeID: $1S,
+                    SchemeID: $1W,
                     SignerProperties: func() $2T {
                         var sp $2T
                         $3W
                         return sp
                     }(),
                 },""",
-                mapEndpointPropertyAuthSchemeName(schemeName),
+                generator.generate(nameExpr),
                 SmithyGoDependency.SMITHY.struct("Properties"),
                 generateOptionSignerProps(generator, scheme));
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointBddResolverGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointBddResolverGenerator.java
@@ -133,8 +133,6 @@ public final class EndpointBddResolverGenerator {
         var condScope = buildConditionScope(derefScope, conditions);
 
         return goTemplate("""
-                $stringSlice:W
-
                 $nodeArray:W
 
                 $conditionContext:W
@@ -146,8 +144,6 @@ public final class EndpointBddResolverGenerator {
                 $resolverType:W
                 """,
                 MapUtils.of(
-                        "stringSlice", needsStringSlice(conditions, parameters)
-                                ? EndpointResolverGenerator.generateStringSliceHelper() : emptyGoTemplate(),
                         "nodeArray", generateNodeArray(bdd),
                         "conditionContext", generateConditionContext(conditions),
                         "evalCondition", generateEvalCondition(conditions, ptrScope, condScope),
@@ -160,17 +156,8 @@ public final class EndpointBddResolverGenerator {
     // It maps to []string in Go, which needs a stringSlice cast for .Get() index access.
     private static String derefParam(Parameter p, String ptrName) {
         return p.getType() == ParameterType.STRING_ARRAY
-                ? "stringSlice(" + ptrName + ")"
+                ? "rulesfn.StringSlice(" + ptrName + ")"
                 : "*" + ptrName;
-    }
-
-    private static boolean needsStringSlice(List<Condition> conditions, Parameters parameters) {
-        for (Iterator<Parameter> iter = parameters.iterator(); iter.hasNext();) {
-            if (iter.next().getType() == ParameterType.STRING_ARRAY) {
-                return true;
-            }
-        }
-        return conditions.stream().anyMatch(c -> c.getFunction().getName().equals("split"));
     }
 
     // ---- Component 1: Node array ----

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolutionGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolutionGenerator.java
@@ -88,6 +88,10 @@ public class EndpointResolutionGenerator {
         var bindingGenerator = new EndpointParameterBindingsGenerator(context);
         var middlewareGenerator = new EndpointMiddlewareGenerator(context);
 
+        // Ensure rulesfn import for StringSlice used in scope-emitted code.
+        writer.write("var _ = $T(nil)", SymbolUtils.createValueSymbolBuilder(
+                "StringSlice", SmithyGoDependency.SMITHY_ENDPOINT_RULESFN).build());
+
         // Prefer BDD trait over tree-based ruleset when available
         var bddTrait = serviceShape.getTrait(EndpointBddTrait.class);
         if (bddTrait.isPresent()) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolverGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolverGenerator.java
@@ -112,8 +112,6 @@ public final class EndpointResolverGenerator {
 
     private Writable generateResolverType(Writable resolveMethodBody) {
         return goTemplate("""
-                $stringSlice:W
-
                 // $resolverInterfaceType:T provides the interface for resolving service endpoints.
                 type $resolverInterfaceType:T interface {
                     $resolveEndpointMethodDocs:W
@@ -141,7 +139,6 @@ public final class EndpointResolverGenerator {
                 commonCodegenArgs,
                 MapUtils.of(
                         "context", SymbolUtils.createValueSymbolBuilder("Context", SmithyGoDependency.CONTEXT).build(),
-                        "stringSlice", generateStringSliceHelper(),
                         "resolverTypeDocs", generateResolverTypeDocs(),
                         "resolveEndpointMethodDocs", generateResolveEndpointMethodDocs(),
                         "resolveMethodBody", resolveMethodBody));
@@ -199,7 +196,7 @@ public final class EndpointResolverGenerator {
                                         w.write("_ = $L", getLocalVarParameterName(param));
                                     }
                                     case STRING_ARRAY -> {
-                                        w.write("$L := stringSlice($L)",
+                                        w.write("$L := rulesfn.StringSlice($L)",
                                                 getLocalVarParameterName(param), getMemberParameterName(param));
                                         w.write("_ = $L", getLocalVarParameterName(param));
                                     }
@@ -328,7 +325,7 @@ public final class EndpointResolverGenerator {
                     }
                     """,
                     MapUtils.of(
-                            "exprVal", isStringSlice ? "stringSlice(exprVal)" : "*exprVal",
+                            "exprVal", isStringSlice ? "rulesfn.StringSlice(exprVal)" : "*exprVal",
                             "conditionIdent", conditionIdentifier,
                             "target", generator.generate(fn),
                             "next", generateRule(
@@ -603,20 +600,6 @@ public final class EndpointResolverGenerator {
         public EndpointResolverGenerator build() {
             return new EndpointResolverGenerator(this);
         }
-    }
-
-    static Writable generateStringSliceHelper() {
-        return goTemplate("""
-                type stringSlice []string
-
-                func (s stringSlice) Get(i int) *string {
-                    if i < 0 || i >= len(s) {
-                        return nil
-                    }
-
-                    v := s[i]
-                    return &v
-                }""");
     }
 
     private boolean isStringSlice(Type type) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/FnGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/FnGenerator.java
@@ -56,9 +56,11 @@ public class FnGenerator {
             writableFnArgs.add(new ExpressionGenerator(scope, this.fnProvider).generate(expr));
         });
 
-        // Wrap split() in stringSlice() for safe .Get() index access
+        // Wrap split() in rulesfn.StringSlice() for safe .Get() index access
         if (fnDef.getId().equals("split")) {
-            return goTemplate("stringSlice($fn:T($args:W))", MapUtils.of(
+            return goTemplate("$stringSlice:T($fn:T($args:W))", MapUtils.of(
+                    "stringSlice", SymbolUtils.createValueSymbolBuilder("StringSlice",
+                            SmithyGoDependency.SMITHY_ENDPOINT_RULESFN).build(),
                     "fn", goFn,
                     "args", joinWritables(writableFnArgs, ", ")));
         }

--- a/endpoints/private/rulesfn/string_slice.go
+++ b/endpoints/private/rulesfn/string_slice.go
@@ -1,0 +1,18 @@
+package rulesfn
+
+// StringSlice is a string slice with a negative-index-aware Get method for use
+// in endpoint rule evaluation.
+type StringSlice []string
+
+// Get returns a pointer to the string at index i, or nil if the index is out
+// of bounds. Negative indices count from the end of the slice.
+func (s StringSlice) Get(i int) *string {
+	if i < 0 {
+		i = len(s) + i
+	}
+	if i < 0 || i >= len(s) {
+		return nil
+	}
+	v := s[i]
+	return &v
+}


### PR DESCRIPTION
* every property now uses the template generator to handle vars etc.
* the "do we need string slice" logic was going to get more complicated so I just converted it to something in the runtime. the codegen that uses it didn't have a good way to inject a symbol so i just added a pinned usage
* previously we prepended the smithy shape id namespace to auth scheme ids in endpoint rules. since those values can now be dynamic that is no longer possible to do, thus the names are now returned as is and the auth scheme resolution logic matches without namespace