### PR TITLE
feat: move common middlewares to shared addCommonMiddlewares

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -230,6 +230,10 @@ public final class OperationGenerator implements Runnable {
                             return;
                         }
 
+                        if (runtimeClientPlugin.isCommon()) {
+                            return;
+                        }
+
                         MiddlewareRegistrar middlewareRegistrar = runtimeClientPlugin.registerMiddleware().get();
                         Collection<Symbol> functionArguments = middlewareRegistrar.getFunctionArguments();
 
@@ -271,11 +275,6 @@ public final class OperationGenerator implements Runnable {
             return;
         }
         writer.addUseImports(SmithyGoDependency.SMITHY_MIDDLEWARE);
-        // persist operation input to context for internal build/finalize middleware access
-        writer.write("""
-                if err := stack.Serialize.Add(&setOperationInputMiddleware{}, middleware.After); err != nil {
-                    return err
-                }""");
 
         if (ctx.settings().useLegacySerde()) {
             // Add request serializer middleware
@@ -327,13 +326,6 @@ public final class OperationGenerator implements Runnable {
             }
         }
 
-        // FUTURE: retry middleware should be at the front of finalize, right now it's added by the SDK
-        writer.write("""
-                if err := addProtocolFinalizerMiddlewares(stack, options, $S); err != nil {
-                    return $T("add protocol finalizers: %v", err)
-                }""",
-                operationSymbol.getName(),
-                GoStdlibTypes.Fmt.Errorf);
         writer.write("");
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -22,6 +22,7 @@ import static software.amazon.smithy.go.codegen.GoWriter.goDocTemplate;
 import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +49,7 @@ import software.amazon.smithy.go.codegen.integration.ClientMemberResolver;
 import software.amazon.smithy.go.codegen.integration.ConfigFieldResolver;
 import software.amazon.smithy.go.codegen.integration.GoIntegration;
 import software.amazon.smithy.go.codegen.integration.OperationMetricsStruct;
+import software.amazon.smithy.go.codegen.integration.MiddlewareRegistrar;
 import software.amazon.smithy.go.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.protocol.traits.Rpcv2CborTrait;
@@ -117,7 +119,8 @@ final class ServiceGenerator implements Runnable {
                 generateEventStreamInvokeOperation(),
                 asyncStreamReaders(),
                 generateInputContextFuncs(),
-                generateAddProtocolFinalizerMiddleware()
+                generateAddProtocolFinalizerMiddleware(),
+                generateAddCommonMiddlewares()
         ).compose();
     }
 
@@ -422,6 +425,10 @@ final class ServiceGenerator implements Runnable {
 
                     $finalizers:W
 
+                    if err := c.addCommonMiddlewares(stack, options, opID); err != nil {
+                        return nil, metadata, err
+                    }
+
                     for _, fn := range stackFns {
                         if err := fn(stack, options); err != nil {
                             return nil, metadata, err
@@ -533,6 +540,10 @@ final class ServiceGenerator implements Runnable {
                     }
 
                     $finalizers:W
+
+                    if err := c.addCommonMiddlewares(stack, options, opID); err != nil {
+                        return nil, metadata, err
+                    }
 
                     for _, fn := range stackFns {
                         if err := fn(stack, options); err != nil {
@@ -742,6 +753,67 @@ final class ServiceGenerator implements Runnable {
                         EndpointMiddlewareGenerator.generateAddToProtocolFinalizers(),
                         SignRequestMiddlewareGenerator.generateAddToProtocolFinalizers()
                 ).compose(false));
+    }
+
+    private Writable generateAddCommonMiddlewares() {
+        return (GoWriter writer) -> {
+            writer.openBlock(
+                    "func (c *$T) addCommonMiddlewares(stack $P, options $L, operation string) error {", "}",
+                    symbolProvider.toSymbol(service),
+                    SmithyGoDependency.SMITHY_MIDDLEWARE.struct("Stack"),
+                    CONFIG_NAME,
+                    () -> {
+                        // Must be first — provides anchors that other middlewares Insert relative to.
+                        writer.addUseImports(SmithyGoDependency.SMITHY_MIDDLEWARE);
+                        writer.write("""
+                                if err := stack.Serialize.Add(&setOperationInputMiddleware{}, middleware.After); err != nil {
+                                    return err
+                                }""");
+                        writer.write("""
+                                if err := addProtocolFinalizerMiddlewares(stack, options, operation); err != nil {
+                                    return fmt.Errorf("add protocol finalizers: %v", err)
+                                }""");
+                        writer.addUseImports(SmithyGoDependency.FMT);
+
+                        runtimePlugins.forEach(plugin -> {
+                            if (!plugin.isCommon()) {
+                                return;
+                            }
+                            if (!plugin.registerMiddleware().isPresent()) {
+                                return;
+                            }
+
+                            MiddlewareRegistrar registrar = plugin.registerMiddleware().get();
+                            Collection<Symbol> functionArguments = registrar.getFunctionArguments();
+
+                            if (registrar.getInlineRegisterMiddlewareStatement() != null) {
+                                String registerStatement = String.format("if err := stack.%s",
+                                        registrar.getInlineRegisterMiddlewareStatement());
+                                writer.writeInline(registerStatement);
+                                writer.writeInline("$T(", registrar.getResolvedFunction());
+                                if (functionArguments != null) {
+                                    for (Symbol arg : functionArguments) {
+                                        writer.writeInline("$P, ", arg);
+                                    }
+                                }
+                                writer.writeInline(")");
+                                writer.write(", $T); err != nil {\nreturn err\n}",
+                                        registrar.getInlineRegisterMiddlewarePosition());
+                            } else {
+                                writer.writeInline("if err := $T(stack", registrar.getResolvedFunction());
+                                if (functionArguments != null) {
+                                    for (Symbol arg : functionArguments) {
+                                        writer.writeInline(", $P", arg);
+                                    }
+                                }
+                                writer.write("); err != nil {\nreturn err\n}");
+                            }
+                        });
+
+                        writer.write("return nil");
+                    });
+            writer.write("");
+        };
     }
 
     /**

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ServiceGenerator.java
@@ -765,6 +765,7 @@ final class ServiceGenerator implements Runnable {
                     () -> {
                         // Must be first — provides anchors that other middlewares Insert relative to.
                         writer.addUseImports(SmithyGoDependency.SMITHY_MIDDLEWARE);
+                        writer.addUseImports(SmithyGoDependency.FMT);
                         writer.write("""
                                 if err := stack.Serialize.Add(&setOperationInputMiddleware{}, middleware.After); err != nil {
                                     return err
@@ -773,7 +774,6 @@ final class ServiceGenerator implements Runnable {
                                 if err := addProtocolFinalizerMiddlewares(stack, options, operation); err != nil {
                                     return fmt.Errorf("add protocol finalizers: %v", err)
                                 }""");
-                        writer.addUseImports(SmithyGoDependency.FMT);
 
                         runtimePlugins.forEach(plugin -> {
                             if (!plugin.isCommon()) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ClientLogger.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/ClientLogger.java
@@ -87,6 +87,7 @@ public class ClientLogger implements GoIntegration {
                                 .resolvedFunction(SymbolUtils.createValueSymbolBuilder(REGISTER_MIDDLEWARE).build())
                                 .useClientOptions()
                                 .build())
+                        .isCommon(true)
                         .build()
         );
     }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/RuntimeClientPlugin.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/RuntimeClientPlugin.java
@@ -56,6 +56,7 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
     private final Map<String, Writable> endpointBuiltinBindings;
     private final Map<ShapeId, AuthSchemeDefinition> authSchemeDefinitions;
     private final Map<ShapeId, Symbol> shapeDeserializers;
+    private final boolean isCommon;
 
     private RuntimeClientPlugin(Builder builder) {
         operationPredicate = builder.operationPredicate;
@@ -70,6 +71,21 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         endpointBuiltinBindings = builder.endpointBuiltinBindings;
         authSchemeDefinitions = builder.authSchemeDefinitions;
         shapeDeserializers = builder.shapeDeserializers;
+        isCommon = builder.isCommon;
+    }
+
+    /**
+     * Returns whether this plugin's middleware should be registered once
+     * by the shared {@code addCommonMiddlewares} helper on the client,
+     * rather than per-operation in {@code addOperation*Middlewares}.
+     *
+     * <p>Plugins whose middleware registration is identical for every
+     * operation in the service can opt-in via {@link Builder#isCommon(boolean)}.
+     *
+     * @return true if this plugin is registered via {@code addCommonMiddlewares}.
+     */
+    public boolean isCommon() {
+        return isCommon;
     }
 
     @FunctionalInterface
@@ -254,10 +270,29 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         private MiddlewareRegistrar registerMiddleware;
         private Map<ShapeId, AuthSchemeDefinition> authSchemeDefinitions = new HashMap<>();
         private Map<ShapeId, Symbol> shapeDeserializers = new HashMap<>();
+        private boolean isCommon = false;
 
         @Override
         public RuntimeClientPlugin build() {
             return new RuntimeClientPlugin(this);
+        }
+
+        /**
+         * Marks the plugin as a "common" middleware whose registration is
+         * identical for every operation in the service. Common plugins are
+         * emitted once into the client's {@code addCommonMiddlewares} helper
+         * (called from {@code invokeOperation}) instead of being repeated in
+         * every {@code addOperation*Middlewares} function.
+         *
+         * <p>Defaults to {@code false} to preserve existing per-operation
+         * behavior for plugins that have not been audited.
+         *
+         * @param isCommon whether the plugin is common across all operations.
+         * @return Returns the builder.
+         */
+        public Builder isCommon(boolean isCommon) {
+            this.isCommon = isCommon;
+            return this;
         }
 
         /**

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/RuntimeClientPlugin.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/RuntimeClientPlugin.java
@@ -75,14 +75,9 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
     }
 
     /**
-     * Returns whether this plugin's middleware should be registered once
-     * by the shared {@code addCommonMiddlewares} helper on the client,
-     * rather than per-operation in {@code addOperation*Middlewares}.
-     *
-     * <p>Plugins whose middleware registration is identical for every
-     * operation in the service can opt-in via {@link Builder#isCommon(boolean)}.
-     *
-     * @return true if this plugin is registered via {@code addCommonMiddlewares}.
+     * Gets whether this plugin is registered once via {@code addCommonMiddlewares}
+     * rather than per-operation.
+     * @return true if this plugin is common across all operations.
      */
     public boolean isCommon() {
         return isCommon;
@@ -278,14 +273,9 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         }
 
         /**
-         * Marks the plugin as a "common" middleware whose registration is
-         * identical for every operation in the service. Common plugins are
-         * emitted once into the client's {@code addCommonMiddlewares} helper
-         * (called from {@code invokeOperation}) instead of being repeated in
-         * every {@code addOperation*Middlewares} function.
-         *
-         * <p>Defaults to {@code false} to preserve existing per-operation
-         * behavior for plugins that have not been audited.
+         * Marks the plugin as common, so its middleware is emitted once into
+         * {@code addCommonMiddlewares} instead of every operation. Defaults to
+         * false.
          *
          * @param isCommon whether the plugin is common across all operations.
          * @return Returns the builder.


### PR DESCRIPTION
Issue: aws/aws-sdk-go-v2#3321

Move common middlewares (those identical across every operation) into a shared `addCommonMiddlewares` method on Client, called from `invokeOperation`. Per-operation `addOperation*Middlewares` functions now only register what is truly unique(serializer, deserializer, predicate-scoped customizations).

Results in ~47% reduction in per-operation function compiled size. SQS benchmark: ~2,550 bytes saved per operation, ~57 KB net savings across 23 operations.

Companion PR in aws-sdk-go-v2 will bump SMITHY_GO_CODEGEN_VERSION and mark additional AWS-specific plugins as common.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
