### PR TITLE
pool byte buffers on deserialize + string arena

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestResponseGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestResponseGenerator.java
@@ -235,9 +235,10 @@ public class HttpProtocolUnitTestResponseGenerator extends HttpProtocolUnitTestG
         writer.writeGoTemplate("""
                 resp := &smithyhttp.Response{
                     Response: &http.Response{
-                        StatusCode: c.StatusCode,
-                        Header:     c.Header.Clone(),
-                        Body:       io.NopCloser(bytes.NewReader(c.Body)),
+                        StatusCode:    c.StatusCode,
+                        Header:        c.Header.Clone(),
+                        ContentLength: int64(len(c.Body)),
+                        Body:          io.NopCloser(bytes.NewReader(c.Body)),
                     },
                 }
                 output := &$outputSymbol:T{}

--- a/internal/serde/read_payload_blob.go
+++ b/internal/serde/read_payload_blob.go
@@ -1,0 +1,34 @@
+package serde
+
+import (
+	"bytes"
+	"io"
+)
+
+// maxPresize bounds how large a buffer we will allocate up front from a
+// Content-Length header. Past this point we allocate maxPresize and let the read
+// grow the buffer to fit whatever actually arrives.
+//
+// We arbitrarily choose 512K.
+const maxPresize = 512 * 1024
+
+// ReadPayloadBlob consumes the given reader into a buffer that does not come
+// from (and will never be returned to) a pool, sizing it from contentLength
+// when that is known and within bounds.
+func ReadPayloadBlob(r io.Reader, contentLength int64) (*bytes.Buffer, error) {
+	buf := &bytes.Buffer{}
+	if contentLength > 0 {
+		presize := contentLength
+		if presize > maxPresize {
+			presize = maxPresize
+		}
+
+		// + bytes.MinRead prevents pointless doubling on EOF
+		buf.Grow(int(presize) + bytes.MinRead)
+	}
+
+	if _, err := buf.ReadFrom(r); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}

--- a/internal/serde/read_payload_blob_test.go
+++ b/internal/serde/read_payload_blob_test.go
@@ -1,0 +1,38 @@
+package serde
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestReadPayloadBlobHugeContentLength(t *testing.T) {
+	body := []byte("short")
+
+	buf, err := ReadPayloadBlob(bytes.NewReader(body), 64<<30)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(buf.Bytes(), body) {
+		t.Fatalf("got %q, want %q", buf.Bytes(), body)
+	}
+
+	if limit := int64(maxPresize) + bytes.MinRead + 64<<10; int64(buf.Cap()) > limit {
+		t.Errorf("capacity %d exceeds the presize cap %d", buf.Cap(), maxPresize)
+	}
+}
+
+func TestReadPayloadBlobWrongContentLength(t *testing.T) {
+	body := make([]byte, 8192)
+	for i := range body {
+		body[i] = byte(i)
+	}
+
+	buf, err := ReadPayloadBlob(bytes.NewReader(body), 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(buf.Bytes(), body) {
+		t.Fatal("body truncated when Content-Length understated it")
+	}
+}

--- a/internal/serde/string_arena.go
+++ b/internal/serde/string_arena.go
@@ -1,0 +1,58 @@
+package serde
+
+import "unsafe"
+
+// The size of a string arena is bounded, but not strictly by [min, max]:
+//   - Attempting to set a capacity below MinArenaSize will have no effect as
+//     beneath this limit it is not worth it. Calls to String with a capacity below
+//     this boundary will simply allocate.
+//   - An arena WILL be capped at MaxArenaSize.
+const (
+	MinArenaSize = 512
+	MaxArenaSize = 4096
+)
+
+// StringArena batches many small string allocations into one block.
+//
+// You MUST call Reset with the desired capacity before use. Failure to do so
+// will mean any calls to String will simply allocate and you won't get the
+// performance benefit of the arena.
+type StringArena struct {
+	buf []byte
+	cap int
+}
+
+// Reset prepares the arena for a new document, sizing its next block to cap.
+func (a *StringArena) Reset(cap int) {
+	if cap > MaxArenaSize {
+		cap = MaxArenaSize
+	}
+	a.buf = nil
+	a.cap = cap
+}
+
+// String attempts to intern a copy of b in the arena, returning a string slice
+// for it.
+//
+// If the arena is at capacity, it will just allocate a new string.
+func (a *StringArena) String(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+
+	if a.buf == nil { // lazy init, there might be no strings at all
+		if a.cap < MinArenaSize || len(b) > a.cap {
+			return string(b) // "not worth it" fallback
+		}
+
+		a.buf = make([]byte, 0, a.cap)
+	}
+
+	if len(b) > cap(a.buf)-len(a.buf) {
+		return string(b) // "over budget" fallback
+	}
+
+	off := len(a.buf)
+	a.buf = append(a.buf, b...)
+	return unsafe.String(&a.buf[off], len(b))
+}

--- a/internal/serde/string_arena.go
+++ b/internal/serde/string_arena.go
@@ -2,6 +2,14 @@ package serde
 
 import "unsafe"
 
+// ArenaPayloadFactor is the ratio at which we size string arenas to the payload
+// (clamped by StringArenaMin/Max)
+//
+// We limit arenas to 4k but smaller payloads likely don't need it, so we size
+// down (somewhat arbitrarily) until we hit the 512-byte floor at which we just
+// don't arena.
+const ArenaPayloadFactor = 4
+
 // The size of a string arena is bounded, but not strictly by [min, max]:
 //   - Attempting to set a capacity below MinArenaSize will have no effect as
 //     beneath this limit it is not worth it. Calls to String with a capacity below

--- a/internal/serde/string_arena_test.go
+++ b/internal/serde/string_arena_test.go
@@ -1,0 +1,107 @@
+package serde
+
+import (
+	"strings"
+	"testing"
+	"unsafe"
+)
+
+func TestStringArena_Basic(t *testing.T) {
+	var a StringArena
+	a.Reset(MaxArenaSize)
+	inputs := []string{"a", "", "hello", strings.Repeat("x", 100), "item", "amount"}
+	got := make([]string, len(inputs))
+	for i, in := range inputs {
+		got[i] = a.String([]byte(in))
+	}
+	for i, in := range inputs {
+		if got[i] != in {
+			t.Errorf("[%d] got %q, want %q", i, got[i], in)
+		}
+	}
+}
+
+func TestStringArena_SourceMutation(t *testing.T) {
+	var a StringArena
+	a.Reset(MaxArenaSize)
+	src := []byte("original")
+	s := a.String(src)
+
+	// the byte buffer this came from goes back into a pool and then is used
+	// for another response
+	copy(src, "MUTATED!")
+
+	if s != "original" {
+		t.Errorf("string changed with its source: got %q", s)
+	}
+}
+
+func TestStringArena_Offsets(t *testing.T) {
+	var a StringArena
+	a.Reset(MaxArenaSize)
+	first := a.String([]byte("first"))
+	second := a.String([]byte("second"))
+
+	if unsafe.StringData(first) == unsafe.StringData(second) {
+		t.Fatal("distinct strings share a start pointer")
+	}
+
+	// 2 should be right after 1, in literal memory
+	gap := uintptr(unsafe.Pointer(unsafe.StringData(second))) - uintptr(unsafe.Pointer(unsafe.StringData(first)))
+	if gap != uintptr(len(first)) {
+		t.Errorf("strings not contiguous in one block: gap %d, want %d", gap, len(first))
+	}
+}
+
+func TestStringArena_Reset(t *testing.T) {
+	var a StringArena
+	a.Reset(MaxArenaSize)
+	old := make([]string, 0, 64)
+	for i := 0; i < 64; i++ {
+		old = append(old, a.String([]byte(strings.Repeat("c", i%16+1))))
+	}
+
+	a.Reset(MaxArenaSize)
+	for i := 0; i < 200; i++ {
+		_ = a.String([]byte(strings.Repeat("z", i%16+1)))
+	}
+
+	// the zs shouldn't bleed into the cs
+	for i, s := range old {
+		if want := strings.Repeat("c", i%16+1); s != want {
+			t.Fatalf("[%d] string corrupted across Reset: got %q, want %q", i, s, want)
+		}
+	}
+}
+
+func TestStringArena_MinArenaSize(t *testing.T) {
+	var a StringArena
+	a.Reset(MinArenaSize - 1) // should just not arena
+
+	first := a.String([]byte("first"))
+	second := a.String([]byte("second"))
+
+	if first != "first" || second != "second" {
+		t.Fatalf("got %q, %q", first, second)
+	}
+	if a.buf != nil {
+		t.Errorf("arena allocated a block despite cap %d < MinArenaSize %d", MinArenaSize-1, MinArenaSize)
+	}
+}
+
+func TestStringArena_MaxArenaSize(t *testing.T) {
+	var a StringArena
+	a.Reset(MaxArenaSize + 1) // should clamp
+
+	huge := strings.Repeat("h", MaxArenaSize-1) // goes into arena
+	if got := a.String([]byte(huge)); got != huge {
+		t.Error("oversized string not returned intact")
+	}
+	hugest := strings.Repeat("hh", MaxArenaSize+1) // fallback
+	if got := a.String([]byte(hugest)); got != hugest {
+		t.Error("oversizeder string not returned intact")
+	}
+	if a.cap-len(a.buf) != 1 {
+		t.Errorf("arena should've been maxed out minus one byte")
+	}
+}

--- a/internal/sync/buffer_pool.go
+++ b/internal/sync/buffer_pool.go
@@ -1,0 +1,52 @@
+package sync
+
+import (
+	"bytes"
+	"io"
+	"sync"
+)
+
+// maxBufferSize is the largest buffer that will be returned to the pool.
+//
+// A pooled buffer retains the capacity its largest occupant forced it to grow
+// to, for the life of the pool. Dropping oversized buffers bounds that
+// retention, at the cost of re-growing after an unusually large response.
+//
+// We arbitrarily choose 64K.
+const maxBufferSize = 64 * 1024
+
+func newBuffer() any {
+	return new(bytes.Buffer)
+}
+
+// BufferPool pools bytes.Buffers for reading response bodies during protocol
+// deserialization.
+type BufferPool struct {
+	pool sync.Pool
+}
+
+// NewBufferPool returns a buffer pool ready for use.
+func NewBufferPool() *BufferPool {
+	return &BufferPool{
+		pool: sync.Pool{New: newBuffer},
+	}
+}
+
+// Get consumes the given reader into a buffer from the pool, returning that
+// buffer.
+func (p *BufferPool) Get(r io.Reader) (*bytes.Buffer, error) {
+	buf := p.pool.Get().(*bytes.Buffer)
+	if _, err := buf.ReadFrom(r); err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}
+
+// Put returns the buffer if it is within the cap limit.
+func (p *BufferPool) Put(buf *bytes.Buffer) {
+	if buf.Cap() <= maxBufferSize {
+		buf.Reset()
+		p.pool.Put(buf)
+	}
+}

--- a/internal/sync/buffer_pool_test.go
+++ b/internal/sync/buffer_pool_test.go
@@ -1,0 +1,41 @@
+package sync
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+)
+
+// exercises the pool the way protocols use it, with mixed sizes including
+// oversized that will drop
+func TestBufferPoolConcurrent(t *testing.T) {
+	p := NewBufferPool()
+
+	sizes := []int{16, 4096, 64 * 1024, maxBufferSize + 1}
+
+	var wg sync.WaitGroup
+	for g := 0; g < 16; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				size := sizes[(g+i)%len(sizes)]
+				fill := byte('a' + g%26)
+				want := bytes.Repeat([]byte{fill}, size)
+
+				buf, err := p.Get(bytes.NewReader(want))
+				if err != nil {
+					t.Errorf("goroutine %d: %v", g, err)
+					return
+				}
+				if !bytes.Equal(buf.Bytes(), want) {
+					t.Errorf("goroutine %d iter %d: content mismatch for size %d", g, i, size)
+					p.Put(buf)
+					return
+				}
+				p.Put(buf)
+			}
+		}(g)
+	}
+	wg.Wait()
+}

--- a/schema_ext.go
+++ b/schema_ext.go
@@ -9,13 +9,14 @@ import (
 // (JSON, CBOR, etc.) uses a distinct slot to cache precomputed data.
 type ExtensionID int
 
-const numExtensionSlots = 4
+const numExtensionSlots = 5
 
 const (
-	ExtJSON  ExtensionID = iota // transport/http/protocol/internal/json
-	ExtCBOR                     // transport/http/protocol/internal/cbor
-	ExtXML                      // transport/http/protocol/internal/xml
-	ExtQuery                    // transport/http/protocol/internal/query
+	ExtJSON        ExtensionID = iota // transport/http/protocol/internal/json
+	ExtCBOR                           // transport/http/protocol/internal/cbor
+	ExtXML                            // transport/http/protocol/internal/xml
+	ExtQuery                          // transport/http/protocol/internal/query
+	ExtHTTPBinding                    // transport/http/protocol/internal/httpbinding
 )
 
 // SchemaExtension retrieves or lazily computes the extension for the given

--- a/transport/http/protocol/awsjson/awsjson.go
+++ b/transport/http/protocol/awsjson/awsjson.go
@@ -7,15 +7,16 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/aws/smithy-go"
-	internaljson "github.com/aws/smithy-go/transport/http/protocol/internal/json"
 	internalerrors "github.com/aws/smithy-go/internal/errors"
 	internales "github.com/aws/smithy-go/internal/eventstream"
+	internalsync "github.com/aws/smithy-go/internal/sync"
 	smithyio "github.com/aws/smithy-go/io"
-	"github.com/aws/smithy-go/middleware"
 	"github.com/aws/smithy-go/traits"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
+	internaljson "github.com/aws/smithy-go/transport/http/protocol/internal/json"
 )
 
 // ProtocolOptions configures aws.protocols#awsJson1_0.
@@ -23,34 +24,26 @@ type ProtocolOptions struct{}
 
 // New10 returns an instance of the awsJson 1.0 protocol.
 func New10(service *smithy.ServiceSchema, opts ...func(*ProtocolOptions)) *Protocol {
-	var o ProtocolOptions
-	for _, fn := range opts {
-		fn(&o)
-	}
-	_, qc := smithy.SchemaTrait[*traits.AWSQueryCompatible](service.Schema)
-	return &Protocol{
-		version:         "1.0",
-		queryCompatible: qc,
-		serviceName:     service.Schema.ID().Name,
-		eventstream: &internales.Codec{
-			Serializer:   func() smithy.ShapeSerializer { return internaljson.NewShapeSerializer() },
-			Deserializer: func(p []byte) smithy.ShapeDeserializer { return internaljson.NewShapeDeserializer(p) },
-			ContentType:  "application/json",
-		},
-	}
+	return new("1.0", service, opts...)
 }
 
 // New11 returns an instance of the awsJson 1.1 protocol.
 func New11(service *smithy.ServiceSchema, opts ...func(*ProtocolOptions)) *Protocol {
+	return new("1.1", service, opts...)
+}
+
+func new(version string, service *smithy.ServiceSchema, opts ...func(*ProtocolOptions)) *Protocol {
 	var o ProtocolOptions
 	for _, fn := range opts {
 		fn(&o)
 	}
+
 	_, qc := smithy.SchemaTrait[*traits.AWSQueryCompatible](service.Schema)
 	return &Protocol{
-		version:         "1.1",
+		version:         version,
 		queryCompatible: qc,
 		serviceName:     service.Schema.ID().Name,
+		bufs:            internalsync.NewBufferPool(),
 		eventstream: &internales.Codec{
 			Serializer:   func() smithy.ShapeSerializer { return internaljson.NewShapeSerializer() },
 			Deserializer: func(p []byte) smithy.ShapeDeserializer { return internaljson.NewShapeDeserializer(p) },
@@ -65,6 +58,7 @@ type Protocol struct {
 	queryCompatible bool
 	serviceName     string
 
+	bufs        *internalsync.BufferPool
 	eventstream *internales.Codec
 }
 
@@ -89,7 +83,7 @@ func (p *Protocol) SerializeRequest(
 	if len(req.URL.Path) == 0 {
 		req.URL.Path = "/"
 	}
-	req.Header.Set("X-Amz-Target", fmt.Sprintf("%s.%s", p.serviceName, middleware.GetOperationName(ctx)))
+	req.Header.Set("X-Amz-Target", fmt.Sprintf("%s.%s", p.serviceName, schema.ID().Name))
 	if schema.IsInputEventStream() {
 		req.Header.Set("Content-Type", "application/vnd.amazon.eventstream")
 		return nil
@@ -101,7 +95,7 @@ func (p *Protocol) SerializeRequest(
 	}
 
 	if schema.Input == nil {
-		sreq, err := req.SetStream(bytes.NewReader([]byte("{}")))
+		sreq, err := req.SetStream(strings.NewReader("{}"))
 		if err != nil {
 			return fmt.Errorf("set stream: %w", err)
 		}
@@ -146,11 +140,13 @@ func (p *Protocol) DeserializeResponse(
 		return nil
 	}
 
-	payload, err := io.ReadAll(resp.Body)
+	buf, err := p.bufs.Get(resp.Body)
 	if err != nil {
 		return &smithy.DeserializationError{Err: err}
 	}
+	defer p.bufs.Put(buf)
 
+	payload := buf.Bytes()
 	if len(payload) == 0 {
 		return nil
 	}

--- a/transport/http/protocol/awsquery/awsquery.go
+++ b/transport/http/protocol/awsquery/awsquery.go
@@ -8,11 +8,12 @@ import (
 	"net/http"
 
 	"github.com/aws/smithy-go"
-	internalquery "github.com/aws/smithy-go/transport/http/protocol/internal/query"
-	internalxml "github.com/aws/smithy-go/transport/http/protocol/internal/xml"
 	internales "github.com/aws/smithy-go/internal/eventstream"
+	internalsync "github.com/aws/smithy-go/internal/sync"
 	"github.com/aws/smithy-go/traits"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
+	internalquery "github.com/aws/smithy-go/transport/http/protocol/internal/query"
+	internalxml "github.com/aws/smithy-go/transport/http/protocol/internal/xml"
 )
 
 // ProtocolOptions configures aws.protocols#awsQuery.
@@ -23,6 +24,8 @@ type Protocol struct {
 	eventstream internales.NoEventStream
 
 	version string
+
+	bufs *internalsync.BufferPool
 }
 
 var _ smithyhttp.ClientProtocol = (*Protocol)(nil)
@@ -34,7 +37,7 @@ func New(service *smithy.ServiceSchema, opts ...func(*ProtocolOptions)) *Protoco
 	for _, fn := range opts {
 		fn(&o)
 	}
-	return &Protocol{version: service.Version}
+	return &Protocol{version: service.Version, bufs: internalsync.NewBufferPool()}
 }
 
 // ID identifies the protocol.
@@ -106,10 +109,15 @@ func (p *Protocol) DeserializeResponse(
 		return p.deserializeError(types, resp)
 	}
 
-	payload, err := io.ReadAll(resp.Body)
+	// NOTE: payload aliases the pooled buffer, which is reused for the next
+	// response, so nothing may retain a reference into it past this call.
+	buf, err := p.bufs.Get(resp.Body)
 	if err != nil {
 		return &smithy.DeserializationError{Err: err}
 	}
+	defer p.bufs.Put(buf)
+
+	payload := buf.Bytes()
 
 	if len(payload) == 0 {
 		return nil

--- a/transport/http/protocol/ec2query/ec2query.go
+++ b/transport/http/protocol/ec2query/ec2query.go
@@ -8,10 +8,11 @@ import (
 	"net/http"
 
 	"github.com/aws/smithy-go"
+	internales "github.com/aws/smithy-go/internal/eventstream"
+	internalsync "github.com/aws/smithy-go/internal/sync"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	internalquery "github.com/aws/smithy-go/transport/http/protocol/internal/query"
 	internalxml "github.com/aws/smithy-go/transport/http/protocol/internal/xml"
-	internales "github.com/aws/smithy-go/internal/eventstream"
-	smithyhttp "github.com/aws/smithy-go/transport/http"
 )
 
 // ProtocolOptions configures aws.protocols#ec2Query.
@@ -22,6 +23,8 @@ type Protocol struct {
 	eventstream internales.NoEventStream
 
 	version string
+
+	bufs *internalsync.BufferPool
 }
 
 var _ smithyhttp.ClientProtocol = (*Protocol)(nil)
@@ -33,7 +36,7 @@ func New(service *smithy.ServiceSchema, opts ...func(*ProtocolOptions)) *Protoco
 	for _, fn := range opts {
 		fn(&o)
 	}
-	return &Protocol{version: service.Version}
+	return &Protocol{version: service.Version, bufs: internalsync.NewBufferPool()}
 }
 
 // ID identifies the protocol.
@@ -107,10 +110,15 @@ func (p *Protocol) DeserializeResponse(
 		return p.deserializeError(types, resp)
 	}
 
-	payload, err := io.ReadAll(resp.Body)
+	// NOTE: payload aliases the pooled buffer, which is reused for the next
+	// response, so nothing may retain a reference into it past this call.
+	buf, err := p.bufs.Get(resp.Body)
 	if err != nil {
 		return &smithy.DeserializationError{Err: err}
 	}
+	defer p.bufs.Put(buf)
+
+	payload := buf.Bytes()
 
 	if len(payload) == 0 {
 		return nil

--- a/transport/http/protocol/internal/cbor/shape_deserializer.go
+++ b/transport/http/protocol/internal/cbor/shape_deserializer.go
@@ -54,7 +54,7 @@ func NewShapeDeserializer(p []byte, opts ...func(*ShapeDeserializerOptions)) *Sh
 	}
 
 	d := &ShapeDeserializer{p: p, head: serde.NewStack[deserCtx](), opts: o}
-	d.arena.Reset(len(p) / 4)
+	d.arena.Reset(len(p) / serde.ArenaPayloadFactor)
 	return d
 }
 

--- a/transport/http/protocol/internal/cbor/shape_deserializer.go
+++ b/transport/http/protocol/internal/cbor/shape_deserializer.go
@@ -22,6 +22,8 @@ type ShapeDeserializer struct {
 	off  int
 	head serde.Stack[deserCtx]
 	opts ShapeDeserializerOptions
+
+	arena serde.StringArena
 }
 
 type deserCtxKind byte
@@ -50,7 +52,10 @@ func NewShapeDeserializer(p []byte, opts ...func(*ShapeDeserializerOptions)) *Sh
 	for _, fn := range opts {
 		fn(&o)
 	}
-	return &ShapeDeserializer{p: p, head: serde.NewStack[deserCtx](), opts: o}
+
+	d := &ShapeDeserializer{p: p, head: serde.NewStack[deserCtx](), opts: o}
+	d.arena.Reset(len(p) / 4)
+	return d
 }
 
 func (d *ShapeDeserializer) eof() bool {
@@ -254,12 +259,25 @@ func (d *ShapeDeserializer) ReadBool(s *smithy.Schema, v *bool) error {
 
 // ReadString implements [smithy.ShapeDeserializer].
 func (d *ShapeDeserializer) ReadString(s *smithy.Schema, v *string) error {
+	b, err := d.readStringBytes()
+	if err != nil {
+		return err
+	}
+
+	*v = d.arena.String(b)
+	return nil
+}
+
+// readStringBytes reads a string token and returns its contents without
+// materializing a string. For the definite-length form the result aliases the
+// payload, so callers that retain it must copy.
+func (d *ShapeDeserializer) readStringBytes() ([]byte, error) {
 	if d.eof() {
-		return errUnexpectedEOF
+		return nil, errUnexpectedEOF
 	}
 
 	if d.peekMajor() != majorTypeString {
-		return fmt.Errorf("expected string, got major type %d", d.peekMajor())
+		return nil, fmt.Errorf("expected string, got major type %d", d.peekMajor())
 	}
 
 	if d.peekMinor() == minorIndefinite {
@@ -267,33 +285,33 @@ func (d *ShapeDeserializer) ReadString(s *smithy.Schema, v *string) error {
 		var result []byte
 		for d.off < len(d.p) && d.p[d.off] != 0xff {
 			if d.peekMajor() != majorTypeString {
-				return fmt.Errorf("expected string chunk, got major type %d", d.peekMajor())
+				return nil, fmt.Errorf("expected string chunk, got major type %d", d.peekMajor())
 			}
 			slen, err := d.readArg()
 			if err != nil {
-				return err
+				return nil, err
 			}
 			if d.off+int(slen) > len(d.p) {
-				return fmt.Errorf("string chunk length %d exceeds remaining data", slen)
+				return nil, fmt.Errorf("string chunk length %d exceeds remaining data", slen)
 			}
 			result = append(result, d.p[d.off:d.off+int(slen)]...)
 			d.off += int(slen)
 		}
 		d.off++ // skip terminator
-		*v = string(result)
-		return nil
+		return result, nil
 	}
 
 	slen, err := d.readArg()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if d.off+int(slen) > len(d.p) {
-		return fmt.Errorf("string length %d exceeds remaining data", slen)
+		return nil, fmt.Errorf("string length %d exceeds remaining data", slen)
 	}
-	*v = string(d.p[d.off : d.off+int(slen)])
+
+	b := d.p[d.off : d.off+int(slen)]
 	d.off += int(slen)
-	return nil
+	return b, nil
 }
 
 // ReadTime implements [smithy.ShapeDeserializer].
@@ -498,12 +516,12 @@ func (d *ShapeDeserializer) ReadStructMember() (*smithy.Schema, error) {
 		sc.remaining--
 	}
 
-	var key string
-	if err := d.ReadString(nil, &key); err != nil {
+	key, err := d.readStringBytes()
+	if err != nil {
 		return nil, err
 	}
 
-	member := sc.schema.Member(key)
+	member := sc.schema.Members()[string(key)]
 	if member == nil {
 		if err := d.skip(); err != nil {
 			return nil, err
@@ -557,8 +575,8 @@ func (d *ShapeDeserializer) ReadUnion(s *smithy.Schema) (*smithy.Schema, error) 
 			uc.remaining--
 		}
 
-		var key string
-		if err := d.ReadString(nil, &key); err != nil {
+		key, err := d.readStringBytes()
+		if err != nil {
 			return nil, err
 		}
 
@@ -570,7 +588,7 @@ func (d *ShapeDeserializer) ReadUnion(s *smithy.Schema) (*smithy.Schema, error) 
 			}
 		}
 
-		member := s.Member(key)
+		member := s.Members()[string(key)]
 		if member == nil {
 			if err := d.skip(); err != nil {
 				return nil, err

--- a/transport/http/protocol/internal/cbor/zz_alias_test.go
+++ b/transport/http/protocol/internal/cbor/zz_alias_test.go
@@ -1,0 +1,113 @@
+package cbor
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/aws/smithy-go"
+)
+
+// The payload handed to NewShapeDeserializer aliases a pooled buffer that the
+// protocol returns to its pool as soon as deserialization finishes. Anything the
+// deserializer yields to the caller must therefore be copied out of it. These
+// tests prove that by scribbling over the payload afterward: if a value aliased
+// it, the value changes.
+
+func scribble(p []byte) {
+	for i := range p {
+		p[i] = 0xAA
+	}
+}
+
+func TestBlobIsCopiedOutOfPayload(t *testing.T) {
+	// {"b": h'DEADBEEF'} -- map(1), text(1) "b", bytes(4)
+	payload := []byte{
+		0xa1,
+		0x61, 'b',
+		0x44, 0xDE, 0xAD, 0xBE, 0xEF,
+	}
+	want := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+
+	schema := smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "S"}, smithy.ShapeTypeStructure, 1)
+	blobTarget := smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "B"}, smithy.ShapeTypeBlob, 0)
+	schema.AddMember("b", blobTarget)
+
+	d := NewShapeDeserializer(payload)
+	if err := d.ReadStruct(schema); err != nil {
+		t.Fatal(err)
+	}
+	member, err := d.ReadStructMember()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if member == nil {
+		t.Fatal("no member read")
+	}
+
+	var got []byte
+	if err := d.ReadBlob(member, &got); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("got %x, want %x", got, want)
+	}
+
+	scribble(payload)
+
+	if !bytes.Equal(got, want) {
+		t.Fatalf("blob ALIASES the payload: became %x after the buffer was reused, want %x", got, want)
+	}
+}
+
+func TestStringAndMapKeyAreCopiedOutOfPayload(t *testing.T) {
+	// {"key": "value"}
+	payload := []byte{
+		0xa1,
+		0x63, 'k', 'e', 'y',
+		0x65, 'v', 'a', 'l', 'u', 'e',
+	}
+
+	mapSchema := smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "M"}, smithy.ShapeTypeMap, 0)
+
+	d := NewShapeDeserializer(payload)
+	if err := d.ReadMap(mapSchema); err != nil {
+		t.Fatal(err)
+	}
+	key, ok, err := d.ReadMapKey(mapSchema)
+	if err != nil || !ok {
+		t.Fatalf("ReadMapKey: %v ok=%v", err, ok)
+	}
+	var val string
+	if err := d.ReadString(nil, &val); err != nil {
+		t.Fatal(err)
+	}
+	if key != "key" || val != "value" {
+		t.Fatalf("got key=%q val=%q", key, val)
+	}
+
+	scribble(payload)
+
+	if key != "key" {
+		t.Errorf("map key ALIASES the payload: became %q", key)
+	}
+	if val != "value" {
+		t.Errorf("string value ALIASES the payload: became %q", val)
+	}
+}
+
+// An indefinite-length byte string is legal CBOR that ReadBlob does not
+// implement. It must fail cleanly rather than mis-parse into payload memory.
+func TestIndefiniteLengthBlobRejected(t *testing.T) {
+	// h'' with indefinite length: 0x5f <chunks> 0xff
+	payload := []byte{0x5f, 0x42, 0xDE, 0xAD, 0xff}
+
+	blobSchema := smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "B"}, smithy.ShapeTypeBlob, 0)
+
+	d := NewShapeDeserializer(payload)
+	var got []byte
+	err := d.ReadBlob(blobSchema, &got)
+	if err == nil {
+		t.Fatalf("expected an error for an indefinite-length blob, got %x", got)
+	}
+	t.Logf("indefinite-length blob rejected with: %v", err)
+}

--- a/transport/http/protocol/internal/httpbinding/deserializer.go
+++ b/transport/http/protocol/internal/httpbinding/deserializer.go
@@ -500,3 +500,16 @@ func (d *ShapeDeserializer) ReadBigInt(_ *smithy.Schema, _ *big.Int) error {
 func (d *ShapeDeserializer) ReadBigFloat(_ *smithy.Schema, _ *big.Float) error {
 	return fmt.Errorf("unimplemented")
 }
+
+// HasBlobPayload reports whether the given output shape binds a blob member as
+// @httpPayload. Such a payload is handed to the caller by reference, so the
+// buffer holding it cannot be reused.
+//
+// The answer is cached per schema: this is called on every response, and walking
+// members with a trait lookup each is not free at that rate.
+func HasBlobPayload(output *smithy.Schema) bool {
+	if output == nil {
+		return false
+	}
+	return getExt(output).hasBlobPayload
+}

--- a/transport/http/protocol/internal/httpbinding/ext.go
+++ b/transport/http/protocol/internal/httpbinding/ext.go
@@ -1,0 +1,34 @@
+package httpbinding
+
+import (
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/traits"
+)
+
+// bindingExt caches per-schema facts about a shape's HTTP bindings that would
+// otherwise be recomputed by walking its members on every request.
+type bindingExt struct {
+	hasBlobPayload bool
+}
+
+func getExt(s *smithy.Schema) *bindingExt {
+	return smithy.SchemaExtension(s, smithy.ExtHTTPBinding, buildExt)
+}
+
+func buildExt(s *smithy.Schema) *bindingExt {
+	return &bindingExt{
+		hasBlobPayload: hasBlobPayload(s),
+	}
+}
+
+func hasBlobPayload(output *smithy.Schema) bool {
+	for _, member := range output.Members() {
+		if _, ok := smithy.SchemaTrait[*traits.HTTPPayload](member); !ok {
+			continue
+		}
+		if member.Type() == smithy.ShapeTypeBlob {
+			return true
+		}
+	}
+	return false
+}

--- a/transport/http/protocol/internal/httpbinding/ext_test.go
+++ b/transport/http/protocol/internal/httpbinding/ext_test.go
@@ -1,0 +1,101 @@
+package httpbinding
+
+import (
+	"testing"
+
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/traits"
+)
+
+func outputWith(memberName string, target *smithy.Schema, ts ...smithy.Trait) *smithy.Schema {
+	out := smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "Output"}, smithy.ShapeTypeStructure, 4)
+	// a few members with no bindings, so the walk this caches is not trivial
+	str := smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "Str"}, smithy.ShapeTypeString, 0)
+	out.AddMember("a", str)
+	out.AddMember("b", str)
+	out.AddMember(memberName, target, ts...)
+	return out
+}
+
+func TestHasBlobPayload(t *testing.T) {
+	blob := smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "Blob"}, smithy.ShapeTypeBlob, 0)
+	str := smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "Str"}, smithy.ShapeTypeString, 0)
+
+	for _, tt := range []struct {
+		name string
+		out  *smithy.Schema
+		want bool
+	}{
+		{"nil output", nil, false},
+		{"blob @httpPayload", outputWith("body", blob, &traits.HTTPPayload{}), true},
+		// a string payload is materialized by copy, so the buffer is still poolable
+		{"string @httpPayload", outputWith("body", str, &traits.HTTPPayload{}), false},
+		{"blob without @httpPayload", outputWith("body", blob), false},
+		{"no members", smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "E"}, smithy.ShapeTypeStructure, 0), false},
+	} {
+		if got := HasBlobPayload(tt.out); got != tt.want {
+			t.Errorf("%s: got %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+// The walk this caches does not allocate, so allocation cannot tell you whether
+// the cache is live -- what it costs is time. Assert the mechanism instead: the
+// extension is built once and returned by pointer thereafter, and HasBlobPayload
+// reads it. BenchmarkHasBlobPayload measures what that saves.
+func TestBindingExtIsCached(t *testing.T) {
+	blob := smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "Blob"}, smithy.ShapeTypeBlob, 0)
+	out := outputWith("body", blob, &traits.HTTPPayload{})
+
+	if !HasBlobPayload(out) {
+		t.Fatal("expected true")
+	}
+
+	first := getExt(out)
+	if first == nil {
+		t.Fatal("extension not populated")
+	}
+	if second := getExt(out); second != first {
+		t.Error("extension rebuilt on second access; the slot is not caching")
+	}
+	if !first.hasBlobPayload {
+		t.Error("cached extension holds the wrong answer")
+	}
+}
+
+func BenchmarkHasBlobPayload(b *testing.B) {
+	blob := smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "Blob"}, smithy.ShapeTypeBlob, 0)
+	out := outputWith("body", blob, &traits.HTTPPayload{})
+
+	b.Run("cached", func(b *testing.B) {
+		HasBlobPayload(out)
+		for b.Loop() {
+			HasBlobPayload(out)
+		}
+	})
+	b.Run("uncached-walk", func(b *testing.B) {
+		for b.Loop() {
+			hasBlobPayload(out)
+		}
+	})
+}
+
+// Adding a member invalidates cached extensions. If that ever stops holding, a
+// schema built up incrementally would answer from a stale walk.
+func TestHasBlobPayloadRecomputedAfterAddMember(t *testing.T) {
+	str := smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "Str"}, smithy.ShapeTypeString, 0)
+	blob := smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "Blob"}, smithy.ShapeTypeBlob, 0)
+
+	out := smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "Output"}, smithy.ShapeTypeStructure, 2)
+	out.AddMember("a", str)
+
+	if HasBlobPayload(out) {
+		t.Fatal("expected false before the payload member exists")
+	}
+
+	out.AddMember("body", blob, &traits.HTTPPayload{})
+
+	if !HasBlobPayload(out) {
+		t.Error("stale cached value after AddMember added a blob @httpPayload")
+	}
+}

--- a/transport/http/protocol/internal/httpbinding/ext_test.go
+++ b/transport/http/protocol/internal/httpbinding/ext_test.go
@@ -48,7 +48,7 @@ func TestBindingExtIsCached(t *testing.T) {
 	out := outputWith("body", blob, &traits.HTTPPayload{})
 
 	if !HasBlobPayload(out) {
-		t.Fatal("expected true")
+		t.Fatal("expected schema to have blob payload")
 	}
 
 	first := getExt(out)

--- a/transport/http/protocol/internal/httpbinding/ext_test.go
+++ b/transport/http/protocol/internal/httpbinding/ext_test.go
@@ -63,23 +63,6 @@ func TestBindingExtIsCached(t *testing.T) {
 	}
 }
 
-func BenchmarkHasBlobPayload(b *testing.B) {
-	blob := smithy.NewSchema(smithy.ShapeID{Namespace: "test", Name: "Blob"}, smithy.ShapeTypeBlob, 0)
-	out := outputWith("body", blob, &traits.HTTPPayload{})
-
-	b.Run("cached", func(b *testing.B) {
-		HasBlobPayload(out)
-		for b.Loop() {
-			HasBlobPayload(out)
-		}
-	})
-	b.Run("uncached-walk", func(b *testing.B) {
-		for b.Loop() {
-			hasBlobPayload(out)
-		}
-	})
-}
-
 // Adding a member invalidates cached extensions. If that ever stops holding, a
 // schema built up incrementally would answer from a stale walk.
 func TestHasBlobPayloadRecomputedAfterAddMember(t *testing.T) {

--- a/transport/http/protocol/internal/json/ext.go
+++ b/transport/http/protocol/internal/json/ext.go
@@ -1,8 +1,6 @@
 package json
 
 import (
-	"sort"
-
 	"github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/traits"
 )
@@ -10,14 +8,6 @@ import (
 type jsonExt struct {
 	jsonKey     []byte // `,"memberName":` -- use [1:] when no comma needed
 	jsonNameKey []byte // `,"jsonName":` -- use [1:] when no comma needed (nil if no @jsonName)
-
-	memberList []memberEntry
-	byteIndex  *[256]int16
-}
-
-type memberEntry struct {
-	name   string
-	schema *smithy.Schema
 }
 
 func getExt(s *smithy.Schema) *jsonExt {
@@ -34,58 +24,13 @@ func buildJSONExt(s *smithy.Schema) *jsonExt {
 		}
 	}
 
-	if members := s.Members(); len(members) > 0 {
-		names := make([]string, 0, len(members))
-		for name := range members {
-			names = append(names, name)
-		}
-		sort.Strings(names)
-
-		ext.memberList = make([]memberEntry, len(names))
-		idx := &[256]int16{}
-		for i := range idx {
-			idx[i] = -1
-		}
-		for pos, name := range names {
-			ext.memberList[pos] = memberEntry{name: name, schema: members[name]}
-			if len(name) > 0 {
-				b := name[0]
-				if idx[b] == -1 {
-					idx[b] = int16(pos)
-				} else {
-					idx[b] = -2
-				}
-			}
-		}
-		ext.byteIndex = idx
-	}
-
 	return ext
 }
 
+// memberByBytes looks a member up without allocating a string for its name: the
+// conversion in a map index expression is optimized away.
 func memberByBytes(s *smithy.Schema, name []byte) *smithy.Schema {
-	ext := getExt(s)
-	if ext.byteIndex == nil || len(name) == 0 {
-		return nil
-	}
-	idx := ext.byteIndex[name[0]]
-	if idx == -1 {
-		return nil
-	}
-	if idx >= 0 {
-		e := &ext.memberList[idx]
-		if len(e.name) == len(name) && e.name == string(name) {
-			return e.schema
-		}
-		return nil
-	}
-	for i := range ext.memberList {
-		e := &ext.memberList[i]
-		if len(e.name) == len(name) && e.name == string(name) {
-			return e.schema
-		}
-	}
-	return nil
+	return s.Members()[string(name)]
 }
 
 func encodeJSONKey(name string) []byte {

--- a/transport/http/protocol/internal/json/shape_deserializer.go
+++ b/transport/http/protocol/internal/json/shape_deserializer.go
@@ -68,7 +68,7 @@ func NewShapeDeserializer(p []byte, opts ...func(*Options)) *ShapeDeserializer {
 	d.head.Reset()
 	d.peeked = nil
 	d.opts = o
-	d.arena.Reset(len(p) / 4)
+	d.arena.Reset(len(p) / serde.ArenaPayloadFactor)
 	return d
 }
 

--- a/transport/http/protocol/internal/json/shape_deserializer.go
+++ b/transport/http/protocol/internal/json/shape_deserializer.go
@@ -40,6 +40,8 @@ type ShapeDeserializer struct {
 
 	peeked        []byte
 	peekedEscaped bool
+
+	arena serde.StringArena
 }
 
 var deserPool = sync.Pool{
@@ -66,6 +68,7 @@ func NewShapeDeserializer(p []byte, opts ...func(*Options)) *ShapeDeserializer {
 	d.head.Reset()
 	d.peeked = nil
 	d.opts = o
+	d.arena.Reset(len(p) / 4)
 	return d
 }
 
@@ -282,11 +285,11 @@ func (d *ShapeDeserializer) ReadString(s *smithy.Schema, v *string) error {
 	}
 
 	if !d.p.escaped {
-		*v = string(tok[1 : len(tok)-1])
+		*v = d.arena.String(tok[1 : len(tok)-1])
 		return nil
 	}
 
-	sv, err := unquote(tok)
+	sv, err := d.unquoteArena(tok)
 	if err != nil {
 		return err
 	}
@@ -418,10 +421,10 @@ func (d *ShapeDeserializer) ReadMapKey(s *smithy.Schema) (string, bool, error) {
 	}
 
 	if !d.p.escaped {
-		return string(tok[1 : len(tok)-1]), true, nil
+		return d.arena.String(tok[1 : len(tok)-1]), true, nil
 	}
 
-	key, err := unquote(tok)
+	key, err := d.unquoteArena(tok)
 	if err != nil {
 		return "", false, err
 	}
@@ -583,6 +586,13 @@ func (d *ShapeDeserializer) ReadDocument(schema *smithy.Schema, v *document.Valu
 func unquote(tok []byte) (string, error) {
 	if s, ok := stdlib.UnquoteBytes(tok); ok {
 		return string(s), nil
+	}
+	return "", fmt.Errorf("cannot unquote %s", tok)
+}
+
+func (d *ShapeDeserializer) unquoteArena(tok []byte) (string, error) {
+	if s, ok := stdlib.UnquoteBytes(tok); ok {
+		return d.arena.String(s), nil
 	}
 	return "", fmt.Errorf("cannot unquote %s", tok)
 }
@@ -808,9 +818,9 @@ func (d *ShapeDeserializer) DirectReadMap(schema *smithy.Schema, memberFn func(s
 
 		var key string
 		if !d.p.escaped {
-			key = string(tok[1 : len(tok)-1])
+			key = d.arena.String(tok[1 : len(tok)-1])
 		} else {
-			key, err = unquote(tok)
+			key, err = d.unquoteArena(tok)
 			if err != nil {
 				return err
 			}

--- a/transport/http/protocol/restjson1/restjson1.go
+++ b/transport/http/protocol/restjson1/restjson1.go
@@ -8,11 +8,13 @@ import (
 	"io"
 
 	"github.com/aws/smithy-go"
-	internalhttpbinding "github.com/aws/smithy-go/transport/http/protocol/internal/httpbinding"
-	internaljson "github.com/aws/smithy-go/transport/http/protocol/internal/json"
 	internales "github.com/aws/smithy-go/internal/eventstream"
+	internalserde "github.com/aws/smithy-go/internal/serde"
+	internalsync "github.com/aws/smithy-go/internal/sync"
 	smithyio "github.com/aws/smithy-go/io"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
+	internalhttpbinding "github.com/aws/smithy-go/transport/http/protocol/internal/httpbinding"
+	internaljson "github.com/aws/smithy-go/transport/http/protocol/internal/json"
 )
 
 // ProtocolOptions configures aws.protocols#restJson1.
@@ -25,16 +27,18 @@ func New(_ *smithy.ServiceSchema, opts ...func(*ProtocolOptions)) *Protocol {
 		fn(&o)
 	}
 	return &Protocol{
+		bufs: internalsync.NewBufferPool(),
 		eventstream: &internales.Codec{
-			Serializer:  func() smithy.ShapeSerializer { return internaljson.NewShapeSerializer() },
+			Serializer:   func() smithy.ShapeSerializer { return internaljson.NewShapeSerializer() },
 			Deserializer: func(p []byte) smithy.ShapeDeserializer { return internaljson.NewShapeDeserializer(p) },
-			ContentType: "application/json",
+			ContentType:  "application/json",
 		},
 	}
 }
 
 // Protocol implements aws.protocols#restJson1.
 type Protocol struct {
+	bufs        *internalsync.BufferPool
 	eventstream *internales.Codec
 }
 
@@ -112,11 +116,22 @@ func (p *Protocol) DeserializeResponse(
 		return nil
 	}
 
-	payload, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return &smithy.DeserializationError{Err: err}
+	// a blob @httpPayload is handed to the caller by reference, so its buffer
+	// can't be reused
+	var buf *bytes.Buffer
+	var err error
+	if internalhttpbinding.HasBlobPayload(op.Output) {
+		if buf, err = internalserde.ReadPayloadBlob(resp.Body, resp.ContentLength); err != nil {
+			return &smithy.DeserializationError{Err: err}
+		}
+	} else {
+		if buf, err = p.bufs.Get(resp.Body); err != nil {
+			return &smithy.DeserializationError{Err: err}
+		}
+		defer p.bufs.Put(buf)
 	}
 
+	payload := buf.Bytes()
 	deser := internalhttpbinding.NewShapeDeserializer(resp.Response, bd(payload), payload)
 	if err := out.Deserialize(deser); err != nil {
 		return &smithy.DeserializationError{Err: err}

--- a/transport/http/protocol/restxml/restxml.go
+++ b/transport/http/protocol/restxml/restxml.go
@@ -7,11 +7,13 @@ import (
 	"io"
 
 	"github.com/aws/smithy-go"
-	internalhttpbinding "github.com/aws/smithy-go/transport/http/protocol/internal/httpbinding"
-	internalxml "github.com/aws/smithy-go/transport/http/protocol/internal/xml"
 	internales "github.com/aws/smithy-go/internal/eventstream"
+	internalserde "github.com/aws/smithy-go/internal/serde"
+	internalsync "github.com/aws/smithy-go/internal/sync"
 	"github.com/aws/smithy-go/traits"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
+	internalhttpbinding "github.com/aws/smithy-go/transport/http/protocol/internal/httpbinding"
+	internalxml "github.com/aws/smithy-go/transport/http/protocol/internal/xml"
 )
 
 // Protocol implements aws.protocols#restXml.
@@ -19,6 +21,8 @@ type Protocol struct {
 	eventstream *internales.Codec
 
 	seropts func(*internalxml.ShapeSerializerOptions)
+
+	bufs *internalsync.BufferPool
 }
 
 // ProtocolOptions configures aws.protocols#restXml.
@@ -54,6 +58,7 @@ func New(service *smithy.ServiceSchema, opts ...func(*ProtocolOptions)) *Protoco
 			ContentType:  "application/xml",
 		},
 		seropts: xmlOpts,
+		bufs:    internalsync.NewBufferPool(),
 	}
 }
 
@@ -152,13 +157,24 @@ func (p *Protocol) DeserializeResponse(
 		return nil
 	}
 
-	payload, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return &smithy.DeserializationError{Err: err}
+	// a blob @httpPayload is handed to the caller by reference, so its buffer
+	// can't be reused
+	var buf *bytes.Buffer
+	var err error
+	if internalhttpbinding.HasBlobPayload(op.Output) {
+		if buf, err = internalserde.ReadPayloadBlob(resp.Body, resp.ContentLength); err != nil {
+			return &smithy.DeserializationError{Err: err}
+		}
+	} else {
+		if buf, err = p.bufs.Get(resp.Body); err != nil {
+			return &smithy.DeserializationError{Err: err}
+		}
+		defer p.bufs.Put(buf)
 	}
 
-	deser := internalhttpbinding.NewShapeDeserializer(resp.Response, deser(payload, op.Output), payload)
-	if err := out.Deserialize(deser); err != nil {
+	payload := buf.Bytes()
+	sd := internalhttpbinding.NewShapeDeserializer(resp.Response, deser(payload, op.Output), payload)
+	if err := out.Deserialize(sd); err != nil {
 		return &smithy.DeserializationError{Err: err}
 	}
 

--- a/transport/http/protocol/rpcv2/rpcv2.go
+++ b/transport/http/protocol/rpcv2/rpcv2.go
@@ -8,13 +8,14 @@ import (
 	"net/http"
 
 	"github.com/aws/smithy-go"
-	internales "github.com/aws/smithy-go/internal/eventstream"
 	internalerrors "github.com/aws/smithy-go/internal/errors"
+	internales "github.com/aws/smithy-go/internal/eventstream"
+	internalsync "github.com/aws/smithy-go/internal/sync"
 	smithyio "github.com/aws/smithy-go/io"
 	"github.com/aws/smithy-go/middleware"
-	internalcbor "github.com/aws/smithy-go/transport/http/protocol/internal/cbor"
 	"github.com/aws/smithy-go/traits"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
+	internalcbor "github.com/aws/smithy-go/transport/http/protocol/internal/cbor"
 )
 
 // Protocol implements an RPC v2 protocol.
@@ -26,6 +27,7 @@ type Protocol struct {
 	serviceName     string
 
 	eventstream *internales.Codec
+	bufs        *internalsync.BufferPool
 }
 
 var _ smithyhttp.ClientProtocol = (*Protocol)(nil)
@@ -48,6 +50,7 @@ func NewCBOR(service *smithy.ServiceSchema, opts ...func(*ProtocolOptions)) *Pro
 			Deserializer: func(p []byte) smithy.ShapeDeserializer { return internalcbor.NewShapeDeserializer(p) },
 			ContentType:  "application/cbor",
 		},
+		bufs: internalsync.NewBufferPool(),
 	}
 }
 
@@ -125,10 +128,16 @@ func (p *Protocol) DeserializeResponse(
 		return nil
 	}
 
-	payload, err := io.ReadAll(resp.Body)
+	// NOTE: payload aliases the pooled buffer, so the deserializer must not
+	// retain references into it -- everything it yields to the caller is
+	// copied out today.
+	buf, err := p.bufs.Get(resp.Body)
 	if err != nil {
 		return &smithy.DeserializationError{Err: err}
 	}
+	defer p.bufs.Put(buf)
+
+	payload := buf.Bytes()
 
 	if len(payload) == 0 {
 		return nil


### PR DESCRIPTION
* io.ReadAll is inefficient for response buffering because it starts at like 512 bytes and repeatedly doubles until it consumes the reader, which means we waste a bunch of intermediate allocations. pool byte buffers on deserialization for all protocols, up to a limit
* add a string arena, the goal here is to reduce allocation pressure for repeated small strings. It sizes to 1/4th of the response payload but I've also capped it at 4k for now, so big responses etc. won't cause a lot of memory to be pinned
* attempt to presize buffers for `@httpPayload + blob` rather than io.ReadAll