### PR TITLE
fix: remove deprecated io/ioutil from codegen templates

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStdlibTypes.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoStdlibTypes.java
@@ -63,7 +63,7 @@ public final class GoStdlibTypes {
         public static final Symbol Copy = SmithyGoDependency.IO.valueSymbol("Copy");
 
         public static final class IoUtil {
-            public static final Symbol Discard = SmithyGoDependency.IOUTIL.valueSymbol("Discard");
+            public static final Symbol Discard = SmithyGoDependency.IO.valueSymbol("Discard");
         }
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -36,7 +36,6 @@ public final class SmithyGoDependency {
     public static final GoDependency STRINGS = stdlib("strings");
     public static final GoDependency JSON = stdlib("encoding/json");
     public static final GoDependency IO = stdlib("io");
-    public static final GoDependency IOUTIL = stdlib("io/ioutil");
     public static final GoDependency FS = stdlib("io/fs");
     public static final GoDependency CRYPTORAND = stdlib("crypto/rand", "cryptorand");
     public static final GoDependency TESTING = stdlib("testing");

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -451,8 +451,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             // without an archetype.
             if (CodegenUtils.isStubSynthetic(ProtocolUtils.expectOutput(model, operation))
                     && streamInfoOptional.isEmpty()) {
-                writer.addUseImports(SmithyGoDependency.IOUTIL);
-                writer.openBlock("if _, err = io.Copy(ioutil.Discard, response.Body); err != nil {", "}", () -> {
+                writer.addUseImports(SmithyGoDependency.IO);
+                writer.openBlock("if _, err = io.Copy(io.Discard, response.Body); err != nil {", "}", () -> {
                     writer.openBlock("return out, metadata, &smithy.DeserializationError{", "}", () -> {
                         writer.write("Err: fmt.Errorf(\"failed to discard response body, %w\", err),");
                     });

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestResponseGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestResponseGenerator.java
@@ -169,10 +169,10 @@ public class HttpProtocolUnitTestResponseGenerator extends HttpProtocolUnitTestG
         });
 
         writer.addUseImports(SmithyGoDependency.BYTES);
-        writer.addUseImports(SmithyGoDependency.IOUTIL);
+        writer.addUseImports(SmithyGoDependency.IO);
         writer.openBlock("if len(c.Body) != 0 {", "} else {", () -> {
             writer.write("response.ContentLength = int64(len(c.Body))");
-            writer.write("response.Body = ioutil.NopCloser(bytes.NewReader(c.Body))");
+            writer.write("response.Body = io.NopCloser(bytes.NewReader(c.Body))");
         });
         writer.openBlock("", "}", () -> {
             // We have to set this special sentinel value for no body, or anything that relies on there being

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
@@ -370,8 +370,8 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
             // without an archetype.
             if (CodegenUtils.isStubSynthetic(ProtocolUtils.expectOutput(model, operation))
                 && streamInfoOptional.isEmpty()) {
-                writer.addUseImports(SmithyGoDependency.IOUTIL);
-                writer.openBlock("if _, err = io.Copy(ioutil.Discard, response.Body); err != nil {", "}",
+                writer.addUseImports(SmithyGoDependency.IO);
+                writer.openBlock("if _, err = io.Copy(io.Discard, response.Body); err != nil {", "}",
                         () -> {
                             writer.openBlock("return out, metadata, &smithy.DeserializationError{", "}", () -> {
                                 writer.write("Err: fmt.Errorf(\"failed to discard response body, %w\", err),");


### PR DESCRIPTION
## What

  Remove deprecated `io/ioutil` package usage from smithy-go codegen templates.

  ## Why

  Resolves part of aws/aws-sdk-go-v2#3094. The `io/ioutil` package has been
  deprecated since Go 1.16. The two symbols this codegen uses (`Discard`,
  `NopCloser`) have direct, byte-identical replacements in the `io` package.

  ## Changes

  - `SmithyGoDependency.IOUTIL` constant removed
  - `GoStdlibTypes.Io.IoUtil.Discard` symbol repointed to `SmithyGoDependency.IO`
  - 3 generator sites updated to emit `io.X` instead of `ioutil.X`:
    - `HttpProtocolUnitTestResponseGenerator` (NopCloser)
    - `HttpBindingProtocolGenerator` (Discard)
    - `HttpRpcProtocolGenerator` (Discard)

  ## Compatibility note

  This removes the public `SmithyGoDependency.IOUTIL` constant. Inside aws-sdk-go-v2
  two sites reference it; I have a follow-up PR there that bumps the codegen
  version pin and updates those sites in lockstep.

  ## Local validation

  - `make smithy-build` — BUILD SUCCESSFUL
  - `make smithy-publish-local` followed by `DEV_SERVICE=s3 make generate-dev`
    in aws-sdk-go-v2: S3 regenerates with `io.X` calls, `service/s3` builds and
    tests pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
