### PR TITLE
add fine-grained benchmark codegen

### DIFF
--- a/.changelog/0f399b8f8d3a4cf68a66ce34f085ba86.json
+++ b/.changelog/0f399b8f8d3a4cf68a66ce34f085ba86.json
@@ -1,0 +1,8 @@
+{
+    "id": "0f399b8f-8d3a-4cf6-8a66-ce34f085ba86",
+    "type": "bugfix",
+    "description": "Fix a performance issue in awsQuery with large response payloads.",
+    "modules": [
+        "."
+    ]
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/CodegenVisitor.java
@@ -285,7 +285,7 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
         }
 
         LOGGER.info("Generating protocol tests for " + service.getId());
-        ProtocolUtils.generateHttpProtocolTests(ctx);
+        ProtocolUtils.generateHttpProtocolTests(ctx, protocolGenerator != null ? protocolGenerator.getProtocolName() : "");
 
         if (!settings.useLegacySerde()) {
             protocolDocumentGenerator.generateLegacyInternalDocumentTypes(ctx);

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoCodegenContext.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoCodegenContext.java
@@ -25,6 +25,7 @@ import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.codegen.core.WriterDelegator;
 import software.amazon.smithy.go.codegen.integration.GoIntegration;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.OperationIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.neighbor.Walker;
 import software.amazon.smithy.model.shapes.ServiceShape;
@@ -63,7 +64,10 @@ public record GoCodegenContext(
                 .map(it -> model.expectShape(it.getOutputShape()))
                 .flatMap(it -> walker.walkShapes(it).stream())
                 .collect(toSet()));
-        shapes.addAll(model.getStructureShapesWithTrait(ErrorTrait.class).stream()
+
+        var operationIndex = OperationIndex.of(model);
+        shapes.addAll(operations.stream()
+                .flatMap(it -> operationIndex.getErrors(it, service()).stream())
                 .flatMap(it -> walker.walkShapes(it).stream())
                 .collect(toSet()));
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/GoWriter.java
@@ -844,7 +844,9 @@ public final class GoWriter extends SymbolWriter<GoWriter, ImportDeclarations> {
     }
 
     public GoWriter addBuildTag(String tag) {
-        buildTags.add(tag);
+        if (!buildTags.contains(tag)) {
+            buildTags.add(tag);
+        }
         return this;
     }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ProtocolUtils.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/ProtocolUtils.java
@@ -26,7 +26,7 @@ public final class ProtocolUtils {
     /**
      * Generates HTTP protocol tests.
      */
-    public static void generateHttpProtocolTests(GoCodegenContext ctx) {
+    public static void generateHttpProtocolTests(GoCodegenContext ctx, String protocolName) {
         var operations = TopDownIndex.of(ctx.model()).getContainedOperations(ctx.settings().getService());
         var hasRequestTests = operations.stream()
                 .anyMatch(it -> it.hasTrait(HttpRequestTestsTrait.class));
@@ -307,7 +307,7 @@ public final class ProtocolUtils {
                         .build()
         ));
 
-        new HttpProtocolTestGenerator(ctx,
+        new HttpProtocolTestGenerator(ctx, protocolName,
                 (HttpProtocolUnitTestRequestGenerator.Builder) new HttpProtocolUnitTestRequestGenerator
                         .Builder()
                         .settings(ctx.settings())

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/TypeRegistry.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/TypeRegistry.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.stream.Collectors;
 import software.amazon.smithy.model.knowledge.EventStreamIndex;
+import software.amazon.smithy.model.knowledge.OperationIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.loader.Prelude;
 import software.amazon.smithy.model.shapes.StructureShape;
@@ -25,7 +26,10 @@ public class TypeRegistry implements Writable {
 
         // Errors: needed for DeserializableError lookup
         var shapes = new HashSet<StructureShape>();
-        shapes.addAll(model.getStructureShapesWithTrait(ErrorTrait.class));
+        var operationIndex = OperationIndex.of(model);
+        for (var op : TopDownIndex.of(model).getContainedOperations(service)) {
+            shapes.addAll(operationIndex.getErrors(op, service));
+        }
 
         // Event stream events: needed for LookupEntry by target ID
         var streamIndex = EventStreamIndex.of(model);

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolTestGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolTestGenerator.java
@@ -80,7 +80,7 @@ public class HttpProtocolTestGenerator {
         OperationIndex operationIndex = model.getKnowledge(OperationIndex.class);
         TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
 
-        boolean[] hasSerdBenchmarks = {false};
+        boolean hasSerdBenchmarks = false;
 
         for (OperationShape operation : new TreeSet<>(topDownIndex.getContainedOperations(service))) {
             if (operation.hasTag("server-only")) {
@@ -88,7 +88,9 @@ public class HttpProtocolTestGenerator {
             }
 
             // 1. Generate test cases for each request.
-            operation.getTrait(HttpRequestTestsTrait.class).ifPresent(trait -> {
+            var requestTestsTrait = operation.getTrait(HttpRequestTestsTrait.class);
+            if (requestTestsTrait.isPresent()) {
+                var trait = requestTestsTrait.get();
                 final List<HttpRequestTestCase> testCases = filterProtocolTestCases(trait.getTestCases());
                 if (testCases.isEmpty()) {
                     return;
@@ -106,7 +108,7 @@ public class HttpProtocolTestGenerator {
                                 .generateTestFunction(writer);
                     });
                 } else {
-                    hasSerdBenchmarks[0] = true;
+                    hasSerdBenchmarks = true;
                     delegator.useShapeTestWriter(operation, (writer) -> {
                         LOGGER.fine(() -> format("Generating request protocol serialization benchmark for %s", operation.getId()));
                         writer.addBuildTag(SERDE_BENCHMARK_BUILD_TAG);
@@ -120,10 +122,12 @@ public class HttpProtocolTestGenerator {
                                 .generateSerdBenchmarkFunction(writer);
                     });
                 }
-            });
+            }
 
             // 2. Generate test cases for each response.
-            operation.getTrait(HttpResponseTestsTrait.class).ifPresent(trait -> {
+            var responseTestsTrait = operation.getTrait(HttpResponseTestsTrait.class);
+            if (responseTestsTrait.isPresent()) {
+                var trait = responseTestsTrait.get();
                 final List<HttpResponseTestCase> testCases = filterProtocolTestCases(trait.getTestCases());
                 if (testCases.isEmpty()) {
                     return;
@@ -143,7 +147,7 @@ public class HttpProtocolTestGenerator {
                                 .generateTestFunction(writer);
                     });
                 } else {
-                    hasSerdBenchmarks[0] = true;
+                    hasSerdBenchmarks = true;
                     delegator.useShapeTestWriter(operation, (writer) -> {
                         LOGGER.fine(() -> format("Generating response protocol deserialization benchmark for %s", operation.getId()));
                         writer.addBuildTag(SERDE_BENCHMARK_BUILD_TAG);
@@ -158,7 +162,7 @@ public class HttpProtocolTestGenerator {
                                 .generateSerdBenchmarkFunction(writer);
                     });
                 }
-            });
+            }
 
             // 3. Generate test cases for each error on each operation.
             for (StructureShape error : operationIndex.getErrors(operation)) {
@@ -188,7 +192,7 @@ public class HttpProtocolTestGenerator {
             }
         }
 
-        if (hasSerdBenchmarks[0]) {
+        if (hasSerdBenchmarks) {
             generateSerdBenchmarkHelpers();
         }
     }
@@ -289,13 +293,11 @@ public class HttpProtocolTestGenerator {
         List<T> filtered = new ArrayList<>();
         var protocol = settings.getProtocol();
         if (protocol == null) {
-            // schema-serde path: resolve from service traits
-            var protocols = software.amazon.smithy.model.knowledge.ServiceIndex.of(model)
-                    .getProtocols(service).keySet();
-            protocol = protocols.isEmpty() ? null : protocols.iterator().next();
+            // Schema-serde generation can run without a selected protocol, so retain all test cases.
+            return testCases;
         }
         for (T testCase : testCases) {
-            if (protocol == null || testCase.getProtocol().equals(protocol)) {
+            if (testCase.getProtocol().equals(protocol)) {
                 filtered.add(testCase);
             }
         }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolTestGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolTestGenerator.java
@@ -92,35 +92,34 @@ public class HttpProtocolTestGenerator {
             if (requestTestsTrait.isPresent()) {
                 var trait = requestTestsTrait.get();
                 final List<HttpRequestTestCase> testCases = filterProtocolTestCases(trait.getTestCases());
-                if (testCases.isEmpty()) {
-                    return;
-                }
-                List<HttpRequestTestCase> serdBenchmarkCases = filterSerdBenchmarkTaggedTestCases(testCases);
-                if (serdBenchmarkCases.isEmpty()) {
-                    delegator.useShapeTestWriter(operation, (writer) -> {
-                        LOGGER.fine(() -> format("Generating request protocol test case for %s", operation.getId()));
-                        requestTestBuilder.model(model)
-                                .symbolProvider(symbolProvider)
-                                .service(service)
-                                .operation(operation)
-                                .testCases(trait.getTestCases())
-                                .build()
-                                .generateTestFunction(writer);
-                    });
-                } else {
-                    hasSerdBenchmarks = true;
-                    delegator.useShapeTestWriter(operation, (writer) -> {
-                        LOGGER.fine(() -> format("Generating request protocol serialization benchmark for %s", operation.getId()));
-                        writer.addBuildTag(SERDE_BENCHMARK_BUILD_TAG);
-                        requestTestBuilder.model(model)
-                                .symbolProvider(symbolProvider)
-                                .service(service)
-                                .operation(operation)
-                                .protocolName(protocolName)
-                                .testCases(serdBenchmarkCases)
-                                .build()
-                                .generateSerdBenchmarkFunction(writer);
-                    });
+                if (!testCases.isEmpty()) {
+                    List<HttpRequestTestCase> serdBenchmarkCases = filterSerdBenchmarkTaggedTestCases(testCases);
+                    if (serdBenchmarkCases.isEmpty()) {
+                        delegator.useShapeTestWriter(operation, (writer) -> {
+                            LOGGER.fine(() -> format("Generating request protocol test case for %s", operation.getId()));
+                            requestTestBuilder.model(model)
+                                    .symbolProvider(symbolProvider)
+                                    .service(service)
+                                    .operation(operation)
+                                    .testCases(trait.getTestCases())
+                                    .build()
+                                    .generateTestFunction(writer);
+                        });
+                    } else {
+                        hasSerdBenchmarks = true;
+                        delegator.useShapeTestWriter(operation, (writer) -> {
+                            LOGGER.fine(() -> format("Generating request protocol serialization benchmark for %s", operation.getId()));
+                            writer.addBuildTag(SERDE_BENCHMARK_BUILD_TAG);
+                            requestTestBuilder.model(model)
+                                    .symbolProvider(symbolProvider)
+                                    .service(service)
+                                    .operation(operation)
+                                    .protocolName(protocolName)
+                                    .testCases(serdBenchmarkCases)
+                                    .build()
+                                    .generateSerdBenchmarkFunction(writer);
+                        });
+                    }
                 }
             }
 
@@ -129,38 +128,37 @@ public class HttpProtocolTestGenerator {
             if (responseTestsTrait.isPresent()) {
                 var trait = responseTestsTrait.get();
                 final List<HttpResponseTestCase> testCases = filterProtocolTestCases(trait.getTestCases());
-                if (testCases.isEmpty()) {
-                    return;
-                }
-                List<HttpResponseTestCase> serdBenchmarkCases = filterSerdBenchmarkTaggedTestCases(testCases);
-                if (serdBenchmarkCases.isEmpty()) {
-                    delegator.useShapeTestWriter(operation, (writer) -> {
-                        LOGGER.fine(() -> format("Generating response protocol test case for %s", operation.getId()));
-                        responseTestBuilder.model(model)
-                                .symbolProvider(symbolProvider)
-                                .service(service)
-                                .operation(operation)
-                                .testCases(trait.getTestCases())
-                                .shapeValueGeneratorConfig(ShapeValueGenerator.Config.builder()
-                                        .normalizeHttpPrefixHeaderKeys(true).build())
-                                .build()
-                                .generateTestFunction(writer);
-                    });
-                } else {
-                    hasSerdBenchmarks = true;
-                    delegator.useShapeTestWriter(operation, (writer) -> {
-                        LOGGER.fine(() -> format("Generating response protocol deserialization benchmark for %s", operation.getId()));
-                        writer.addBuildTag(SERDE_BENCHMARK_BUILD_TAG);
-                        responseTestBuilder.model(model)
-                                .symbolProvider(symbolProvider)
-                                .service(service)
-                                .operation(operation)
-                                .testCases(serdBenchmarkCases)
-                                .shapeValueGeneratorConfig(ShapeValueGenerator.Config.builder()
-                                        .normalizeHttpPrefixHeaderKeys(true).build())
-                                .build()
-                                .generateSerdBenchmarkFunction(writer);
-                    });
+                if (!testCases.isEmpty()) {
+                    List<HttpResponseTestCase> serdBenchmarkCases = filterSerdBenchmarkTaggedTestCases(testCases);
+                    if (serdBenchmarkCases.isEmpty()) {
+                        delegator.useShapeTestWriter(operation, (writer) -> {
+                            LOGGER.fine(() -> format("Generating response protocol test case for %s", operation.getId()));
+                            responseTestBuilder.model(model)
+                                    .symbolProvider(symbolProvider)
+                                    .service(service)
+                                    .operation(operation)
+                                    .testCases(trait.getTestCases())
+                                    .shapeValueGeneratorConfig(ShapeValueGenerator.Config.builder()
+                                            .normalizeHttpPrefixHeaderKeys(true).build())
+                                    .build()
+                                    .generateTestFunction(writer);
+                        });
+                    } else {
+                        hasSerdBenchmarks = true;
+                        delegator.useShapeTestWriter(operation, (writer) -> {
+                            LOGGER.fine(() -> format("Generating response protocol deserialization benchmark for %s", operation.getId()));
+                            writer.addBuildTag(SERDE_BENCHMARK_BUILD_TAG);
+                            responseTestBuilder.model(model)
+                                    .symbolProvider(symbolProvider)
+                                    .service(service)
+                                    .operation(operation)
+                                    .testCases(serdBenchmarkCases)
+                                    .shapeValueGeneratorConfig(ShapeValueGenerator.Config.builder()
+                                            .normalizeHttpPrefixHeaderKeys(true).build())
+                                    .build()
+                                    .generateSerdBenchmarkFunction(writer);
+                        });
+                    }
                 }
             }
 

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolTestGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolTestGenerator.java
@@ -12,6 +12,7 @@ import software.amazon.smithy.go.codegen.GoCodegenContext;
 import software.amazon.smithy.go.codegen.GoDelegator;
 import software.amazon.smithy.go.codegen.GoSettings;
 import software.amazon.smithy.go.codegen.ShapeValueGenerator;
+import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.OperationIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
@@ -40,17 +41,22 @@ public class HttpProtocolTestGenerator {
     private final HttpProtocolUnitTestRequestGenerator.Builder requestTestBuilder;
     private final HttpProtocolUnitTestResponseGenerator.Builder responseTestBuilder;
     private final HttpProtocolUnitTestResponseErrorGenerator.Builder responseErrorTestBuilder;
+    private final String SERDE_BENCHMARK_TAG = "serde-benchmark";
+    private final String SERDE_BENCHMARK_BUILD_TAG = "serdebenchmark";
+    private final String protocolName;
 
     /**
      * Initializes the protocol generator.
      *
      * @param ctx                      codegen context.
+     * @param protocolName             the protocol name prefix for generated middleware types.
      * @param requestTestBuilder       builder that will create a request test generator.
      * @param responseTestBuilder      build that will create a response test generator.
      * @param responseErrorTestBuilder builder that will create a response API error test generator.
      */
     public HttpProtocolTestGenerator(
             GoCodegenContext ctx,
+            String protocolName,
             HttpProtocolUnitTestRequestGenerator.Builder requestTestBuilder,
             HttpProtocolUnitTestResponseGenerator.Builder responseTestBuilder,
             HttpProtocolUnitTestResponseErrorGenerator.Builder responseErrorTestBuilder
@@ -60,6 +66,7 @@ public class HttpProtocolTestGenerator {
         this.service = ctx.settings().getService(ctx.model());
         this.symbolProvider = ctx.symbolProvider();
         this.delegator = (GoDelegator) ctx.writerDelegator();
+        this.protocolName = protocolName;
 
         this.requestTestBuilder = requestTestBuilder;
         this.responseTestBuilder = responseTestBuilder;
@@ -73,6 +80,8 @@ public class HttpProtocolTestGenerator {
         OperationIndex operationIndex = model.getKnowledge(OperationIndex.class);
         TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
 
+        boolean[] hasSerdBenchmarks = {false};
+
         for (OperationShape operation : new TreeSet<>(topDownIndex.getContainedOperations(service))) {
             if (operation.hasTag("server-only")) {
                 continue;
@@ -84,28 +93,33 @@ public class HttpProtocolTestGenerator {
                 if (testCases.isEmpty()) {
                     return;
                 }
-
-                delegator.useShapeTestWriter(operation, (writer) -> {
-                    LOGGER.fine(() -> format("Generating request protocol test case for %s", operation.getId()));
-                    requestTestBuilder.model(model)
-                            .symbolProvider(symbolProvider)
-                            .service(service)
-                            .operation(operation)
-                            .testCases(trait.getTestCases())
-                            .build()
-                            .generateTestFunction(writer);
-                });
-
-                delegator.useShapeTestWriter(operation, (writer) -> {
-                    LOGGER.fine(() -> format("Generating request protocol benchmark for %s", operation.getId()));
-                    requestTestBuilder.model(model)
-                            .symbolProvider(symbolProvider)
-                            .service(service)
-                            .operation(operation)
-                            .testCases(trait.getTestCases())
-                            .build()
-                            .generateBenchmarkFunction(writer);
-                });
+                List<HttpRequestTestCase> serdBenchmarkCases = filterSerdBenchmarkTaggedTestCases(testCases);
+                if (serdBenchmarkCases.isEmpty()) {
+                    delegator.useShapeTestWriter(operation, (writer) -> {
+                        LOGGER.fine(() -> format("Generating request protocol test case for %s", operation.getId()));
+                        requestTestBuilder.model(model)
+                                .symbolProvider(symbolProvider)
+                                .service(service)
+                                .operation(operation)
+                                .testCases(trait.getTestCases())
+                                .build()
+                                .generateTestFunction(writer);
+                    });
+                } else {
+                    hasSerdBenchmarks[0] = true;
+                    delegator.useShapeTestWriter(operation, (writer) -> {
+                        LOGGER.fine(() -> format("Generating request protocol serialization benchmark for %s", operation.getId()));
+                        writer.addBuildTag(SERDE_BENCHMARK_BUILD_TAG);
+                        requestTestBuilder.model(model)
+                                .symbolProvider(symbolProvider)
+                                .service(service)
+                                .operation(operation)
+                                .protocolName(protocolName)
+                                .testCases(serdBenchmarkCases)
+                                .build()
+                                .generateSerdBenchmarkFunction(writer);
+                    });
+                }
             });
 
             // 2. Generate test cases for each response.
@@ -114,32 +128,36 @@ public class HttpProtocolTestGenerator {
                 if (testCases.isEmpty()) {
                     return;
                 }
-
-                delegator.useShapeTestWriter(operation, (writer) -> {
-                    LOGGER.fine(() -> format("Generating response protocol test case for %s", operation.getId()));
-                    responseTestBuilder.model(model)
-                            .symbolProvider(symbolProvider)
-                            .service(service)
-                            .operation(operation)
-                            .testCases(trait.getTestCases())
-                            .shapeValueGeneratorConfig(ShapeValueGenerator.Config.builder()
-                                    .normalizeHttpPrefixHeaderKeys(true).build())
-                            .build()
-                            .generateTestFunction(writer);
-                });
-
-                delegator.useShapeTestWriter(operation, (writer) -> {
-                    LOGGER.fine(() -> format("Generating response protocol benchmark for %s", operation.getId()));
-                    responseTestBuilder.model(model)
-                            .symbolProvider(symbolProvider)
-                            .service(service)
-                            .operation(operation)
-                            .testCases(trait.getTestCases())
-                            .shapeValueGeneratorConfig(ShapeValueGenerator.Config.builder()
-                                    .normalizeHttpPrefixHeaderKeys(true).build())
-                            .build()
-                            .generateBenchmarkFunction(writer);
-                });
+                List<HttpResponseTestCase> serdBenchmarkCases = filterSerdBenchmarkTaggedTestCases(testCases);
+                if (serdBenchmarkCases.isEmpty()) {
+                    delegator.useShapeTestWriter(operation, (writer) -> {
+                        LOGGER.fine(() -> format("Generating response protocol test case for %s", operation.getId()));
+                        responseTestBuilder.model(model)
+                                .symbolProvider(symbolProvider)
+                                .service(service)
+                                .operation(operation)
+                                .testCases(trait.getTestCases())
+                                .shapeValueGeneratorConfig(ShapeValueGenerator.Config.builder()
+                                        .normalizeHttpPrefixHeaderKeys(true).build())
+                                .build()
+                                .generateTestFunction(writer);
+                    });
+                } else {
+                    hasSerdBenchmarks[0] = true;
+                    delegator.useShapeTestWriter(operation, (writer) -> {
+                        LOGGER.fine(() -> format("Generating response protocol deserialization benchmark for %s", operation.getId()));
+                        writer.addBuildTag(SERDE_BENCHMARK_BUILD_TAG);
+                        responseTestBuilder.model(model)
+                                .symbolProvider(symbolProvider)
+                                .service(service)
+                                .operation(operation)
+                                .testCases(serdBenchmarkCases)
+                                .shapeValueGeneratorConfig(ShapeValueGenerator.Config.builder()
+                                        .normalizeHttpPrefixHeaderKeys(true).build())
+                                .build()
+                                .generateSerdBenchmarkFunction(writer);
+                    });
+                }
             });
 
             // 3. Generate test cases for each error on each operation.
@@ -166,28 +184,128 @@ public class HttpProtocolTestGenerator {
                                 .build()
                                 .generateTestFunction(writer);
                     });
-
-                    delegator.useShapeTestWriter(operation, (writer) -> {
-                        LOGGER.fine(() -> format("Generating response error protocol benchmark for %s",
-                                operation.getId()));
-                        responseErrorTestBuilder.model(model)
-                                .symbolProvider(symbolProvider)
-                                .service(service)
-                                .operation(operation)
-                                .error(error)
-                                .testCases(trait.getTestCases())
-                                .build()
-                                .generateBenchmarkFunction(writer);
-                    });
                 });
             }
         }
+
+        if (hasSerdBenchmarks[0]) {
+            generateSerdBenchmarkHelpers();
+        }
+    }
+
+    private void generateSerdBenchmarkHelpers() {
+        delegator.useFileWriter("serd_benchmark_test.go", settings.getModuleName(), writer -> {
+            writer.addBuildTag(SERDE_BENCHMARK_BUILD_TAG);
+            writer.addUseImports(SmithyGoDependency.JSON);
+            writer.addUseImports(SmithyGoDependency.OS);
+            writer.addUseImports(SmithyGoDependency.FMT);
+            writer.addUseImports(SmithyGoDependency.SYNC);
+            writer.addUseImports(SmithyGoDependency.TESTING);
+            writer.addUseImports(SmithyGoDependency.PATH_FILEPATH);
+            writer.addUseImports(SmithyGoDependency.stdlib("runtime"));
+            writer.write("""
+                    type serdBenchmarkResult struct {
+                        ID     string  `json:"id"`
+                        N      int     `json:"n"`
+                        Mean   float64 `json:"mean"`
+                        P50    float64 `json:"p50"`
+                        P90    float64 `json:"p90"`
+                        P95    float64 `json:"p95"`
+                        P99    float64 `json:"p99"`
+                        StdDev float64 `json:"std_dev"`
+                    }
+
+                    type serdBenchmarkOutput struct {
+                        Metadata       serdBenchmarkMetadata `json:"metadata"`
+                        SerdBenchmarks []serdBenchmarkResult `json:"serde_benchmarks"`
+                    }
+
+                    type serdBenchmarkMetadata struct {
+                        Lang      string     `json:"lang"`
+                        Software  [][]string `json:"software"`
+                        OS        string     `json:"os"`
+                        Instance  string     `json:"instance"`
+                        Precision string     `json:"precision"`
+                    }
+
+                    var (
+                        serdBenchmarkResults []serdBenchmarkResult
+                        serdBenchmarkMu      sync.Mutex
+                    )
+
+                    func addSerdBenchmarkResult(r serdBenchmarkResult) {
+                        serdBenchmarkMu.Lock()
+                        defer serdBenchmarkMu.Unlock()
+                        serdBenchmarkResults = append(serdBenchmarkResults, r)
+                    }
+
+                    func writeSerdBenchmarkResults() error {
+                        serdBenchmarkMu.Lock()
+                        defer serdBenchmarkMu.Unlock()
+                        if len(serdBenchmarkResults) == 0 {
+                            return nil
+                        }
+                        output := serdBenchmarkOutput{
+                            Metadata: serdBenchmarkMetadata{
+                                Lang:      "Go",
+                                Software:  [][]string{{"smithy-go", goModuleVersion}, {"AWS SDK for Go v2", goModuleVersion}},
+                                OS:        runtime.GOOS + "/" + runtime.GOARCH,
+                                Precision: "-9",
+                            },
+                            SerdBenchmarks: serdBenchmarkResults,
+                        }
+                        data, err := json.MarshalIndent(output, "", "  ")
+                        if err != nil {
+                            return fmt.Errorf("failed to marshal serd benchmark results: %v", err)
+                        }
+                        dir, err := findBenchmarkDir()
+                        if err != nil {
+                            return fmt.Errorf("failed to find benchmark directory: %v", err)
+                        }
+                        path := filepath.Join(dir, "benchmark.json")
+                        return os.WriteFile(path, data, 0644)
+                    }
+
+                    func findBenchmarkDir() (string, error) {
+                        dir, err := os.Getwd()
+                        if err != nil {
+                            return "", err
+                        }
+                        return dir, nil
+                    }
+
+                    func TestMain(m *testing.M) {
+                        code := m.Run()
+                        if err := writeSerdBenchmarkResults(); err != nil {
+                            fmt.Fprintf(os.Stderr, "failed to write serd benchmark results: %v\\n", err)
+                        }
+                        os.Exit(code)
+                    }
+                    """);
+        });
     }
 
     private <T extends HttpMessageTestCase> List<T> filterProtocolTestCases(List<T> testCases) {
         List<T> filtered = new ArrayList<>();
+        var protocol = settings.getProtocol();
+        if (protocol == null) {
+            // schema-serde path: resolve from service traits
+            var protocols = software.amazon.smithy.model.knowledge.ServiceIndex.of(model)
+                    .getProtocols(service).keySet();
+            protocol = protocols.isEmpty() ? null : protocols.iterator().next();
+        }
         for (T testCase : testCases) {
-            if (testCase.getProtocol().equals(settings.getProtocol())) {
+            if (protocol == null || testCase.getProtocol().equals(protocol)) {
+                filtered.add(testCase);
+            }
+        }
+        return filtered;
+    }
+
+    private <T extends HttpMessageTestCase> List<T> filterSerdBenchmarkTaggedTestCases(List<T> testCases) {
+        List<T> filtered = new ArrayList<>();
+        for (T testCase : testCases) {
+            if (testCase.hasTag(SERDE_BENCHMARK_TAG)) {
                 filtered.add(testCase);
             }
         }

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestGenerator.java
@@ -115,10 +115,9 @@ public abstract class HttpProtocolUnitTestGenerator<T extends HttpMessageTestCas
      */
     abstract Object[] unitTestFuncNameArgs();
 
-    abstract String benchmarkFuncNameFormat();
+    abstract Object[] serdBenchmarkFuncNameArgs();
 
-    abstract Object[] benchmarkFuncNameArgs();
-
+    abstract String serdBenchmarkFunctionNameFormat();
 
     /**
      * Hook to provide custom generated code within a test function before test cases are defined.
@@ -197,6 +196,10 @@ public abstract class HttpProtocolUnitTestGenerator<T extends HttpMessageTestCas
         });
     }
 
+    protected void generateSerdBenchmarkTestClient(GoWriter writer, String clientName) {
+        generateTestClient(writer, clientName);
+    }
+
     /**
      * Hook to generate the client invoking the API operation of the test. Should not do any assertions.
      *
@@ -204,10 +207,6 @@ public abstract class HttpProtocolUnitTestGenerator<T extends HttpMessageTestCas
      * @param clientName name of the client variable.
      */
     abstract void generateTestInvokeClientOperation(GoWriter writer, String clientName);
-
-    protected void generateBenchmarkInvokeClientOperation(GoWriter writer, String clientName) {
-        generateTestInvokeClientOperation(writer, clientName);
-    }
 
     /**
      * Hook to generate the assertions for the operation's test cases. Will be in the same scope as the test body.
@@ -274,17 +273,22 @@ public abstract class HttpProtocolUnitTestGenerator<T extends HttpMessageTestCas
                 });
     }
 
-    protected void generateBenchmarkBodySetup(GoWriter writer) {
+    protected void generateSerdBenchmarkBodySetup(GoWriter writer) {
         generateTestBodySetup(writer);
     }
 
-    protected void generateBenchmarkServer(GoWriter writer) {
-        generateTestServer(writer, "server", this::generateTestServerHandler);
+    protected void generateSerdBenchmarkServer(GoWriter writer) {
     }
 
-    public void generateBenchmarkFunction(GoWriter writer) {
+    public void generateSerdBenchmarkTestCaseValues(GoWriter writer, T testCase) {
+        generateTestCaseValues(writer, testCase);
+    }
+
+    public void generateSerdBenchmarkIteration(GoWriter writer, String clientName) {}
+
+    public void generateSerdBenchmarkFunction(GoWriter writer) {
         writer.addUseImports(SmithyGoDependency.TESTING);
-        writer.openBlock("func " + benchmarkFuncNameFormat() + "(b *testing.B) {", "}", benchmarkFuncNameArgs(),
+        writer.openBlock("func " + serdBenchmarkFunctionNameFormat() + "(t *testing.T) {", "}", serdBenchmarkFuncNameArgs(),
                 () -> {
                     generateTestSetup(writer);
 
@@ -298,19 +302,62 @@ public abstract class HttpProtocolUnitTestGenerator<T extends HttpMessageTestCas
                             }
 
                             writer.openBlock("$S: {", "},", testCase.getId(), () -> {
-                                generateTestCaseValues(writer, testCase);
+                                generateSerdBenchmarkTestCaseValues(writer, testCase);
                             });
                         }
                     });
 
                     writer.openBlock("for name, c := range cases {", "}", () -> {
-                        writer.openBlock("b.Run(name, func(b *testing.B) {", "})", () -> {
-                            generateBenchmarkBodySetup(writer);
-                            generateBenchmarkServer(writer);
-                            generateTestClient(writer, "client");
-                            writer.openBlock("for i := 0; i < b.N; i++ {", "}", () -> {
-                                generateBenchmarkInvokeClientOperation(writer, "client");
+                        writer.openBlock("t.Run(name, func(t *testing.T) {", "})", () -> {
+                            generateSerdBenchmarkBodySetup(writer);
+                            generateSerdBenchmarkServer(writer);
+                            generateSerdBenchmarkTestClient(writer, "client");
+                            writer.addUseImports(SmithyGoDependency.TIME);
+                            writer.addUseImports(SmithyGoDependency.SLICES);
+                            writer.addUseImports(SmithyGoDependency.MATH);
+                            writer.writeGoTemplate("""
+                                timings := make([]time.Duration, 0)
+                                benchmarkStart := time.Now()
+                            """);
+                            writer.openBlock("for i := 0; i < 10000; i++ {", "}", () -> {
+                                generateSerdBenchmarkIteration(writer, "client");
                             });
+                            // generate benchmark stat code
+                            writer.writeGoTemplate("""
+                                    mean := float64(0)
+                                    n := len(timings)
+                                    slices.Sort(timings)
+                                    stddev := float64(0)
+                                    for _, t := range(timings) {
+                                        mean += float64(t) / float64(n)
+                                    }
+                                    p50 := timings[int64(float64(n-1)*0.5)]
+                                    p90 := timings[int64(float64(n-1)*0.9)]
+                                    p95 := timings[int64(float64(n-1)*0.95)]
+                                    p99 := timings[int64(float64(n-1)*0.99)]
+                                    for _, t := range(timings) {
+                                        stddev += (float64(t) - mean) * (float64(t) - mean) / float64(n)
+                                    }
+                                    stddev = math.Sqrt(stddev)
+                                    
+                                    t.Logf("p50: %v\\n", p50)
+                                    t.Logf("p90: %v\\n", p90)
+                                    t.Logf("p95: %v\\n", p95)
+                                    t.Logf("p99: %v\\n", p99)
+                                    t.Logf("mean: %v ns\\n", mean)
+                                    t.Logf("stddev: %v\\n", stddev)
+
+                                    addSerdBenchmarkResult(serdBenchmarkResult{
+                                        ID:     name,
+                                        N:      n,
+                                        Mean:   mean,
+                                        P50:    float64(p50),
+                                        P90:    float64(p90),
+                                        P95:    float64(p95),
+                                        P99:    float64(p99),
+                                        StdDev: stddev,
+                                    })
+                                    """);
                         });
                     });
                 });

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestGenerator.java
@@ -316,10 +316,19 @@ public abstract class HttpProtocolUnitTestGenerator<T extends HttpMessageTestCas
                             writer.addUseImports(SmithyGoDependency.SLICES);
                             writer.addUseImports(SmithyGoDependency.MATH);
                             writer.writeGoTemplate("""
+                                const (
+                                    // benchmarkIterations collects enough samples for stable percentile metrics.
+                                    benchmarkIterations = 10_000
+                                    // benchmarkWarmupIterations excludes startup effects from measurements.
+                                    benchmarkWarmupIterations = 1_000
+                                    // maxBenchmarkDuration prevents a slow case from delaying the benchmark suite.
+                                    maxBenchmarkDuration = 30 * time.Second
+                                )
+
                                 timings := make([]time.Duration, 0)
                                 benchmarkStart := time.Now()
                             """);
-                            writer.openBlock("for i := 0; i < 10000; i++ {", "}", () -> {
+                            writer.openBlock("for i := 0; i < benchmarkIterations; i++ {", "}", () -> {
                                 generateSerdBenchmarkIteration(writer, "client");
                             });
                             // generate benchmark stat code

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestRequestGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestRequestGenerator.java
@@ -22,7 +22,6 @@ import static software.amazon.smithy.go.codegen.SmithyGoDependency.SMITHY_REQUES
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
@@ -264,10 +263,10 @@ public class HttpProtocolUnitTestRequestGenerator extends HttpProtocolUnitTestGe
                 }
 
                 serializeEnd := time.Now()
-                if i >= 1000 {
+                if i >= benchmarkWarmupIterations {
                     timings = append(timings, serializeEnd.Sub(serializeStart))
                 }
-                if benchmarkStart.Add(30000000000).Before(serializeEnd) {
+                if benchmarkStart.Add(maxBenchmarkDuration).Before(serializeEnd) {
                     break
                 }
                 """);

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestRequestGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestRequestGenerator.java
@@ -22,14 +22,17 @@ import static software.amazon.smithy.go.codegen.SmithyGoDependency.SMITHY_REQUES
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SchemaGenerator;
 import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.go.codegen.SymbolUtils;
 import software.amazon.smithy.model.traits.RequestCompressionTrait;
+import software.amazon.smithy.protocoltests.traits.AppliesTo;
 import software.amazon.smithy.protocoltests.traits.HttpRequestTestCase;
 import software.amazon.smithy.utils.MapUtils;
 
@@ -71,13 +74,13 @@ public class HttpProtocolUnitTestRequestGenerator extends HttpProtocolUnitTestGe
     }
 
     @Override
-    protected String benchmarkFuncNameFormat() {
-        return "BenchmarkClient_$L_$LSerialize";
+    protected Object[] serdBenchmarkFuncNameArgs() {
+        return new Object[]{opSymbol.getName(), protocolName};
     }
 
     @Override
-    protected Object[] benchmarkFuncNameArgs() {
-        return new Object[]{opSymbol.getName(), protocolName};
+    String serdBenchmarkFunctionNameFormat() {
+        return "TestSerdClient_$L_$L";
     }
 
     /**
@@ -230,28 +233,52 @@ public class HttpProtocolUnitTestRequestGenerator extends HttpProtocolUnitTestGe
     }
 
     @Override
-    protected void generateBenchmarkBodySetup(GoWriter writer) {
-        // No request capture needed for benchmarks.
+    protected void generateSerdBenchmarkBodySetup(GoWriter writer) {
+        var opSchemaName = SchemaGenerator.getSchemaRef(operation, service);
+        var inputSchemaName = SchemaGenerator.getSchemaRef(
+                model.expectShape(operation.getInputShape()), service);
+        var outputSchemaName = SchemaGenerator.getSchemaRef(
+                model.expectShape(operation.getOutputShape()), service);
+
+        writer.addUseImports(SmithyGoDependency.SMITHY);
+        writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_TRANSPORT);
+        writer.addUseImports(SmithyGoDependency.CONTEXT);
+        writer.addImport(settings.getModuleName() + "/schemas", "schemas");
+        writer.write("""
+                protocol := New(Options{}).options.Protocol
+                opSchema := smithy.NewOperationSchema($L, $L, $L)
+                """, opSchemaName, inputSchemaName, outputSchemaName);
     }
 
     @Override
-    protected void generateBenchmarkServer(GoWriter writer) {
-        writer.write("serverURL := \"http://localhost:8888/\"");
-        writer.pushState();
-        writer.putContext("parse", SymbolUtils.createValueSymbolBuilder("Parse", SmithyGoDependency.NET_URL)
-                .build());
-        writer.write("""
-                     if c.Host != nil {
-                         u, err := $parse:T(serverURL)
-                         if err != nil {
-                             panic(err)
-                         }
-                         u.Path = c.Host.Path
-                         u.RawPath = c.Host.RawPath
-                         u.RawQuery = c.Host.RawQuery
-                         serverURL = u.String()
-                     }""");
-        writer.popState();
+    public void generateSerdBenchmarkIteration(GoWriter writer, String clientName) {
+        writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_TRANSPORT);
+        writer.addUseImports(SmithyGoDependency.CONTEXT);
+        writer.writeGoTemplate("""
+                req := smithyhttp.NewStackRequest().(*smithyhttp.Request)
+
+                serializeStart := time.Now()
+                err := protocol.SerializeRequest(context.Background(), opSchema, c.Params, req)
+                if err != nil {
+                    t.Fatalf("error when running serd test for %s: %v", name, err)
+                }
+
+                serializeEnd := time.Now()
+                if i >= 1000 {
+                    timings = append(timings, serializeEnd.Sub(serializeStart))
+                }
+                if benchmarkStart.Add(30000000000).Before(serializeEnd) {
+                    break
+                }
+                """);
+    }
+
+    @Override
+    protected void generateSerdBenchmarkServer(GoWriter writer) {
+    }
+
+    @Override
+    protected void generateSerdBenchmarkTestClient(GoWriter writer, String clientName) {
     }
 
     /**
@@ -310,12 +337,6 @@ public class HttpProtocolUnitTestRequestGenerator extends HttpProtocolUnitTestGe
                     "client", clientName
                     )));
         }
-    }
-
-    @Override
-    protected void generateBenchmarkInvokeClientOperation(GoWriter writer, String clientName) {
-        writer.addUseImports(SmithyGoDependency.CONTEXT);
-        writer.write("$L.$T(context.Background(), c.Params)", clientName, opSymbol);
     }
 
     /**

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestResponseErrorGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestResponseErrorGenerator.java
@@ -67,16 +67,6 @@ public class HttpProtocolUnitTestResponseErrorGenerator extends HttpProtocolUnit
         return new Object[]{opSymbol.getName(), errorSymbol.getName(), protocolName};
     }
 
-    @Override
-    protected String benchmarkFuncNameFormat() {
-        return "BenchmarkClient_$L_$L_$LDeserialize";
-    }
-
-    @Override
-    protected Object[] benchmarkFuncNameArgs() {
-        return new Object[]{opSymbol.getName(), errorSymbol.getName(), protocolName};
-    }
-
     /**
      * Hook to generate the parameter declarations as struct parameters into the test case's struct definition.
      * Must generate all test case parameters before returning.

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestResponseGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestResponseGenerator.java
@@ -17,11 +17,14 @@
 
 package software.amazon.smithy.go.codegen.integration;
 
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 import software.amazon.smithy.go.codegen.GoWriter;
+import software.amazon.smithy.go.codegen.SchemaGenerator;
 import software.amazon.smithy.go.codegen.SmithyGoDependency;
 import software.amazon.smithy.protocoltests.traits.HttpResponseTestCase;
+import software.amazon.smithy.utils.MapUtils;
 
 /**
  * Generates HTTP protocol unit tests for HTTP response test cases.
@@ -59,13 +62,13 @@ public class HttpProtocolUnitTestResponseGenerator extends HttpProtocolUnitTestG
     }
 
     @Override
-    protected String benchmarkFuncNameFormat() {
-        return "BenchmarkClient_$L_$LDeserialize";
+    protected Object[] serdBenchmarkFuncNameArgs() {
+        return new Object[]{opSymbol.getName(), protocolName};
     }
 
     @Override
-    protected Object[] benchmarkFuncNameArgs() {
-        return new Object[]{opSymbol.getName(), protocolName};
+    String serdBenchmarkFunctionNameFormat() {
+        return "TestDeserdClient_$L_$L";
     }
 
     /**
@@ -197,14 +200,89 @@ public class HttpProtocolUnitTestResponseGenerator extends HttpProtocolUnitTestG
     }
 
     @Override
-    protected void generateBenchmarkInvokeClientOperation(GoWriter writer, String clientName) {
-        writer.addUseImports(SmithyGoDependency.CONTEXT);
-        writer.write("$L.$T(context.Background(), &params)", clientName, opSymbol);
+    public void generateSerdBenchmarkTestCaseValues(GoWriter writer, HttpResponseTestCase testCase) {
+        writeStructField(writer, "StatusCode", testCase.getCode());
+        writeHeaderStructField(writer, "Header", testCase.getHeaders());
+
+        testCase.getBodyMediaType().ifPresent(mediaType -> {
+            writeStructField(writer, "BodyMediaType", "$S", mediaType);
+        });
+        testCase.getBody().ifPresent(body -> {
+            var mediaType = testCase.getBodyMediaType().orElse("");
+            if (mediaType.equalsIgnoreCase("application/cbor") || testCase.getProtocol().toString().toLowerCase().contains("cbor")) {
+                writeStructField(writer, "Body", """
+                        func() []byte {
+                            p, err := $T.DecodeString(`$L`)
+                            if err != nil {
+                                panic(err)
+                            }
+
+                            return p
+                        }()""", SmithyGoDependency.BASE64.func("StdEncoding"), body.trim());
+            } else {
+                writeStructField(writer, "Body", "[]byte(`$L`)", body);
+            }
+        });
+
+        writeStructField(writer, "ExpectResult", outputShape, testCase.getParams());
     }
 
     @Override
-    protected void generateBenchmarkBodySetup(GoWriter writer) {
-        writer.write("var params $T", inputSymbol);
+    public void generateSerdBenchmarkIteration(GoWriter writer, String clientName) {
+        writer.addUseImports(SmithyGoDependency.CONTEXT);
+        writer.addUseImports(SmithyGoDependency.SMITHY_HTTP_TRANSPORT);
+        writer.addUseImports(SmithyGoDependency.NET_HTTP);
+        writer.writeGoTemplate("""
+                resp := &smithyhttp.Response{
+                    Response: &http.Response{
+                        StatusCode: c.StatusCode,
+                        Header:     c.Header.Clone(),
+                        Body:       io.NopCloser(bytes.NewReader(c.Body)),
+                    },
+                }
+                output := &$outputSymbol:T{}
+
+                deserializeStart := time.Now()
+                err := protocol.DeserializeResponse(context.Background(), opSchema, TypeRegistry, resp, output)
+                if err != nil {
+                    t.Fatalf("error when running deserd test for %s: %v", name, err)
+                }
+
+                deserializeEnd := time.Now()
+                if i >= 1000 {
+                    timings = append(timings, deserializeEnd.Sub(deserializeStart))
+                }
+                if benchmarkStart.Add(30000000000).Before(deserializeEnd) {
+                    break
+                }
+    """,
+                MapUtils.of("outputSymbol", outputSymbol));
+    }
+
+    @Override
+    protected void generateSerdBenchmarkBodySetup(GoWriter writer) {
+        var opSchemaName = SchemaGenerator.getSchemaRef(operation, service);
+        var inputSchemaName = SchemaGenerator.getSchemaRef(
+                model.expectShape(operation.getInputShape()), service);
+        var outputSchemaName = SchemaGenerator.getSchemaRef(
+                model.expectShape(operation.getOutputShape()), service);
+
+        writer.addUseImports(SmithyGoDependency.SMITHY);
+        writer.addUseImports(SmithyGoDependency.BYTES);
+        writer.addUseImports(SmithyGoDependency.IO);
+        writer.addImport(settings.getModuleName() + "/schemas", "schemas");
+        writer.write("""
+                protocol := New(Options{}).options.Protocol
+                opSchema := smithy.NewOperationSchema($L, $L, $L)
+                """, opSchemaName, inputSchemaName, outputSchemaName);
+    }
+
+    @Override
+    protected void generateSerdBenchmarkServer(GoWriter writer) {
+    }
+
+    @Override
+    protected void generateSerdBenchmarkTestClient(GoWriter writer, String clientName) {
     }
 
     /**

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestResponseGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestResponseGenerator.java
@@ -249,10 +249,10 @@ public class HttpProtocolUnitTestResponseGenerator extends HttpProtocolUnitTestG
                 }
 
                 deserializeEnd := time.Now()
-                if i >= 1000 {
+                if i >= benchmarkWarmupIterations {
                     timings = append(timings, deserializeEnd.Sub(deserializeStart))
                 }
-                if benchmarkStart.Add(30000000000).Before(deserializeEnd) {
+                if benchmarkStart.Add(maxBenchmarkDuration).Before(deserializeEnd) {
                     break
                 }
     """,

--- a/transport/http/protocol/awsquery/awsquery.go
+++ b/transport/http/protocol/awsquery/awsquery.go
@@ -11,7 +11,6 @@ import (
 	internalquery "github.com/aws/smithy-go/transport/http/protocol/internal/query"
 	internalxml "github.com/aws/smithy-go/transport/http/protocol/internal/xml"
 	internales "github.com/aws/smithy-go/internal/eventstream"
-	"github.com/aws/smithy-go/middleware"
 	"github.com/aws/smithy-go/traits"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 )
@@ -81,7 +80,7 @@ func (p *Protocol) SerializeRequest(
 		req.URL.Path = "/"
 	}
 
-	ss := internalquery.NewShapeSerializer(middleware.GetOperationName(ctx), p.version)
+	ss := internalquery.NewShapeSerializer(schema.ID().Name, p.version)
 	if schema.Input != nil {
 		in.Serialize(ss)
 	}
@@ -116,7 +115,7 @@ func (p *Protocol) DeserializeResponse(
 		return nil
 	}
 
-	inner, err := internalxml.ExtractElement(payload, middleware.GetOperationName(ctx)+"Result")
+	sd, err := internalxml.NewShapeDeserializerAtElement(payload, schema.ID().Name+"Result")
 	if err != nil {
 		if schema.Output == nil {
 			return nil
@@ -124,11 +123,6 @@ func (p *Protocol) DeserializeResponse(
 		return &smithy.DeserializationError{Err: err}
 	}
 
-	if len(inner) == 0 {
-		return nil
-	}
-
-	sd := internalxml.NewShapeDeserializer(inner)
 	return out.Deserialize(sd)
 }
 

--- a/transport/http/protocol/ec2query/ec2query.go
+++ b/transport/http/protocol/ec2query/ec2query.go
@@ -11,7 +11,6 @@ import (
 	internalquery "github.com/aws/smithy-go/transport/http/protocol/internal/query"
 	internalxml "github.com/aws/smithy-go/transport/http/protocol/internal/xml"
 	internales "github.com/aws/smithy-go/internal/eventstream"
-	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 )
 
@@ -80,7 +79,7 @@ func (p *Protocol) SerializeRequest(
 		req.URL.Path = "/"
 	}
 
-	ss := internalquery.NewShapeSerializer(middleware.GetOperationName(ctx), p.version,
+	ss := internalquery.NewShapeSerializer(schema.ID().Name, p.version,
 		func(o *internalquery.ShapeSerializerOptions) { o.EC2Mode = true },
 	)
 	if schema.Input != nil {
@@ -117,7 +116,7 @@ func (p *Protocol) DeserializeResponse(
 		return nil
 	}
 
-	inner, err := internalxml.ExtractElement(payload, middleware.GetOperationName(ctx)+"Response")
+	inner, err := internalxml.ExtractElement(payload, schema.ID().Name+"Response")
 	if err != nil {
 		return &smithy.DeserializationError{Err: err}
 	}

--- a/transport/http/protocol/internal/xml/shape_deserializer.go
+++ b/transport/http/protocol/internal/xml/shape_deserializer.go
@@ -5,8 +5,8 @@ import (
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
-	"math/big"
 	"math"
+	"math/big"
 	"strconv"
 	"strings"
 	"time"
@@ -93,6 +93,34 @@ func NewShapeDeserializer(p []byte) *ShapeDeserializer {
 	return &ShapeDeserializer{
 		dec:   xml.NewDecoder(bytes.NewReader(p)),
 		stack: serde.NewStack[deserCtx](),
+	}
+}
+
+// NewShapeDeserializerAtElement scans payload for the first element named
+// `name` and returns a ShapeDeserializer positioned to read that element as
+// its opening tag. Used for protocols that have an arbitrary nesting of their
+// modeled output shape in the wire response body.
+//
+// It forwards the underlying decoder's error, notably io.EOF, when the named
+// element is not found.
+func NewShapeDeserializerAtElement(payload []byte, name string) (*ShapeDeserializer, error) {
+	dec := xml.NewDecoder(bytes.NewReader(payload))
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+
+		start, ok := tok.(xml.StartElement)
+		if !ok || !strings.EqualFold(start.Name.Local, name) {
+			continue
+		}
+
+		return &ShapeDeserializer{
+			dec:       dec,
+			currStart: &start,
+			stack:     serde.NewStack[deserCtx](),
+		}, nil
 	}
 }
 


### PR DESCRIPTION
- remove old protocoltest benchmarks
- fix awsquery deser realloc issue w/ large payloads
- use schema name instead of ctx var in awsquery deser

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
