### PR TITLE
support sigv4[a] and non-rule endpoint resolution in generic clients

### DIFF
--- a/aws-http-auth-schemes/go.mod
+++ b/aws-http-auth-schemes/go.mod
@@ -1,0 +1,12 @@
+module github.com/aws/smithy-go/aws-http-auth-schemes
+
+go 1.24
+
+require (
+	github.com/aws/smithy-go v1.27.3
+	github.com/aws/smithy-go/aws-http-auth v1.2.0
+)
+
+replace github.com/aws/smithy-go => ..
+
+replace github.com/aws/smithy-go/aws-http-auth => ../aws-http-auth

--- a/aws-http-auth-schemes/identity/identity.go
+++ b/aws-http-auth-schemes/identity/identity.go
@@ -1,0 +1,81 @@
+// Package identity provides the AWS credential identity types shared by the
+// generic smithy-go AWS auth schemes (SigV4, SigV4A).
+package identity
+
+import (
+	"context"
+	"time"
+
+	smithy "github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/auth"
+	"github.com/aws/smithy-go/aws-http-auth/credentials"
+)
+
+// AWSCredentialIdentity is the [auth.Identity] carrying AWS credentials
+// through the auth pipeline.
+type AWSCredentialIdentity struct {
+	credentials.Credentials
+}
+
+var _ auth.Identity = (*AWSCredentialIdentity)(nil)
+
+// Expiration returns when the underlying credentials expire.
+func (i *AWSCredentialIdentity) Expiration() time.Time {
+	return i.Expires
+}
+
+// AWSCredentialIdentityResolver resolves an [AWSCredentialIdentity].
+//
+// This is the concrete, credential-flavored counterpart to [auth.IdentityResolver]
+// for the SigV4/SigV4A auth schemes. Implementations resolve AWS credentials
+// (static, environment, assumed-role, etc.) and return them boxed as an
+// [AWSCredentialIdentity].
+type AWSCredentialIdentityResolver interface {
+	GetIdentity(context.Context, smithy.Properties) (*AWSCredentialIdentity, error)
+}
+
+// staticAWSCredentialIdentityResolver resolves a fixed, unchanging
+// [AWSCredentialIdentity].
+type staticAWSCredentialIdentityResolver struct {
+	identity AWSCredentialIdentity
+}
+
+var _ AWSCredentialIdentityResolver = (*staticAWSCredentialIdentityResolver)(nil)
+
+// GetIdentity implements [AWSCredentialIdentityResolver].
+func (r *staticAWSCredentialIdentityResolver) GetIdentity(context.Context, smithy.Properties) (*AWSCredentialIdentity, error) {
+	return &r.identity, nil
+}
+
+// NewStaticAWSCredentialIdentityResolver returns an [AWSCredentialIdentityResolver]
+// that always resolves to the given, unchanging AWS credentials.
+func NewStaticAWSCredentialIdentityResolver(accessKeyID, secretAccessKey, sessionToken string) AWSCredentialIdentityResolver {
+	return &staticAWSCredentialIdentityResolver{
+		identity: AWSCredentialIdentity{
+			Credentials: credentials.Credentials{
+				AccessKeyID:     accessKeyID,
+				SecretAccessKey: secretAccessKey,
+				SessionToken:    sessionToken,
+			},
+		},
+	}
+}
+
+// identityResolverAdapter adapts an [AWSCredentialIdentityResolver] to the
+// pipeline's opaque [auth.IdentityResolver] interface.
+type identityResolverAdapter struct {
+	Resolver AWSCredentialIdentityResolver
+}
+
+var _ auth.IdentityResolver = (*identityResolverAdapter)(nil)
+
+// GetIdentity implements [auth.IdentityResolver].
+func (a *identityResolverAdapter) GetIdentity(ctx context.Context, props smithy.Properties) (auth.Identity, error) {
+	return a.Resolver.GetIdentity(ctx, props)
+}
+
+// NewIdentityResolver adapts an [AWSCredentialIdentityResolver] to the
+// pipeline's opaque [auth.IdentityResolver] interface.
+func NewIdentityResolver(resolver AWSCredentialIdentityResolver) auth.IdentityResolver {
+	return &identityResolverAdapter{Resolver: resolver}
+}

--- a/aws-http-auth-schemes/internal/payloadhash/payloadhash.go
+++ b/aws-http-auth-schemes/internal/payloadhash/payloadhash.go
@@ -1,0 +1,45 @@
+// Package payloadhash provides the shared payload hashing logic used by the
+// generic smithy-go AWS auth scheme signers (SigV4, SigV4A).
+package payloadhash
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+
+	smithy "github.com/aws/smithy-go"
+	v4 "github.com/aws/smithy-go/aws-http-auth/v4"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+// Hash returns the SHA256 hash of the request payload, or the SigV4/SigV4A
+// unsigned-payload sentinel if the payload is not signed.
+//
+// The aws-http-auth signers support implicit payload hashing, but in the
+// client pipeline the body is carried on the separate Stream field, so it has
+// to be hashed here instead.
+func Hash(r *smithyhttp.Request, props *smithy.Properties) ([]byte, error) {
+	if unsigned, _ := smithyhttp.GetIsUnsignedPayload(props); unsigned {
+		return v4.UnsignedPayload(), nil
+	}
+
+	stream := r.GetStream()
+	if stream == nil {
+		sum := sha256.Sum256(nil)
+		return sum[:], nil
+	}
+
+	if !r.IsStreamSeekable() {
+		return v4.UnsignedPayload(), nil
+	}
+
+	h := sha256.New()
+	if _, err := io.Copy(h, stream); err != nil {
+		return nil, fmt.Errorf("hash payload: %w", err)
+	}
+	if err := r.RewindStream(); err != nil {
+		return nil, fmt.Errorf("rewind payload: %w", err)
+	}
+
+	return h.Sum(nil), nil
+}

--- a/aws-http-auth-schemes/internal/payloadhash/payloadhash_test.go
+++ b/aws-http-auth-schemes/internal/payloadhash/payloadhash_test.go
@@ -1,0 +1,69 @@
+package payloadhash
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"testing"
+
+	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+// emptyStringSHA256 is the well-known SHA256 of an empty payload that services compute for
+// bodyless requests (e.g. GET). Sending UNSIGNED-PAYLOAD instead causes InvalidSignatureException.
+const emptyStringSHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+func TestHashEmptyBody(t *testing.T) {
+	r := smithyhttp.NewStackRequest().(*smithyhttp.Request)
+
+	got, err := Hash(r, &smithy.Properties{})
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	if hex.EncodeToString(got) != emptyStringSHA256 {
+		t.Fatalf("empty-body hash = %s, want %s", hex.EncodeToString(got), emptyStringSHA256)
+	}
+}
+
+func TestHashSeekableBody(t *testing.T) {
+	body := []byte(`{"name":"foo"}`)
+	r := smithyhttp.NewStackRequest().(*smithyhttp.Request)
+	r, err := r.SetStream(bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("SetStream: %v", err)
+	}
+
+	got, err := Hash(r, &smithy.Properties{})
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	want := sha256.Sum256(body)
+	if !bytes.Equal(got, want[:]) {
+		t.Fatalf("body hash = %x, want %x", got, want)
+	}
+
+	// stream must be rewound so the body can still be sent
+	rest, err := io.ReadAll(r.GetStream())
+	if err != nil {
+		t.Fatalf("read stream after hashing: %v", err)
+	}
+	if !bytes.Equal(rest, body) {
+		t.Fatalf("stream not rewound: got %q, want %q", rest, body)
+	}
+}
+
+func TestHashUnsignedOverride(t *testing.T) {
+	r := smithyhttp.NewStackRequest().(*smithyhttp.Request)
+	var props smithy.Properties
+	smithyhttp.SetIsUnsignedPayload(&props, true)
+
+	got, err := Hash(r, &props)
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	if string(got) != "UNSIGNED-PAYLOAD" {
+		t.Fatalf("unsigned override = %q, want UNSIGNED-PAYLOAD", got)
+	}
+}

--- a/aws-http-auth-schemes/sigv4/auth_scheme.go
+++ b/aws-http-auth-schemes/sigv4/auth_scheme.go
@@ -1,0 +1,35 @@
+package sigv4
+
+import (
+	"github.com/aws/smithy-go/auth"
+	v4 "github.com/aws/smithy-go/aws-http-auth/v4"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+// AuthScheme implements request signing for aws.auth#sigv4.
+type AuthScheme struct {
+	signer *signer
+}
+
+var _ smithyhttp.AuthScheme = (*AuthScheme)(nil)
+
+// NewAuthScheme returns a SigV4 [AuthScheme] backed by a default signer
+// configured with the given options.
+func NewAuthScheme(opts ...v4.SignerOption) *AuthScheme {
+	return &AuthScheme{signer: newSigner(opts...)}
+}
+
+// SchemeID implements [smithyhttp.AuthScheme].
+func (s *AuthScheme) SchemeID() string {
+	return auth.SchemeIDSigV4
+}
+
+// IdentityResolver implements [smithyhttp.AuthScheme].
+func (s *AuthScheme) IdentityResolver(o auth.IdentityResolverOptions) auth.IdentityResolver {
+	return o.GetIdentityResolver(s.SchemeID())
+}
+
+// Signer implements [smithyhttp.AuthScheme].
+func (s *AuthScheme) Signer() smithyhttp.Signer {
+	return s.signer
+}

--- a/aws-http-auth-schemes/sigv4/signer.go
+++ b/aws-http-auth-schemes/sigv4/signer.go
@@ -1,0 +1,68 @@
+package sigv4
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/auth"
+	awssigv4 "github.com/aws/smithy-go/aws-http-auth/sigv4"
+	v4 "github.com/aws/smithy-go/aws-http-auth/v4"
+	"github.com/aws/smithy-go/aws-http-auth-schemes/identity"
+	"github.com/aws/smithy-go/aws-http-auth-schemes/internal/payloadhash"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+// signer adapts the standalone [awssigv4.Signer] to the client-side
+// [smithyhttp.Signer] interface, sourcing the signing name and region from the
+// request's resolved auth properties.
+type signer struct {
+	Signer *awssigv4.Signer
+}
+
+var _ smithyhttp.Signer = (*signer)(nil)
+
+// newSigner returns a signer backed by a default SigV4 signer configured
+// with the given options.
+func newSigner(opts ...v4.SignerOption) *signer {
+	return &signer{Signer: awssigv4.New(opts...)}
+}
+
+// SignRequest implements [smithyhttp.Signer].
+func (a *signer) SignRequest(
+	ctx context.Context, r *smithyhttp.Request, ident auth.Identity, props smithy.Properties,
+) error {
+	ci, ok := ident.(*identity.AWSCredentialIdentity)
+	if !ok {
+		return fmt.Errorf("sigv4: unexpected identity type %T", ident)
+	}
+
+	name, ok := smithyhttp.GetSigV4SigningName(&props)
+	if !ok {
+		return fmt.Errorf("sigv4: signing name is required")
+	}
+
+	region, ok := smithyhttp.GetSigV4SigningRegion(&props)
+	if !ok {
+		return fmt.Errorf("sigv4: signing region is required")
+	}
+
+	hash, err := payloadhash.Hash(r, &props)
+	if err != nil {
+		return fmt.Errorf("sigv4: %w", err)
+	}
+
+	in := &awssigv4.SignRequestInput{
+		Request:     r.Request,
+		Credentials: ci.Credentials,
+		Service:     name,
+		Region:      region,
+		PayloadHash: hash,
+	}
+
+	if err := a.Signer.SignRequest(in); err != nil {
+		return fmt.Errorf("sigv4: sign request: %w", err)
+	}
+
+	return nil
+}

--- a/aws-http-auth-schemes/sigv4a/auth_scheme.go
+++ b/aws-http-auth-schemes/sigv4a/auth_scheme.go
@@ -1,0 +1,35 @@
+package sigv4a
+
+import (
+	"github.com/aws/smithy-go/auth"
+	v4 "github.com/aws/smithy-go/aws-http-auth/v4"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+// AuthScheme implements request signing for aws.auth#sigv4a.
+type AuthScheme struct {
+	signer *signer
+}
+
+var _ smithyhttp.AuthScheme = (*AuthScheme)(nil)
+
+// NewAuthScheme returns a SigV4A [AuthScheme] backed by a default signer
+// configured with the given options.
+func NewAuthScheme(opts ...v4.SignerOption) *AuthScheme {
+	return &AuthScheme{signer: newSigner(opts...)}
+}
+
+// SchemeID implements [smithyhttp.AuthScheme].
+func (s *AuthScheme) SchemeID() string {
+	return auth.SchemeIDSigV4A
+}
+
+// IdentityResolver implements [smithyhttp.AuthScheme].
+func (s *AuthScheme) IdentityResolver(o auth.IdentityResolverOptions) auth.IdentityResolver {
+	return o.GetIdentityResolver(s.SchemeID())
+}
+
+// Signer implements [smithyhttp.AuthScheme].
+func (s *AuthScheme) Signer() smithyhttp.Signer {
+	return s.signer
+}

--- a/aws-http-auth-schemes/sigv4a/doc.go
+++ b/aws-http-auth-schemes/sigv4a/doc.go
@@ -1,0 +1,12 @@
+// Package sigv4a provides the generic smithy-go client wiring for AWS
+// Signature Version 4a (asymmetric) request signing.
+//
+// It adapts the standalone signer in
+// [github.com/aws/smithy-go/aws-http-auth/sigv4a] to the client auth scheme
+// interfaces in [github.com/aws/smithy-go/transport/http], allowing non-SDK
+// smithy-go clients to sign requests with SigV4A without depending on the AWS
+// SDK for Go. It is a sibling package to
+// [github.com/aws/smithy-go/aws-http-auth-schemes/sigv4] within the same
+// module, so that the core smithy-go runtime does not take on an
+// AWS-specific dependency.
+package sigv4a

--- a/aws-http-auth-schemes/sigv4a/signer.go
+++ b/aws-http-auth-schemes/sigv4a/signer.go
@@ -1,0 +1,68 @@
+package sigv4a
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/auth"
+	awssigv4a "github.com/aws/smithy-go/aws-http-auth/sigv4a"
+	v4 "github.com/aws/smithy-go/aws-http-auth/v4"
+	"github.com/aws/smithy-go/aws-http-auth-schemes/identity"
+	"github.com/aws/smithy-go/aws-http-auth-schemes/internal/payloadhash"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+// signer adapts the standalone [awssigv4a.Signer] to the client-side
+// [smithyhttp.Signer] interface, sourcing the signing name and region set from
+// the request's resolved auth properties.
+type signer struct {
+	Signer *awssigv4a.Signer
+}
+
+var _ smithyhttp.Signer = (*signer)(nil)
+
+// newSigner returns a signer backed by a default SigV4A signer configured
+// with the given options.
+func newSigner(opts ...v4.SignerOption) *signer {
+	return &signer{Signer: awssigv4a.New(opts...)}
+}
+
+// SignRequest implements [smithyhttp.Signer].
+func (a *signer) SignRequest(
+	ctx context.Context, r *smithyhttp.Request, ident auth.Identity, props smithy.Properties,
+) error {
+	ci, ok := ident.(*identity.AWSCredentialIdentity)
+	if !ok {
+		return fmt.Errorf("sigv4a: unexpected identity type %T", ident)
+	}
+
+	name, ok := smithyhttp.GetSigV4ASigningName(&props)
+	if !ok {
+		return fmt.Errorf("sigv4a: signing name is required")
+	}
+
+	regions, ok := smithyhttp.GetSigV4ASigningRegions(&props)
+	if !ok {
+		return fmt.Errorf("sigv4a: signing region set is required")
+	}
+
+	hash, err := payloadhash.Hash(r, &props)
+	if err != nil {
+		return fmt.Errorf("sigv4a: %w", err)
+	}
+
+	in := &awssigv4a.SignRequestInput{
+		Request:     r.Request,
+		Credentials: ci.Credentials,
+		Service:     name,
+		RegionSet:   regions,
+		PayloadHash: hash,
+	}
+
+	if err := a.Signer.SignRequest(in); err != nil {
+		return fmt.Errorf("sigv4a: sign request: %w", err)
+	}
+
+	return nil
+}

--- a/aws-http-auth/internal/v4/signer.go
+++ b/aws-http-auth/internal/v4/signer.go
@@ -122,7 +122,15 @@ func (s *Signer) resolvePayloadHash() error {
 func (s *Signer) setRequiredHeaders() {
 	headers := s.Request.Header
 
-	s.Request.Header.Set("Host", s.Request.Host)
+	// Host optionally overrides the Host header; when empty, net/http sends URL.Host on the
+	// wire, so that is what must be signed. Signing s.Request.Host directly would sign an
+	// empty host for a request that only has URL.Host set (e.g. one not built via
+	// http.NewRequest), producing a signature mismatch.
+	host := s.Request.Host
+	if host == "" {
+		host = s.Request.URL.Host
+	}
+	s.Request.Header.Set("Host", host)
 
 	// X-Amz-Date and X-Amz-Security-Token are only set as headers when using a header signature type
 	if s.SignatureType == v4.SignatureTypeHeader {

--- a/aws-http-auth/sigv4/host_test.go
+++ b/aws-http-auth/sigv4/host_test.go
@@ -1,0 +1,43 @@
+package sigv4
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/aws/smithy-go/aws-http-auth/credentials"
+)
+
+// A request built outside http.NewRequest (as in the smithy-go pipeline) has URL.Host set
+// but Request.Host empty. net/http sends URL.Host on the wire, so the signature must be over
+// URL.Host, not an empty host.
+func TestSignRequestHostFromURLWhenHostEmpty(t *testing.T) {
+	u, err := url.Parse("https://api.example.com/v2/events/abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    u,
+		Header: http.Header{},
+		// Host intentionally left empty.
+	}
+
+	s := New()
+	if err := s.SignRequest(&SignRequestInput{
+		Request:     req,
+		Credentials: credentials.Credentials{AccessKeyID: "AKIDEXAMPLE", SecretAccessKey: "SECRET"},
+		Service:     "execute-api",
+		Region:      "us-east-1",
+	}); err != nil {
+		t.Fatalf("SignRequest: %v", err)
+	}
+
+	if got := req.Header.Get("Host"); got != "api.example.com" {
+		t.Fatalf("signed Host header = %q, want api.example.com", got)
+	}
+	if auth := req.Header.Get("Authorization"); !strings.Contains(auth, "SignedHeaders=host;") {
+		t.Fatalf("expected host in SignedHeaders, got %q", auth)
+	}
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -38,6 +38,7 @@ import software.amazon.smithy.go.codegen.endpoints.EndpointResolutionGenerator;
 import software.amazon.smithy.go.codegen.endpoints.FnGenerator;
 import software.amazon.smithy.go.codegen.endpoints.FnProvider;
 import software.amazon.smithy.go.codegen.integration.GoIntegration;
+import software.amazon.smithy.go.codegen.integration.GoIntegrationResolver;
 import software.amazon.smithy.go.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.go.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.go.codegen.serde2.ListDeserializer;
@@ -108,6 +109,12 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
                     }
                 });
         integrations.sort(Comparator.comparingInt(GoIntegration::getOrder));
+
+        var resolved = GoIntegrationResolver.resolveReplacements(integrations);
+        if (resolved != integrations) {
+            integrations.clear();
+            integrations.addAll(resolved);
+        }
 
         settings = GoSettings.from(context.getSettings());
         fileManifest = context.getFileManifest();

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/OperationGenerator.java
@@ -271,12 +271,15 @@ public final class OperationGenerator implements Runnable {
      * Generate operation protocol middleware helper.
      */
     private void generateOperationProtocolMiddlewareAdders() {
-        if (protocolGenerator == null) {
-            return;
-        }
         writer.addUseImports(SmithyGoDependency.SMITHY_MIDDLEWARE);
 
         if (ctx.settings().useLegacySerde()) {
+            // Legacy serde generates per-operation serializer/deserializer middleware whose names derive from the
+            // resolved protocol generator; without one there is nothing to add.
+            if (protocolGenerator == null) {
+                return;
+            }
+
             // Add request serializer middleware
             String serializerMiddlewareName = ProtocolGenerator.getSerializeMiddlewareName(
                     operation.getId(), service, protocolGenerator.getProtocolName());

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SmithyGoDependency.java
@@ -78,6 +78,9 @@ public final class SmithyGoDependency {
     public static final GoDependency SMITHY_EVENTSTREAM = smithy("eventstream", "eventstream");
     public static final GoDependency SMITHY_AUTH = smithy("auth", "smithyauth");
     public static final GoDependency SMITHY_AUTH_BEARER = smithy("auth/bearer");
+    public static final GoDependency SMITHY_HTTP_SIGV4 = awsHttpAuthSchemes("sigv4", "sigv4");
+    public static final GoDependency SMITHY_HTTP_SIGV4A = awsHttpAuthSchemes("sigv4a", "sigv4a");
+    public static final GoDependency SMITHY_HTTP_AUTH_IDENTITY = awsHttpAuthSchemes("identity", "identity");
     public static final GoDependency SMITHY_ENDPOINTS = smithy("endpoints", "smithyendpoints");
     public static final GoDependency SMITHY_ENDPOINT_RULESFN = smithy("endpoints/private/rulesfn");
     public static final GoDependency SMITHY_ENDPOINT_BDD = smithy("endpoints/private/bdd");
@@ -94,6 +97,7 @@ public final class SmithyGoDependency {
     public static final GoDependency MATH = stdlib("math");
 
     private static final String SMITHY_SOURCE_PATH = "github.com/aws/smithy-go";
+    private static final String AWS_HTTP_AUTH_SCHEMES_SOURCE_PATH = "github.com/aws/smithy-go/aws-http-auth-schemes";
 
     private SmithyGoDependency() {
     }
@@ -127,6 +131,10 @@ public final class SmithyGoDependency {
         return relativePackage(SMITHY_SOURCE_PATH, relativePath, Versions.SMITHY_GO, alias);
     }
 
+    private static GoDependency awsHttpAuthSchemes(String relativePath, String alias) {
+        return relativePackage(AWS_HTTP_AUTH_SCHEMES_SOURCE_PATH, relativePath, Versions.SMITHY_GO_SIGV4, alias);
+    }
+
     private static GoDependency relativePackage(
             String moduleImportPath,
             String relativePath,
@@ -143,6 +151,7 @@ public final class SmithyGoDependency {
     private static final class Versions {
         private static final String GO_STDLIB = "1.15";
         private static final String SMITHY_GO = "v1.4.0";
+        private static final String SMITHY_GO_SIGV4 = "v1.0.0";
         private static final String GO_JMESPATH = "v0.4.0";
     }
 }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolverGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/endpoints/EndpointResolverGenerator.java
@@ -107,7 +107,54 @@ public final class EndpointResolverGenerator {
     }
 
     public Writable generateEmptyRules() {
-        return generateResolverType(generateEmptyResolveMethodBody());
+        return goTemplate("""
+                // $resolverInterfaceType:T provides the interface for resolving service endpoints.
+                type $resolverInterfaceType:T interface {
+                    $resolveEndpointMethodDocs:W
+                    $resolveEndpointMethodName:L(ctx $context:T, $paramArgName:L $parametersType:T) (
+                        $endpointType:T, error,
+                    )
+                }
+
+                $resolverTypeDocs:W
+                //
+                // This service has no modeled endpoint rules. The resolver falls back to the
+                // client's BaseEndpoint; requests fail if neither BaseEndpoint nor a custom
+                // EndpointResolverV2 is configured.
+                type $resolverImplementationType:T struct{
+                    baseEndpoint *string
+                }
+
+                func $newResolverFn:T() $resolverInterfaceType:T {
+                    return &$resolverImplementationType:T{}
+                }
+
+                $resolveEndpointMethodDocs:W
+                func (r *$resolverImplementationType:T) $resolveEndpointMethodName:L(
+                    ctx $context:T, $paramArgName:L $parametersType:T,
+                ) (
+                    endpoint $endpointType:T, err error,
+                ) {
+                    if r.baseEndpoint == nil {
+                        return endpoint, $fmtErrorf:T("no endpoint rules are defined for this service; " +
+                            "set BaseEndpoint or a custom EndpointResolverV2 to make requests")
+                    }
+
+                    uri, err := $urlParse:T(*r.baseEndpoint)
+                    if err != nil {
+                        return endpoint, $fmtErrorf:T("parse BaseEndpoint %q: %w", *r.baseEndpoint, err)
+                    }
+
+                    endpoint.URI = *uri
+                    return endpoint, nil
+                }
+                """,
+                commonCodegenArgs,
+                MapUtils.of(
+                        "context", SymbolUtils.createValueSymbolBuilder("Context", SmithyGoDependency.CONTEXT).build(),
+                        "urlParse", SymbolUtils.createValueSymbolBuilder("Parse", SmithyGoDependency.NET_URL).build(),
+                        "resolverTypeDocs", generateResolverTypeDocs(),
+                        "resolveEndpointMethodDocs", generateResolveEndpointMethodDocs()));
     }
 
     private Writable generateResolverType(Writable resolveMethodBody) {
@@ -212,10 +259,6 @@ public final class EndpointResolverGenerator {
                 commonCodegenArgs,
                 MapUtils.of(
                         "withDefaults", EndpointParametersGenerator.DEFAULT_VALUE_FUNC_NAME));
-    }
-
-    private Writable generateEmptyResolveMethodBody() {
-        return goTemplate("return endpoint, $fmtErrorf:T(\"no endpoint rules defined\")", commonCodegenArgs);
     }
 
     private Writable generateResolverTypeDocs() {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/DefaultEndpointResolverV2.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/DefaultEndpointResolverV2.java
@@ -1,0 +1,57 @@
+package software.amazon.smithy.go.codegen.integration;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+import static software.amazon.smithy.go.codegen.SymbolUtils.buildPackageSymbol;
+
+import java.util.List;
+import software.amazon.smithy.go.codegen.GoCodegenContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.rulesengine.traits.EndpointBddTrait;
+import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
+
+/**
+ * Defaults EndpointResolverV2 for clients whose service models no endpoint rules, backing it with the client's
+ * BaseEndpoint (the no-rules resolver emitted by EndpointResolverGenerator). Without this, such clients have a nil
+ * resolver and error at request time.
+ *
+ * <p>AWS SDK clients initialize EndpointResolverV2 through their own endpoint resolution codegen, so they replace this
+ * integration via {@link Replaces}.
+ */
+public class DefaultEndpointResolverV2 implements GoIntegration {
+    private static boolean hasNoEndpointRules(Model model, ServiceShape service) {
+        return !service.hasTrait(EndpointRuleSetTrait.class) && !service.hasTrait(EndpointBddTrait.class);
+    }
+
+    @Override
+    public List<RuntimeClientPlugin> getClientPlugins() {
+        return List.of(
+                RuntimeClientPlugin.builder()
+                        .servicePredicate(DefaultEndpointResolverV2::hasNoEndpointRules)
+                        .addConfigFieldResolver(ConfigFieldResolver.builder()
+                                .resolver(buildPackageSymbol("resolveEndpointResolverV2"))
+                                .location(ConfigFieldResolver.Location.CLIENT)
+                                .target(ConfigFieldResolver.Target.FINALIZATION)
+                                .build())
+                        .build()
+        );
+    }
+
+    @Override
+    public void writeAdditionalFiles(GoCodegenContext ctx) {
+        if (!hasNoEndpointRules(ctx.model(), ctx.settings().getService(ctx.model()))) {
+            return;
+        }
+
+        ctx.writerDelegator().useFileWriter("endpoints.go", ctx.settings().getModuleName(), goTemplate("""
+                // resolveEndpointResolverV2 defaults the client's EndpointResolverV2 to one backed by
+                // BaseEndpoint when the caller has not supplied their own. Generated for services with no
+                // modeled endpoint rules.
+                func resolveEndpointResolverV2(options *Options) {
+                    if options.EndpointResolverV2 == nil {
+                        options.EndpointResolverV2 = &resolver{baseEndpoint: options.BaseEndpoint}
+                    }
+                }
+                """));
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/DefaultHTTPClient.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/DefaultHTTPClient.java
@@ -1,0 +1,43 @@
+package software.amazon.smithy.go.codegen.integration;
+
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+import static software.amazon.smithy.go.codegen.SymbolUtils.buildPackageSymbol;
+
+import java.util.List;
+import software.amazon.smithy.go.codegen.GoCodegenContext;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+
+/**
+ * Defaults the client's HTTPClient config field when the caller does not supply one.
+ *
+ * <p>This is the generic smithy-go default (a bare {@code *net/http.Client}). AWS SDK clients replace this
+ * integration with one that provides their own HTTP client (with sane transport defaults) via {@link Replaces}.
+ */
+public class DefaultHTTPClient implements GoIntegration {
+    private static final ConfigFieldResolver RESOLVE_HTTP_CLIENT = ConfigFieldResolver.builder()
+            .resolver(buildPackageSymbol("resolveHTTPClient"))
+            .location(ConfigFieldResolver.Location.CLIENT)
+            .target(ConfigFieldResolver.Target.INITIALIZATION)
+            .build();
+
+    @Override
+    public List<RuntimeClientPlugin> getClientPlugins() {
+        return List.of(
+                RuntimeClientPlugin.builder()
+                        .addConfigFieldResolver(RESOLVE_HTTP_CLIENT)
+                        .build()
+        );
+    }
+
+    @Override
+    public void writeAdditionalFiles(GoCodegenContext ctx) {
+        ctx.writerDelegator().useFileWriter("api_client.go", ctx.settings().getModuleName(), goTemplate("""
+                func resolveHTTPClient(o *Options) {
+                    if o.HTTPClient == nil {
+                        o.HTTPClient = &$T{}
+                    }
+                }
+                """,
+                SmithyGoDependency.NET_HTTP.struct("Client")));
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegrationResolver.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/GoIntegrationResolver.java
@@ -1,0 +1,74 @@
+package software.amazon.smithy.go.codegen.integration;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+import software.amazon.smithy.codegen.core.CodegenException;
+
+/**
+ * Resolves {@link Replaces} declarations across a set of loaded integrations.
+ *
+ * <p>Java's {@link java.util.ServiceLoader} has no mechanism to suppress a discovered service implementation, so
+ * replacement is resolved here, after loading, by removing any integration that another integration declares it
+ * replaces via {@link Replaces}.
+ */
+public final class GoIntegrationResolver {
+    private static final Logger LOGGER = Logger.getLogger(GoIntegrationResolver.class.getName());
+
+    private GoIntegrationResolver() {}
+
+    /**
+     * Returns the effective list of integrations with replaced integrations removed.
+     *
+     * <p>The replacement targets are computed in a single pass over all supplied integrations. An integration is
+     * dropped if any supplied integration declares it as a replacement target, regardless of whether that replacer
+     * is itself replaced (so mutually-replacing integrations both drop out). Targets are matched by exact class
+     * identity. The {@link Replaces} annotation is repeatable, so one integration may declare multiple targets.
+     *
+     * @param integrations the loaded integrations, in their resolved order.
+     * @return the integrations that survive replacement, preserving input order.
+     * @throws CodegenException if an integration declares itself as a replacement target, or if two integrations
+     *     declare a replacement of the same target.
+     */
+    public static List<GoIntegration> resolveReplacements(List<GoIntegration> integrations) {
+        Map<Class<? extends GoIntegration>, Class<? extends GoIntegration>> replacedBy = new HashMap<>();
+        for (GoIntegration integration : integrations) {
+            for (Replaces replaces : integration.getClass().getAnnotationsByType(Replaces.class)) {
+                var target = replaces.value();
+
+                if (target.equals(integration.getClass())) {
+                    throw new CodegenException("GoIntegration " + integration.getClass().getName()
+                            + " declares itself as a replacement target.");
+                }
+
+                var existing = replacedBy.get(target);
+                if (existing != null) {
+                    throw new CodegenException(String.format(
+                            "GoIntegrations %s and %s both declare a replacement of %s; a given integration may be "
+                                    + "replaced by at most one other.",
+                            existing.getName(), integration.getClass().getName(), target.getName()));
+                }
+
+                replacedBy.put(target, integration.getClass());
+            }
+        }
+
+        if (replacedBy.isEmpty()) {
+            return integrations;
+        }
+
+        return integrations.stream()
+                .filter(integration -> {
+                    var replacer = replacedBy.get(integration.getClass());
+                    if (replacer != null) {
+                        LOGGER.info(() -> String.format(
+                                "Suppressing GoIntegration %s, replaced by %s.",
+                                integration.getClass().getName(), replacer.getName()));
+                        return false;
+                    }
+                    return true;
+                })
+                .toList();
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/Replaces.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/Replaces.java
@@ -1,0 +1,53 @@
+package software.amazon.smithy.go.codegen.integration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares that the annotated {@link GoIntegration} replaces another integration.
+ *
+ * <p>When an integration is replaced, it is removed in its entirety before code generation begins: none of its hooks
+ * are invoked and none of its contributions (client plugins, auth scheme definitions, auth parameters, protocol
+ * generators, etc.) are applied. This lets a downstream integration substitute its own behavior for a default
+ * provided by an upstream one - for example, an AWS SDK integration replacing a generic smithy-go default.
+ *
+ * <p>The annotation is repeatable, so one integration may replace multiple targets:
+ *
+ * <pre>{@code
+ * @Replaces(SigV4AuthScheme.class)
+ * @Replaces(AnonymousAuthScheme.class)
+ * public final class AwsSigV4AuthScheme implements GoIntegration { ... }
+ * }</pre>
+ *
+ * <p>A given integration may be replaced by at most one other. If two integrations declare a replacement of the same
+ * target, code generation fails rather than resolving the conflict silently.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Repeatable(Replaces.Container.class)
+public @interface Replaces {
+    /**
+     * The integration class that the annotated integration replaces.
+     *
+     * @return the replaced integration class.
+     */
+    Class<? extends GoIntegration> value();
+
+    /**
+     * Container for repeated {@link Replaces} declarations. Applied automatically by the compiler; not intended for
+     * direct use.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @interface Container {
+        /**
+         * The repeated declarations.
+         *
+         * @return the declarations.
+         */
+        Replaces[] value();
+    }
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/auth/SigV4AuthScheme.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/auth/SigV4AuthScheme.java
@@ -15,10 +15,23 @@
 
 package software.amazon.smithy.go.codegen.integration.auth;
 
+import static software.amazon.smithy.go.codegen.GoWriter.goTemplate;
+import static software.amazon.smithy.go.codegen.SymbolUtils.buildPackageSymbol;
+
 import java.util.List;
 import software.amazon.smithy.aws.traits.auth.SigV4ATrait;
 import software.amazon.smithy.aws.traits.auth.SigV4Trait;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.go.codegen.ChainWritable;
+import software.amazon.smithy.go.codegen.GoDelegator;
+import software.amazon.smithy.go.codegen.GoSettings;
+import software.amazon.smithy.go.codegen.GoUniverseTypes;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
+import software.amazon.smithy.go.codegen.Writable;
 import software.amazon.smithy.go.codegen.auth.AuthParameter;
+import software.amazon.smithy.go.codegen.auth.AuthParametersGenerator;
+import software.amazon.smithy.go.codegen.auth.AuthParametersResolver;
+import software.amazon.smithy.go.codegen.integration.ConfigField;
 import software.amazon.smithy.go.codegen.integration.GoIntegration;
 import software.amazon.smithy.go.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.model.Model;
@@ -27,21 +40,128 @@ import software.amazon.smithy.utils.ListUtils;
 
 /**
  * Code generation for SigV4/SigV4A.
+ *
+ * <p>This integration provides the default, generic SigV4 and SigV4A auth schemes for smithy-go clients: the
+ * modeled auth options, default auth schemes backed by the standalone signers in
+ * {@code github.com/aws/smithy-go/aws-http-auth-schemes/sigv4} and
+ * {@code github.com/aws/smithy-go/aws-http-auth-schemes/sigv4a}, a credentials-backed identity resolver from
+ * {@code github.com/aws/smithy-go/aws-http-auth-schemes/identity} shared by both schemes, and the
+ * {@code Region}/{@code Credentials} client config they need. AWS SDK clients replace this integration wholesale
+ * (see {@link software.amazon.smithy.go.codegen.integration.Replaces}) with one bound to the SDK runtime.
  */
 public class SigV4AuthScheme implements GoIntegration {
     private boolean isSigV4XService(Model model, ServiceShape service) {
         return service.hasTrait(SigV4Trait.class) || service.hasTrait(SigV4ATrait.class);
     }
 
+    private boolean isSigV4Service(Model model, ServiceShape service) {
+        return service.hasTrait(SigV4Trait.class);
+    }
+
+    private boolean isSigV4AService(Model model, ServiceShape service) {
+        return service.hasTrait(SigV4ATrait.class);
+    }
+
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
-        // FUTURE: add default Region client option and scheme definitions - we need a more structured way of
-        //         suppressing elements of a GoIntegration before we do so, for now those are registered SDK-side
         return ListUtils.of(
                 RuntimeClientPlugin.builder()
                         .servicePredicate(this::isSigV4XService)
                         .addAuthParameter(AuthParameter.REGION)
+                        .addConfigField(ConfigField.builder()
+                                .name("Region")
+                                .type(GoUniverseTypes.String)
+                                .documentation("The region to sign requests for.")
+                                .build())
+                        .addConfigField(ConfigField.builder()
+                                .name("Credentials")
+                                .type(SmithyGoDependency.SMITHY_HTTP_AUTH_IDENTITY.interfaceSymbol("AWSCredentialIdentityResolver"))
+                                .documentation("The credentials provider used to sign SigV4/SigV4A requests.")
+                                .build())
+                        .addAuthParameterResolver(
+                                new AuthParametersResolver(buildPackageSymbol("bindAuthParamsRegion")))
+                        .build(),
+                RuntimeClientPlugin.builder()
+                        .servicePredicate(this::isSigV4Service)
+                        .addAuthSchemeDefinition(SigV4Trait.ID, new DefaultSigV4())
+                        .build(),
+                RuntimeClientPlugin.builder()
+                        .servicePredicate(this::isSigV4AService)
+                        .addAuthSchemeDefinition(SigV4ATrait.ID, new DefaultSigV4A())
                         .build()
         );
+    }
+
+    @Override
+    public void writeAdditionalFiles(
+            GoSettings settings, Model model, SymbolProvider symbolProvider, GoDelegator goDelegator
+    ) {
+        if (isSigV4XService(model, settings.getService(model))) {
+            goDelegator.useFileWriter("auth.go", settings.getModuleName(), generateAdditionalSource());
+        }
+    }
+
+    /**
+     * Default SigV4 auth scheme definition for generic clients. Extends the shared modeled-option generation with a
+     * default scheme and identity resolver wired to the smithy-go SigV4 runtime.
+     */
+    public static class DefaultSigV4 extends SigV4Definition {
+        @Override
+        public Writable generateDefaultAuthScheme() {
+            return goTemplate("$T()",
+                    SmithyGoDependency.SMITHY_HTTP_SIGV4.func("NewAuthScheme"));
+        }
+
+        @Override
+        public Writable generateOptionsIdentityResolver() {
+            return goTemplate("getSigV4IdentityResolver(o)");
+        }
+    }
+
+    /**
+     * Default SigV4A auth scheme definition for generic clients. Extends the shared modeled-option generation with a
+     * default scheme and identity resolver wired to the smithy-go SigV4A runtime.
+     */
+    public static class DefaultSigV4A extends SigV4ADefinition {
+        @Override
+        public Writable generateDefaultAuthScheme() {
+            return goTemplate("$T()",
+                    SmithyGoDependency.SMITHY_HTTP_SIGV4A.func("NewAuthScheme"));
+        }
+
+        @Override
+        public Writable generateOptionsIdentityResolver() {
+            return goTemplate("getSigV4IdentityResolver(o)");
+        }
+    }
+
+    private Writable generateAdditionalSource() {
+        return ChainWritable.of(
+                generateGetIdentityResolver(),
+                generateRegionResolver()
+        ).compose();
+    }
+
+    private Writable generateGetIdentityResolver() {
+        return goTemplate("""
+                func getSigV4IdentityResolver(o Options) $T {
+                    if o.Credentials != nil {
+                        return $T(o.Credentials)
+                    }
+
+                    return nil
+                }
+                """,
+                SmithyGoDependency.SMITHY_AUTH.interfaceSymbol("IdentityResolver"),
+                SmithyGoDependency.SMITHY_HTTP_AUTH_IDENTITY.func("NewIdentityResolver"));
+    }
+
+    private Writable generateRegionResolver() {
+        return goTemplate("""
+                func bindAuthParamsRegion(_ interface{}, params $P, _ interface{}, options Options) error {
+                    params.Region = options.Region
+                    return nil
+                }
+                """, AuthParametersGenerator.STRUCT_SYMBOL);
     }
 }

--- a/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.go.codegen.integration.GoIntegration
+++ b/codegen/smithy-go-codegen/src/main/resources/META-INF/services/software.amazon.smithy.go.codegen.integration.GoIntegration
@@ -16,6 +16,8 @@ software.amazon.smithy.go.codegen.integration.auth.AnonymousAuthScheme
 software.amazon.smithy.go.codegen.requestcompression.RequestCompression
 
 software.amazon.smithy.go.codegen.integration.ObservabilityOptions
+software.amazon.smithy.go.codegen.integration.DefaultHTTPClient
+software.amazon.smithy.go.codegen.integration.DefaultEndpointResolverV2
 
 # server
 software.amazon.smithy.go.codegen.server.integration.DefaultProtocols


### PR DESCRIPTION
- new module aws-http-auth-schemes bridges the standalone aws-http-auth signers into smithy-go's client auth interfaces, so generic (non-SDK) clients can sign with SigV4/SigV4A
without depending on aws-sdk-go-v2
- `@Replaces` annotation lets one GoIntegration suppress another, so the SDK can swap in its own auth scheme/HTTP client/endpoint resolver over the generic defaults
- DefaultEndpointResolverV2 and DefaultHTTPClient integrations give generic clients working defaults (base-endpoint-only resolution, plain http.Client) that were previously never
wired up

there wil be a downstream PR that adds `@Replaces` in SDK codegen where necessary, verified that this doesn't affect the output of the generated SDK at all with those.