### PR TITLE
fix several http binding serde issues

### DIFF
--- a/.changelog/6078e4b1fc904fbd9f08d5439639fcb5.json
+++ b/.changelog/6078e4b1fc904fbd9f08d5439639fcb5.json
@@ -1,0 +1,8 @@
+{
+    "id": "6078e4b1-fc90-4fbd-9f08-d5439639fcb5",
+    "type": "bugfix",
+    "description": "Fix failure to deserialize any `@httpPayload` struct with a non-string member.",
+    "modules": [
+        "."
+    ]
+}

--- a/.changelog/ecc8ba8a6e074a8bb4af3d2832810465.json
+++ b/.changelog/ecc8ba8a6e074a8bb4af3d2832810465.json
@@ -1,0 +1,8 @@
+{
+    "id": "ecc8ba8a-6e07-4a8b-b4af-3d2832810465",
+    "type": "bugfix",
+    "description": "Fix failure to serialize any `@httpPayload` struct with a nested struct.",
+    "modules": [
+        "."
+    ]
+}

--- a/transport/http/protocol/internal/httpbinding/deserializer.go
+++ b/transport/http/protocol/internal/httpbinding/deserializer.go
@@ -30,9 +30,9 @@ type ShapeDeserializer struct {
 	// unlike an RPC-style protocol, members of the top-level output could be
 	// HTTP-bound, so we track that when ReadStruct is first called and "yield"
 	// them back to the caller through ReadStructMember
-	inBindings   bool
-	bindings     []*smithy.Schema
-	bindingIndex int
+	currentBinding *smithy.Schema
+	bindings       []*smithy.Schema
+	bindingIndex   int
 
 	inBody     bool
 	hasPayload bool
@@ -97,10 +97,10 @@ func (d *ShapeDeserializer) ReadStructMember() (*smithy.Schema, error) {
 	if d.bindingIndex < len(d.bindings) {
 		member := d.bindings[d.bindingIndex]
 		d.bindingIndex++
-		d.inBindings = true
+		d.currentBinding = member
 		return member, nil
 	}
-	d.inBindings = false
+	d.currentBinding = nil
 
 	if d.hasPayload { // i.e. no unbound members
 		d.depth--
@@ -128,7 +128,7 @@ func (d *ShapeDeserializer) ReadString(s *smithy.Schema, v *string) error {
 		d.headerListIdx++
 		return nil
 	}
-	if d.inBindings {
+	if d.isCurrentBinding(s) {
 		if _, ok := isHTTPHeader(s); ok {
 			hv, err := d.readHeaderString(s)
 			if err != nil {
@@ -152,7 +152,7 @@ func (d *ShapeDeserializer) ReadString(s *smithy.Schema, v *string) error {
 
 // ReadBool implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadBool(s *smithy.Schema, v *bool) error {
-	if !d.inBindings {
+	if !d.inHeaderList && !d.isCurrentBinding(s) {
 		return d.body.ReadBool(s, v)
 	}
 
@@ -176,7 +176,7 @@ func (d *ShapeDeserializer) ReadBool(s *smithy.Schema, v *bool) error {
 
 // ReadInt8 implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadInt8(s *smithy.Schema, v *int8) error {
-	if !d.inBindings {
+	if !d.inHeaderList && !d.isCurrentBinding(s) {
 		return d.body.ReadInt8(s, v)
 	}
 	return readHeaderInt[int8](d, s, v)
@@ -184,7 +184,7 @@ func (d *ShapeDeserializer) ReadInt8(s *smithy.Schema, v *int8) error {
 
 // ReadInt16 implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadInt16(s *smithy.Schema, v *int16) error {
-	if !d.inBindings {
+	if !d.inHeaderList && !d.isCurrentBinding(s) {
 		return d.body.ReadInt16(s, v)
 	}
 	return readHeaderInt[int16](d, s, v)
@@ -192,7 +192,7 @@ func (d *ShapeDeserializer) ReadInt16(s *smithy.Schema, v *int16) error {
 
 // ReadInt32 implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadInt32(s *smithy.Schema, v *int32) error {
-	if !d.inBindings {
+	if !d.inHeaderList && !d.isCurrentBinding(s) {
 		return d.body.ReadInt32(s, v)
 	}
 
@@ -210,7 +210,7 @@ func (d *ShapeDeserializer) ReadInt32(s *smithy.Schema, v *int32) error {
 
 // ReadInt64 implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadInt64(s *smithy.Schema, v *int64) error {
-	if !d.inBindings {
+	if !d.inHeaderList && !d.isCurrentBinding(s) {
 		return d.body.ReadInt64(s, v)
 	}
 	return readHeaderInt[int64](d, s, v)
@@ -218,7 +218,7 @@ func (d *ShapeDeserializer) ReadInt64(s *smithy.Schema, v *int64) error {
 
 // ReadFloat32 implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadFloat32(s *smithy.Schema, v *float32) error {
-	if !d.inBindings {
+	if !d.inHeaderList && !d.isCurrentBinding(s) {
 		return d.body.ReadFloat32(s, v)
 	}
 	return readHeaderFloat[float32](d, s, v)
@@ -226,7 +226,7 @@ func (d *ShapeDeserializer) ReadFloat32(s *smithy.Schema, v *float32) error {
 
 // ReadFloat64 implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadFloat64(s *smithy.Schema, v *float64) error {
-	if !d.inBindings {
+	if !d.inHeaderList && !d.isCurrentBinding(s) {
 		return d.body.ReadFloat64(s, v)
 	}
 	return readHeaderFloat[float64](d, s, v)
@@ -237,7 +237,7 @@ func (d *ShapeDeserializer) ReadTime(s *smithy.Schema, v *time.Time) error {
 	if d.inHeaderList {
 		return d.readHeaderListTime(func(t time.Time) { *v = t })
 	}
-	if d.inBindings {
+	if d.isCurrentBinding(s) {
 		t, err := d.readHeaderTime(s)
 		if err != nil {
 			return err
@@ -271,7 +271,7 @@ func (d *ShapeDeserializer) readHeaderListTime(assign func(time.Time)) error {
 
 // ReadBlob implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadBlob(s *smithy.Schema, v *[]byte) error {
-	if !d.inBindings {
+	if !d.isCurrentBinding(s) {
 		return d.body.ReadBlob(s, v)
 	}
 
@@ -296,7 +296,7 @@ func (d *ShapeDeserializer) ReadBlob(s *smithy.Schema, v *[]byte) error {
 
 // ReadList implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadList(s *smithy.Schema) error {
-	if !d.inBindings {
+	if !d.isCurrentBinding(s) {
 		return d.body.ReadList(s)
 	}
 
@@ -340,7 +340,7 @@ func (d *ShapeDeserializer) ReadListItem(s *smithy.Schema) (bool, error) {
 
 // ReadMap implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadMap(s *smithy.Schema) error {
-	if !d.inBindings {
+	if !d.isCurrentBinding(s) {
 		return d.body.ReadMap(s)
 	}
 
@@ -391,6 +391,12 @@ func (d *ShapeDeserializer) ReadDocument(s *smithy.Schema, v *document.Value) er
 // ReadUnion implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadUnion(s *smithy.Schema) (*smithy.Schema, error) {
 	return d.body.ReadUnion(s)
+}
+
+// whether the schema we're operating right now is the current HTTP binding
+// that we gave back to the caller
+func (d *ShapeDeserializer) isCurrentBinding(schema *smithy.Schema) bool {
+	return schema != nil && schema == d.currentBinding
 }
 
 func (d *ShapeDeserializer) isBindingSet(schema *smithy.Schema) bool {

--- a/transport/http/protocol/internal/httpbinding/deserializer_test.go
+++ b/transport/http/protocol/internal/httpbinding/deserializer_test.go
@@ -1,0 +1,151 @@
+package httpbinding
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/prelude"
+	"github.com/aws/smithy-go/traits"
+	internaljson "github.com/aws/smithy-go/transport/http/protocol/internal/json"
+)
+
+// nested holds the deserialized values of the payload-targeted structure.
+type nested struct {
+	Str       string
+	Bool      bool
+	Int       int32
+	Float     float64
+	CreatedAt time.Time
+	List      []string
+	Map       map[string]string
+	ETag      string
+}
+
+func nestedSchemas() (out, target *smithy.Schema) {
+	strList := smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "StrList"}, smithy.ShapeTypeList, 1)
+	strList.AddMember("member", prelude.String)
+
+	strMap := smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "StrMap"}, smithy.ShapeTypeMap, 2)
+	strMap.AddMember("key", prelude.String)
+	strMap.AddMember("value", prelude.String)
+
+	target = smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "Nested"}, smithy.ShapeTypeStructure, 7)
+	target.AddMember("str", prelude.String)
+	target.AddMember("bool", prelude.Boolean)
+	target.AddMember("int", prelude.Integer)
+	target.AddMember("float", prelude.Double)
+	target.AddMember("createdAt", prelude.Timestamp, &traits.TimestampFormat{Format: "date-time"})
+	target.AddMember("list", strList)
+	target.AddMember("map", strMap)
+
+	out = smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "Output"}, smithy.ShapeTypeStructure, 2)
+	out.AddMember("payload", target, &traits.HTTPPayload{})
+	out.AddMember("etag", prelude.String, &traits.HTTPHeader{Name: "ETag"})
+	return out, target
+}
+
+// deserializeNested drives deserialization the way generated code does.
+func deserializeNested(d smithy.ShapeDeserializer, out *smithy.Schema, v *nested) error {
+	return smithy.ReadStruct(d, out, func(ms *smithy.Schema) error {
+		if ms.MemberName() == "etag" {
+			return d.ReadString(ms, &v.ETag)
+		}
+		if ms.MemberName() != "payload" {
+			return nil
+		}
+		return smithy.ReadStruct(d, ms, func(ms *smithy.Schema) error {
+			switch ms.MemberName() {
+			case "str":
+				return d.ReadString(ms, &v.Str)
+			case "bool":
+				return d.ReadBool(ms, &v.Bool)
+			case "int":
+				return d.ReadInt32(ms, &v.Int)
+			case "float":
+				return d.ReadFloat64(ms, &v.Float)
+			case "createdAt":
+				return d.ReadTime(ms, &v.CreatedAt)
+			case "list":
+				return smithy.ReadList(d, ms, func() error {
+					var s string
+					if err := d.ReadString(ms.ListMember(), &s); err != nil {
+						return err
+					}
+					v.List = append(v.List, s)
+					return nil
+				})
+			case "map":
+				v.Map = map[string]string{}
+				return smithy.ReadMap(d, ms, func(k string) error {
+					var s string
+					if err := d.ReadString(ms.MapValue(), &s); err != nil {
+						return err
+					}
+					v.Map[k] = s
+					return nil
+				})
+			}
+			return nil
+		})
+	})
+}
+
+// A structure member bound with @httpPayload is a "binding" at the top level,
+// but everything inside of it comes from the body. Prior to the fix for this,
+// the deserializer left inBindings set while descending into the payload
+// structure, causing nested members to be read out of (nonexistent) HTTP
+// headers.
+func TestDeserializeNestedPayloadStruct(t *testing.T) {
+	payload := []byte(`{` +
+		`"str":"foo",` +
+		`"bool":true,` +
+		`"int":7,` +
+		`"float":1.5,` +
+		`"createdAt":"2000-01-01T00:00:00Z",` +
+		`"list":["a","b"],` +
+		`"map":{"k":"v"}` +
+		`}`)
+
+	resp := &http.Response{
+		StatusCode: 200,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+			"Etag":         []string{"__ETag__"},
+		},
+	}
+
+	out, _ := nestedSchemas()
+	d := NewShapeDeserializer(resp, internaljson.NewShapeDeserializer(payload), payload)
+
+	var v nested
+	if err := deserializeNested(d, out, &v); err != nil {
+		t.Fatalf("deserialize: %v", err)
+	}
+
+	if v.Str != "foo" {
+		t.Errorf("str: expect %q, got %q", "foo", v.Str)
+	}
+	if !v.Bool {
+		t.Errorf("bool: expect true, got false")
+	}
+	if v.Int != 7 {
+		t.Errorf("int: expect 7, got %d", v.Int)
+	}
+	if v.Float != 1.5 {
+		t.Errorf("float: expect 1.5, got %v", v.Float)
+	}
+	if expect := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC); !v.CreatedAt.Equal(expect) {
+		t.Errorf("createdAt: expect %v, got %v", expect, v.CreatedAt)
+	}
+	if len(v.List) != 2 || v.List[0] != "a" || v.List[1] != "b" {
+		t.Errorf("list: expect [a b], got %v", v.List)
+	}
+	if len(v.Map) != 1 || v.Map["k"] != "v" {
+		t.Errorf("map: expect map[k:v], got %v", v.Map)
+	}
+	if v.ETag != "__ETag__" {
+		t.Errorf("etag: expect %q, got %q", "__ETag__", v.ETag)
+	}
+}

--- a/transport/http/protocol/internal/httpbinding/serializer.go
+++ b/transport/http/protocol/internal/httpbinding/serializer.go
@@ -12,11 +12,11 @@ import (
 	"time"
 
 	"github.com/aws/smithy-go"
-	awsjson "github.com/aws/smithy-go/transport/http/protocol/internal/json"
 	"github.com/aws/smithy-go/document"
 	httpbinding "github.com/aws/smithy-go/encoding/httpbinding"
 	"github.com/aws/smithy-go/traits"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
+	awsjson "github.com/aws/smithy-go/transport/http/protocol/internal/json"
 )
 
 // ShapeSerializer routes top-level input struct members to their HTTP binding
@@ -52,6 +52,8 @@ type ShapeSerializer struct {
 
 	noBody           bool
 	hasStructPayload bool
+
+	depth int
 }
 
 // ShapeSerializerOptions configures a ShapeSerializer.
@@ -554,7 +556,9 @@ func (s *ShapeSerializer) CloseMap() {
 
 // WriteStruct implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) WriteStruct(schema *smithy.Schema) {
-	if schema.MemberName() != "" { // the root
+	s.depth++
+
+	if s.depth > 1 { // not the root, HTTP bindings don't apply
 		if isHTTPPayload(schema) {
 			s.hasStructPayload = true
 		}
@@ -582,16 +586,20 @@ func (s *ShapeSerializer) WriteStruct(schema *smithy.Schema) {
 		return
 	}
 
+	// IMPLICIT payload, ie. no @httpPayload but there is at least one member
+	// that isn't http-bound
 	s.input.WriteStruct(schema)
 }
 
 // CloseStruct implements [smithy.ShapeSerializer].
 func (s *ShapeSerializer) CloseStruct() {
-	if s.noBody {
-		s.noBody = false
-		return
+	s.depth--
+
+	// we skip the close if there was no payload to begin with, implicit or
+	// otherwise
+	if s.depth > 0 || !s.noBody {
+		s.input.CloseStruct()
 	}
-	s.input.CloseStruct()
 }
 
 // WriteUnion implements [smithy.ShapeSerializer].

--- a/transport/http/protocol/internal/httpbinding/serializer_test.go
+++ b/transport/http/protocol/internal/httpbinding/serializer_test.go
@@ -1,0 +1,113 @@
+package httpbinding
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/prelude"
+	"github.com/aws/smithy-go/traits"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	internaljson "github.com/aws/smithy-go/transport/http/protocol/internal/json"
+)
+
+// payloadInput models an operation input whose only members are an
+// @httpPayload structure and an @httpHeader, i.e. it has no unbound body
+// members of its own. The payload structure contains a nested structure.
+type payloadInput struct{}
+
+func (payloadInput) Serialize(s smithy.ShapeSerializer) {
+	out, payload, inner := payloadSchemas()
+
+	s.WriteStruct(out)
+	s.WriteString(out.Member("etag"), "__ETag__")
+
+	s.WriteStruct(payload)
+	s.WriteString(payload.Member("arn"), "__Arn__")
+	s.WriteStruct(payload.Member("inner"))
+	s.WriteString(inner.Member("changeType"), "DOWNGRADE")
+	s.CloseStruct()
+	// these come after the nested struct: if its closing brace is dropped
+	// they end up nested inside of it
+	s.WriteString(payload.Member("status"), "PENDING_APPROVAL")
+	s.CloseStruct()
+
+	s.CloseStruct()
+}
+
+func payloadSchemas() (out, payload, inner *smithy.Schema) {
+	inner = smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "Inner"}, smithy.ShapeTypeStructure, 1)
+	inner.AddMember("changeType", prelude.String)
+
+	payload = smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "Payload"}, smithy.ShapeTypeStructure, 3)
+	payload.AddMember("arn", prelude.String)
+	payload.AddMember("inner", inner)
+	payload.AddMember("status", prelude.String)
+
+	out = smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "Input"}, smithy.ShapeTypeStructure, 2,
+		&traits.HTTP{Method: "POST", URI: "/"})
+	out.AddMember("payload", payload, &traits.HTTPPayload{})
+	out.AddMember("etag", prelude.String, &traits.HTTPHeader{Name: "ETag"})
+	return out, payload, inner
+}
+
+// An input with no body members of its own suppresses the top-level struct
+// delimiters, since the body comes entirely from the @httpPayload member.
+// That suppression must not be applied to structs nested inside the payload:
+// prior to the fix for this, the first nested CloseStruct consumed the
+// top-level suppression flag and its closing brace was dropped, so members
+// following the nested struct were emitted inside of it.
+func TestSerializeNestedStructInPayload(t *testing.T) {
+	out, _, _ := payloadSchemas()
+
+	req := smithyhttp.NewStackRequest().(*smithyhttp.Request)
+	s, err := NewShapeSerializer(out, req, internaljson.NewShapeSerializer())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	in := payloadInput{}
+	in.Serialize(s)
+	if err := s.Build(nil, "application/json"); err != nil {
+		t.Fatal(err)
+	}
+
+	built := req.Build(context.Background())
+	body, err := io.ReadAll(built.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal body %s: %v", body, err)
+	}
+
+	expect := map[string]any{
+		"arn":    "__Arn__",
+		"status": "PENDING_APPROVAL",
+		"inner": map[string]any{
+			"changeType": "DOWNGRADE",
+		},
+	}
+	if !jsonEqual(got, expect) {
+		t.Errorf("body mismatch\n\tgot:    %s\n\texpect: %v", body, expect)
+	}
+	if v := built.Header.Get("ETag"); v != "__ETag__" {
+		t.Errorf("ETag: expect %q, got %q", "__ETag__", v)
+	}
+}
+
+func jsonEqual(a, b any) bool {
+	ab, err := json.Marshal(a)
+	if err != nil {
+		return false
+	}
+	bb, err := json.Marshal(b)
+	if err != nil {
+		return false
+	}
+	return string(ab) == string(bb)
+}

--- a/transport/http/protocol/internal/httpbinding/union_payload_test.go
+++ b/transport/http/protocol/internal/httpbinding/union_payload_test.go
@@ -1,0 +1,58 @@
+package httpbinding
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/prelude"
+	"github.com/aws/smithy-go/traits"
+	internaljson "github.com/aws/smithy-go/transport/http/protocol/internal/json"
+)
+
+// A union targeted by @httpPayload is reached without going through
+// ReadStruct's depth counter, so it is a second, independent way for bindings
+// to leak into body members.
+func TestDeserializeUnionPayload(t *testing.T) {
+	u := smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "U"}, smithy.ShapeTypeUnion, 2)
+	u.AddMember("at", prelude.Timestamp, &traits.TimestampFormat{Format: "date-time"})
+	u.AddMember("name", prelude.String)
+
+	out := smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "Out"}, smithy.ShapeTypeStructure, 2)
+	out.AddMember("payload", u, &traits.HTTPPayload{})
+	out.AddMember("etag", prelude.String, &traits.HTTPHeader{Name: "ETag"})
+
+	payload := []byte(`{"at":"2000-01-01T00:00:00Z"}`)
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Etag": []string{"__ETag__"}},
+	}
+	d := NewShapeDeserializer(resp, internaljson.NewShapeDeserializer(payload), payload)
+
+	var at time.Time
+	var etag string
+	err := smithy.ReadStruct(d, out, func(ms *smithy.Schema) error {
+		switch ms.MemberName() {
+		case "etag":
+			return d.ReadString(ms, &etag)
+		case "payload":
+			return smithy.ReadUnion(d, ms, func(vs *smithy.Schema) error {
+				if vs.MemberName() == "at" {
+					return d.ReadTime(vs, &at)
+				}
+				return nil
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("deserialize: %v", err)
+	}
+	if expect := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC); !at.Equal(expect) {
+		t.Errorf("at: expect %v, got %v", expect, at)
+	}
+	if etag != "__ETag__" {
+		t.Errorf("etag: expect %q, got %q", "__ETag__", etag)
+	}
+}


### PR DESCRIPTION
two issues:
* deserialization inside an httpPayload struct would still think it was in http bindings and go to read from the headers etc. rather than the body, I just replaced the flaky inBindings flag with a more stateful check
* serialization of a nested struct inside httpPayload struct would failure to properly close the object } when existing it. the only place we're supposed to skip that close is on the top-level struct when there wasn't a body, fixed with a depth check

relates aws/aws-sdk-go-v2#3504