### PR TITLE
feat: close response body in operation deserializer instead of a standalone middleware

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java
@@ -390,10 +390,24 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         String errorFunctionName = ProtocolGenerator.getOperationErrorDeserFunctionName(
                 operation, service, context.getProtocolName());
 
+        // Close body on success unless the response carries a caller-owned stream
+        // (a streaming payload like S3 GetObject, or an event stream output).
+        boolean closeOnSuccess = !hasStreamingResponse(model, operation);
+
         middleware.writeMiddleware(goWriter, (generator, writer) -> {
             writer.addUseImports(SmithyGoDependency.FMT);
+            writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_TRANSPORT);
 
             writer.write("out, metadata, err = next.$L(ctx, in)", generator.getHandleMethodName());
+            writer.write("");
+
+            // Close the body on every exit path in place of the standalone close middleware.
+            writer.write("response, _ := out.RawResponse.($P)", responseType);
+            writer.write("defer $T(ctx, response, $L, err)",
+                    SmithyGoDependency.SMITHY_HTTP_TRANSPORT.func("DrainAndCloseResponseBody"),
+                    closeOnSuccess ? "true" : "false");
+            writer.write("");
+
             writer.write("if err != nil { return out, metadata, err }");
             writer.write("");
 
@@ -404,8 +418,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                     defer span.End()
                     """, SMITHY_TRACING.func("StartSpan")));
 
-            writer.write("response, ok := out.RawResponse.($P)", responseType);
-            writer.openBlock("if !ok {", "}", () -> {
+            writer.openBlock("if response == nil {", "}", () -> {
                 writer.addUseImports(SmithyGoDependency.SMITHY);
                 writer.write(String.format("return out, metadata, &smithy.DeserializationError{Err: %s}",
                         "fmt.Errorf(\"unknown transport type %T\", out.RawResponse)"));
@@ -484,6 +497,20 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 this::getOperationErrors);
         deserializingErrorShapes.addAll(errorShapes);
         deserializeDocumentBindingShapes.addAll(errorShapes);
+    }
+
+    // True when the operation's successful response body is a caller-owned stream:
+    // a streaming payload (e.g. S3 GetObject) or an event stream output.
+    private static boolean hasStreamingResponse(Model model, OperationShape operation) {
+        if (!EventStreamIndex.of(model).getOutputInfo(operation).isEmpty()) {
+            return true;
+        }
+        HttpBindingIndex bindingIndex = HttpBindingIndex.of(model);
+        return bindingIndex.getResponseBindings(operation, HttpBinding.Location.PAYLOAD).stream()
+                .findFirst()
+                .map(binding -> model.expectShape(binding.getMember().getTarget())
+                        .hasTrait(StreamingTrait.class))
+                .orElse(false);
     }
 
     /**

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpRpcProtocolGenerator.java
@@ -334,11 +334,24 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
                 ProtocolGenerator.getDeserializeMiddlewareName(operation.getId(), service, getProtocolName()),
                 ProtocolUtils.OPERATION_DESERIALIZER_MIDDLEWARE_ID);
 
+        // Close body on success unless the output is a caller-owned event stream.
+        boolean closeOnSuccess = EventStreamIndex.of(model).getOutputInfo(operation).isEmpty();
+
         middleware.writeMiddleware(writer, (generator, w) -> {
             writer.addUseImports(SmithyGoDependency.FMT);
             writer.addUseImports(SmithyGoDependency.SMITHY);
+            writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_TRANSPORT);
 
             writer.write("out, metadata, err = next.$L(ctx, in)", generator.getHandleMethodName());
+            writer.write("");
+
+            // Close the body on every exit path in place of the standalone close middleware.
+            writer.write("response, _ := out.RawResponse.($P)", responseType);
+            writer.write("defer $T(ctx, response, $L, err)",
+                    SmithyGoDependency.SMITHY_HTTP_TRANSPORT.func("DrainAndCloseResponseBody"),
+                    closeOnSuccess ? "true" : "false");
+            writer.write("");
+
             writer.write("if err != nil { return out, metadata, err }");
             writer.write("");
 
@@ -349,8 +362,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
                     defer span.End()
                     """, SMITHY_TRACING.func("StartSpan")));
 
-            writer.write("response, ok := out.RawResponse.($P)", responseType);
-            writer.openBlock("if !ok {", "}", () -> {
+            writer.openBlock("if response == nil {", "}", () -> {
                 writer.write(String.format("return out, metadata, &smithy.DeserializationError{Err: %s}",
                         "fmt.Errorf(\"unknown transport type %T\", out.RawResponse)"));
             });

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/DeserializeResponseMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/protocol/DeserializeResponseMiddleware.java
@@ -23,9 +23,11 @@ import static software.amazon.smithy.go.codegen.integration.ProtocolGenerator.ge
 
 import software.amazon.smithy.go.codegen.GoStdlibTypes;
 import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.go.codegen.Writable;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.go.codegen.integration.ProtocolUtils;
+import software.amazon.smithy.model.knowledge.EventStreamIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.utils.MapUtils;
@@ -62,8 +64,14 @@ public abstract class DeserializeResponseMiddleware implements Writable {
     public abstract Writable generateDeserialize();
 
     private Writable generateHandleDeserialize() {
+        // Close body on success unless the output is a caller-owned event stream.
+        boolean closeOnSuccess = EventStreamIndex.of(ctx.getModel()).getOutputInfo(operation).isEmpty();
         return goTemplate("""
                 out, metadata, err = next.HandleDeserialize(ctx, in)
+
+                // Close the body on every exit path in place of the standalone close middleware.
+                resp, _ := out.RawResponse.($response:P)
+                defer $drainClose:T(ctx, resp, $closeOnSuccess:L, err)
 
                 _, span := $startSpan:T(ctx, "OperationDeserializer")
                 endTimer := startMetricTimer(ctx, "client.call.deserialization_duration")
@@ -74,8 +82,7 @@ public abstract class DeserializeResponseMiddleware implements Writable {
                     return out, metadata, err
                 }
 
-                resp, ok := out.RawResponse.($response:P)
-                if !ok {
+                if resp == nil {
                     return out, metadata, $errorf:T("unexpected transport type %T", out.RawResponse)
                 }
 
@@ -87,7 +94,9 @@ public abstract class DeserializeResponseMiddleware implements Writable {
                         "startSpan", SMITHY_TRACING.func("StartSpan"),
                         "response", generator.getApplicationProtocol().getResponseType(),
                         "deserialize", generateDeserialize(),
-                        "errorf", GoStdlibTypes.Fmt.Errorf
+                        "errorf", GoStdlibTypes.Fmt.Errorf,
+                        "drainClose", SmithyGoDependency.SMITHY_HTTP_TRANSPORT.func("DrainAndCloseResponseBody"),
+                        "closeOnSuccess", closeOnSuccess ? "true" : "false"
                 ));
     }
 }

--- a/transport/http/middleware_close_response_body.go
+++ b/transport/http/middleware_close_response_body.go
@@ -8,6 +8,34 @@ import (
 	"github.com/aws/smithy-go/middleware"
 )
 
+// DrainAndCloseResponseBody drains and closes the HTTP response body. It always
+// closes on error; on success it closes only when closeOnSuccess is true (pass
+// false when the response is a streaming payload owned by the caller).
+func DrainAndCloseResponseBody(ctx context.Context, resp *Response, closeOnSuccess bool, opErr error) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+
+	if opErr != nil {
+		// Consume the full body to prevent TCP connection resets on some platforms.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		// Do not validate that the response closes successfully on the error path.
+		resp.Body.Close()
+		return
+	}
+
+	if !closeOnSuccess {
+		return
+	}
+
+	if _, copyErr := io.Copy(io.Discard, resp.Body); copyErr != nil {
+		middleware.GetLogger(ctx).Logf(logging.Warn, "failed to discard remaining HTTP response body, this may affect connection reuse")
+	}
+	if closeErr := resp.Body.Close(); closeErr != nil {
+		middleware.GetLogger(ctx).Logf(logging.Warn, "failed to close HTTP response body, this may affect connection reuse")
+	}
+}
+
 // AddErrorCloseResponseBodyMiddleware adds the middleware to automatically
 // close the response body of an operation request if the request response
 // failed.


### PR DESCRIPTION
Add DrainAndCloseResponseBody and emit a deferred call to it from the generated operation deserializer (HttpRpc, HttpBinding, and protocol/serde2 rpc2 paths), removing the need for a standalone close-response-body middleware on the stack.

closeOnSuccess is decided at codegen time: false for caller-owned streams (streaming payloads and event-stream outputs), true otherwise. The existing Add*CloseResponseBodyMiddleware functions are retained for backwards compatibility.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
