### PR TITLE
Fix document.Number serialization and BigDecimal negative zero sign loss

### DIFF
--- a/document/json/encoder.go
+++ b/document/json/encoder.go
@@ -232,6 +232,7 @@ func (e *Encoder) encodeScalar(vp valueProvider, rv reflect.Value) error {
 			return &document.InvalidMarshalError{Message: fmt.Sprintf("invalid number literal: %s", number)}
 		}
 		vp.GetValue().Write([]byte(number))
+		return nil
 	}
 
 	switch rv.Kind() {

--- a/document/json/encoder_test.go
+++ b/document/json/encoder_test.go
@@ -93,6 +93,44 @@ func TestDeterministicMapOrder(t *testing.T) {
 	}
 }
 
+func TestDocumentNumberEncodesAsNumber(t *testing.T) {
+	encoder := json.NewEncoder()
+
+	cases := map[string]struct {
+		input    interface{}
+		expected string
+	}{
+		"integer": {
+			input:    map[string]interface{}{"x": document.Number("42")},
+			expected: `{"x":42}`,
+		},
+		"float": {
+			input:    map[string]interface{}{"x": document.Number("42.0")},
+			expected: `{"x":42.0}`,
+		},
+		"negative zero": {
+			input:    map[string]interface{}{"x": document.Number("-0.0")},
+			expected: `{"x":-0.0}`,
+		},
+		"scientific notation": {
+			input:    map[string]interface{}{"x": document.Number("1.5e+10")},
+			expected: `{"x":1.5e+10}`,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			b, err := encoder.Encode(tc.input)
+			if err != nil {
+				t.Fatalf("Encode() error: %v", err)
+			}
+			if string(b) != tc.expected {
+				t.Errorf("Encode() = %s, want %s", b, tc.expected)
+			}
+		})
+	}
+}
+
 func testEncode(t *testing.T, tt testCase) {
 	t.Helper()
 

--- a/encoding/json/value.go
+++ b/encoding/json/value.go
@@ -106,6 +106,11 @@ func (jv Value) BigInteger(v *big.Int) {
 
 // BigDecimal encodes v as JSON value
 func (jv Value) BigDecimal(v *big.Float) {
+	if v.Sign() == 0 && v.Signbit() {
+		// Preserve negative zero sign which Int64() would lose.
+		jv.w.Write([]byte("-0"))
+		return
+	}
 	if i, accuracy := v.Int64(); accuracy == big.Exact {
 		jv.Long(i)
 		return

--- a/encoding/json/value_test.go
+++ b/encoding/json/value_test.go
@@ -138,6 +138,26 @@ func TestValue(t *testing.T) {
 			},
 			expected: "9223372036854775807",
 		},
+		"bigFloat negative zero preserves sign": {
+			setter: func(value Value) {
+				v := new(big.Float).SetFloat64(math.Copysign(0, -1))
+				value.BigDecimal(v)
+			},
+			expected: "-0",
+		},
+		"bigFloat negative integer": {
+			setter: func(value Value) {
+				v := new(big.Float).SetFloat64(-7)
+				value.BigDecimal(v)
+			},
+			expected: "-7",
+		},
+		"bigFloat positive zero": {
+			setter: func(value Value) {
+				value.BigDecimal(new(big.Float))
+			},
+			expected: "0",
+		},
 	}
 	scratch := make([]byte, 64)
 


### PR DESCRIPTION
This PR fixes two bugs in the JSON document encoder.

### document.Number produces invalid JSON (duplicate keys)

`encodeScalar` was missing a `return` after writing a `document.Number` value. Because `document.Number` is defined as `type Number string`, execution fell through to the `reflect.String` case, causing the same key to be written twice — once as a raw number and once as a quoted string:

```json
   {"x":42.0,"x":"42.0"}
```
Fix: Add return nil after writing the number. Resolves #596.

### BigDecimal loses the sign of negative zero

BigDecimal short-circuits to Long() when v.Int64() returns Exact. For negative zero, Int64() returns `(0, Exact)`, discarding the sign. The value `-0` is a valid JSON number and must be preserved.

Fix: Add a guard that checks for negative zero before the Int64 path.

## Testing

   - Added TestDocumentNumberEncodesAsNumber covering integer, float, negative zero, and scientific notation literals.
   - Added TestValue/bigFloat_negative_zero_preserves_sign and TestValue/bigFloat_negative_integer to the existing value encoder test table.
   - All existing tests pass without modification.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
