### PR TITLE
add prefix/suffix hyphen rejection for host label validation based on rfc1123

### DIFF
--- a/endpoints/private/rulesfn/uri.go
+++ b/endpoints/private/rulesfn/uri.go
@@ -27,6 +27,9 @@ func IsValidHostLabel(input string, allowSubDomains bool) bool {
 		if !smithyhttp.ValidHostLabel(label) {
 			return false
 		}
+		if label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
 	}
 
 	return true

--- a/endpoints/private/rulesfn/uri_test.go
+++ b/endpoints/private/rulesfn/uri_test.go
@@ -159,22 +159,36 @@ func TestIsValidHostLabel(t *testing.T) {
 		expect          bool
 	}{
 		"single label no split": {
-			input:  "abc123-",
+			input:  "abc123",
 			expect: true,
 		},
+		"single label no split with invalid suffix hyphen": {
+			input:  "abc123-",
+			expect: false,
+		},
 		"single label with split": {
-			input:           "abc123-",
+			input:           "abc123",
 			allowSubDomains: true,
 			expect:          true,
+		},
+		"single label with split and invalid suffix hyphen": {
+			input:           "abc123-",
+			allowSubDomains: true,
+			expect:          false,
 		},
 		"multiple labels no split": {
 			input:  "abc.123-",
 			expect: false,
 		},
 		"multiple labels with split": {
-			input:           "abc.123-",
+			input:           "abc.123",
 			allowSubDomains: true,
 			expect:          true,
+		},
+		"multiple labels with split and invalid prefix hyphen": {
+			input:           "abc.-123",
+			allowSubDomains: true,
+			expect:          false,
 		},
 		"multiple labels with split invalid label": {
 			input:           "abc.123-...",
@@ -187,6 +201,10 @@ func TestIsValidHostLabel(t *testing.T) {
 		},
 		"too large host label": {
 			input:  "0123456789012345678901234567890123456789012345678901234567891234",
+			expect: false,
+		},
+		"multiple labels with too large segment": {
+			input:  "abc.0123456789012345678901234567890123456789012345678901234567891234",
 			expect: false,
 		},
 		"too small host label": {

--- a/transport/http/host.go
+++ b/transport/http/host.go
@@ -69,7 +69,7 @@ func ValidPortNumber(port string) bool {
 	return true
 }
 
-// ValidHostLabel returns whether the label is a valid RFC 3986 host label.
+// ValidHostLabel returns whether the label is a valid RFC 952/1123 host label.
 func ValidHostLabel(label string) bool {
 	if l := len(label); l == 0 || l > 63 {
 		return false


### PR DESCRIPTION
Currently `IsValidHostLabel` in endpoint rulesfn aligns with [rfc1123](https://datatracker.ietf.org/doc/html/rfc1123#section-2) to check a host label: 

- contains 1-63 chars
- only has alpha/numeric chars and hyphen 

But rfc1123 and superior [952](https://datatracker.ietf.org/doc/html/rfc952) require the first/last char to only be alpha/numeric, and our old validation ignores hyphen rejection for that. This pr just adds that check for endpoint level host label validation without changing bottom http check 

Test: run `go run ./internal/repotools/cmd/eachmodule -p . "go test ./... -run TestEndpointCase"` under go v2 to make sure each service's endpoint test cases pass
