### PR TITLE
fix: json ShapeDeserializer panic on union nested directly inside a union

### DIFF
--- a/serde.go
+++ b/serde.go
@@ -138,10 +138,15 @@ func ReadUnion(d ShapeDeserializer, schema *Schema, memberFn func(*Schema) error
 		return err
 	}
 
-	if ms != nil {
-		if err := memberFn(ms); err != nil {
-			return err
-		}
+	// A nil member on the first read means the union value was null, empty,
+	// or contained only null members -- the union has been fully consumed and
+	// reading again would read past it.
+	if ms == nil {
+		return nil
+	}
+
+	if err := memberFn(ms); err != nil {
+		return err
 	}
 
 	for {

--- a/transport/http/protocol/internal/json/shape_deserializer.go
+++ b/transport/http/protocol/internal/json/shape_deserializer.go
@@ -11,11 +11,11 @@ import (
 	"time"
 
 	"github.com/aws/smithy-go"
-	"github.com/aws/smithy-go/transport/http/protocol/internal/json/internal/stdlib"
 	"github.com/aws/smithy-go/document"
 	"github.com/aws/smithy-go/internal/serde"
 	smithytime "github.com/aws/smithy-go/time"
 	"github.com/aws/smithy-go/traits"
+	"github.com/aws/smithy-go/transport/http/protocol/internal/json/internal/stdlib"
 )
 
 type ctxKind int8
@@ -500,7 +500,19 @@ func (d *ShapeDeserializer) ReadStructMember() (*smithy.Schema, error) {
 
 // ReadUnion implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadUnion(s *smithy.Schema) (*smithy.Schema, error) {
-	if top := d.head.Top(); top == nil || top.kind != ctxUnion {
+	resuming := false
+	if top := d.head.Top(); top != nil && top.kind == ctxUnion {
+		// The context on top of the stack may belong to a parent union when
+		// this union is itself the value of a union member. Disambiguate by
+		// peeking: at a value position the next token can only be '{' (or
+		// null), while on resume it can only be a member name or '}'.
+		tok, err := d.peek()
+		if err != nil {
+			return nil, err
+		}
+		resuming = !isLCB(tok) && !isN(tok)
+	}
+	if !resuming {
 		if isNil, err := d.ReadNil(s); isNil || err != nil {
 			return nil, err
 		}
@@ -588,6 +600,9 @@ func unquote(tok []byte) (string, error) {
 }
 
 func memberFromToken(s *smithy.Schema, tok []byte, escaped bool) (*smithy.Schema, error) {
+	if len(tok) < 2 || tok[0] != '"' {
+		return nil, fmt.Errorf("expected member name, got %s", tok)
+	}
 	inner := tok[1 : len(tok)-1]
 	if m := memberByBytes(s, inner); m != nil {
 		return m, nil

--- a/transport/http/protocol/internal/json/shape_deserializer_union_test.go
+++ b/transport/http/protocol/internal/json/shape_deserializer_union_test.go
@@ -1,0 +1,94 @@
+package json
+
+import (
+	"testing"
+
+	"github.com/aws/smithy-go"
+)
+
+// Schemas modeling a union member whose value is itself a union, e.g.
+// bedrock-agentcore's TargetConfiguration -> mcp -> McpTargetConfiguration.
+var (
+	testSchemaString = smithy.NewSchema(smithy.ShapeID{
+		Namespace: "smithy.api", Name: "String",
+	}, smithy.ShapeTypeString, 0)
+
+	testSchemaInnerUnion = smithy.NewSchema(smithy.ShapeID{
+		Namespace: "com.test", Name: "InnerUnion",
+	}, smithy.ShapeTypeUnion, 1)
+
+	testSchemaOuterUnion = smithy.NewSchema(smithy.ShapeID{
+		Namespace: "com.test", Name: "OuterUnion",
+	}, smithy.ShapeTypeUnion, 1)
+
+	testSchemaInnerUnion_Lambda *smithy.Schema
+	testSchemaOuterUnion_Mcp    *smithy.Schema
+)
+
+func init() {
+	testSchemaInnerUnion_Lambda = testSchemaInnerUnion.AddMember("lambda", testSchemaString)
+	testSchemaOuterUnion_Mcp = testSchemaOuterUnion.AddMember("mcp", testSchemaInnerUnion)
+}
+
+// readNestedUnion mimics the calling pattern of SDK-generated code
+// (smithy.ReadUnion in serde.go): repeatedly call ReadUnion until it returns
+// no member, deserializing each member value in between.
+func readNestedUnion(d *ShapeDeserializer) (member string, value string, err error) {
+	err = smithy.ReadUnion(d, testSchemaOuterUnion, func(ms *smithy.Schema) error {
+		member = ms.MemberName()
+		return smithy.ReadUnion(d, testSchemaInnerUnion, func(inner *smithy.Schema) error {
+			member += "." + inner.MemberName()
+			return d.ReadString(inner, &value)
+		})
+	})
+	return member, value, err
+}
+
+func TestReadUnion_NestedUnionValue(t *testing.T) {
+	// A union whose member value is itself a union. Before the fix,
+	// ReadUnion mistook the parent's union context for its own, skipped the
+	// inner '{' and panicked in memberFromToken (slice bounds [1:0]).
+	d := NewShapeDeserializer([]byte(`{"mcp":{"lambda":"arn:aws:lambda:fn"}}`))
+
+	member, value, err := readNestedUnion(d)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if member != "mcp.lambda" {
+		t.Errorf("expected member mcp.lambda, got %q", member)
+	}
+	if value != "arn:aws:lambda:fn" {
+		t.Errorf("expected value arn:aws:lambda:fn, got %q", value)
+	}
+}
+
+func TestReadUnion_NestedUnionNullValue(t *testing.T) {
+	// A union member with a null value is skipped entirely; the member
+	// callback must not fire.
+	d := NewShapeDeserializer([]byte(`{"mcp":null}`))
+
+	member, _, err := readNestedUnion(d)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if member != "" {
+		t.Errorf("expected no member, got %q", member)
+	}
+}
+
+func TestReadUnion_FlatUnionStillWorks(t *testing.T) {
+	// Regression guard: a plain (non-nested) union read.
+	d := NewShapeDeserializer([]byte(`{"lambda":"v"}`))
+
+	var member, value string
+	err := smithy.ReadUnion(d, testSchemaInnerUnion, func(ms *smithy.Schema) error {
+		member = ms.MemberName()
+		return d.ReadString(ms, &value)
+	})
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if member != "lambda" || value != "v" {
+		t.Errorf("expected lambda/v, got %q/%q", member, value)
+	}
+}


### PR DESCRIPTION
Fixes #671

## Problem

`json.(*ShapeDeserializer).ReadUnion` panics with `slice bounds out of range [1:0]` when a union member's value is itself a union (e.g. `bedrockagentcorecontrol` `GetGatewayTarget`'s `TargetConfiguration` → `mcp` → `McpTargetConfiguration`). This currently crashes terraform-provider-aws v6.48.0 on every refresh of `aws_bedrockagentcore_gateway_target`.

`ReadUnion` detected "resume after reading a member value" by checking whether the top of the context stack is `ctxUnion`. For a union nested directly inside a union, the inner call sees the **parent's** `ctxUnion`, wrongly resumes, skips the inner `'{'`, and passes that 1-byte token to `memberFromToken` → panic.

## Fix

- **`ReadUnion`**: when the top of the stack is `ctxUnion`, disambiguate by peeking. At a value position the next token can only be `'{'` (or `null`); on resume it can only be a member name (`'"'`) or `'}'`. The parser's grammar state machine guarantees these sets are disjoint, so the peek is a sound discriminator. Behavior is unchanged for all non-nested cases.
- **`memberFromToken`**: validate the token shape and return an error instead of panicking (defense in depth).
- **`smithy.ReadUnion` helper (`serde.go`)**: when the first `d.ReadUnion` returns no member (union value was `null`, `{}`, or contained only null members), the union has already been fully consumed — calling `d.ReadUnion` again read tokens past the union and corrupted the stream. Return early instead.

## Testing

- New regression tests in `shape_deserializer_union_test.go`:
  - nested union value (panicked before this change, with the exact production stack trace)
  - union member with `null` value (read past the union before this change)
  - flat union (behavior unchanged)
- `go test ./...` passes across the repository (includes the JSONTestSuite corpus and fuzz seed corpora).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Co-Authored-By: Claude Opus 4.8 (1M context)