### PR TITLE
fix schema-serde sparse collection deser to not point to the same value

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/ListDeserializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/ListDeserializer.java
@@ -69,7 +69,6 @@ public class ListDeserializer implements Writable {
     private void renderSparse(GoWriter writer) {
         writer.writeGoTemplate("""
                 func deserialize$shapeName:L(d smithy.ShapeDeserializer, s *smithy.Schema, v *$symbol:T) error {
-                    var vv $memberSymbol:T
                     return smithy.ReadList(d, s, func() error {
                         if isNil, err := d.ReadNil(s.ListMember()); err != nil {
                             return err
@@ -78,6 +77,9 @@ public class ListDeserializer implements Writable {
                             return nil
                         }
 
+                        // vv must be declared per-element for sparse since we
+                        // are taking its pointer
+                        var vv $memberSymbol:T
                         $zeroValue:W
                         if err := $deserializeMember:W; err != nil {
                             return err

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/MapDeserializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/MapDeserializer.java
@@ -71,7 +71,6 @@ public class MapDeserializer implements Writable {
         writer.writeGoTemplate("""
                 func deserialize$shapeName:L(d smithy.ShapeDeserializer, s *smithy.Schema, v *$symbol:T) error {
                     *v = make($symbol:T)
-                    var vv $valueSymbol:T
                     return smithy.ReadMap(d, s, func(k string) error {
                         if isNil, err := d.ReadNil(s.MapValue()); err != nil {
                             return err
@@ -80,6 +79,9 @@ public class MapDeserializer implements Writable {
                             return nil
                         }
 
+                        // vv must be declared per-element for sparse since we
+                        // are taking its pointer
+                        var vv $valueSymbol:T
                         $zeroValue:W
                         if err := $deserializeValue:W; err != nil {
                             return err


### PR DESCRIPTION
Found this while working on a new body of protocol tests with the Smithy team. Fortunately no released services that are on schema-serde in the downstream SDK are affected.

Schema-serde deserializers for sparse lists/maps declared the scratch variable once outside the read loop and appended `&vv` for every element, so every non-null element aliases the same variable and ends up as the last decoded value. Nulls are fine (appended as literal `nil`) but the non-null entries get overwritten.

```
["foo", null, "bar"]      -> ["bar", nil, "bar"]
{"a":1, "b":null, "c":3}  -> {"a":3, "b":nil, "c":3}
```

The existing sparse deserialize tests only ever have a *single null* element so this was not caught ([awsJson1_1/null.smithy](https://github.com/lucix-aws/smithy/blob/f466f110b255eb1f936e0618f18135bbab6c4dfb/smithy-aws-protocol-tests/model/awsJson1_1/null.smithy#L156-L172)):

```smithy
{
    id: "AwsJson11SparseListsDeserializeNull"
    protocol: awsJson1_1
    code: 200
    body: "{ \"sparseStringList\": [null] }"
    params: { sparseStringList: [null] }
}
```

Caught this with a new test like so:

```smithy
{
    id: "AwsJson10SparseListOfScalarsWithNullsResponse"
    protocol: awsJson1_0
    code: 200
    body: "{ \"strings\": [\"foo\", null, \"bar\"], \"integers\": [1, null, 3] }"
    params: { strings: ["foo", null, "bar"], integers: [1, null, 3] }
}
```