### PR TITLE
fix: drain response body before closing in CloseResponseBody

### DIFF
--- a/.changelog/a21d781b-9faa-463b-9b5c-4e5430a7ade4.json
+++ b/.changelog/a21d781b-9faa-463b-9b5c-4e5430a7ade4.json
@@ -1,0 +1,9 @@
+{
+    "id": "a21d781b-9faa-463b-9b5c-4e5430a7ade4",
+    "type": "bugfix",
+    "description": "Restore draining the HTTP response body in `CloseResponseBody` to avoid TCP connection leak.",
+    "collapse": false,
+    "modules": [
+        "."
+    ]
+}

--- a/.changelog/a21d781b-9faa-463b-9b5c-4e5430a7ade4.json
+++ b/.changelog/a21d781b-9faa-463b-9b5c-4e5430a7ade4.json
@@ -1,7 +1,7 @@
 {
     "id": "a21d781b-9faa-463b-9b5c-4e5430a7ade4",
     "type": "bugfix",
-    "description": "Restore draining the HTTP response body in `CloseResponseBody` to avoid TCP connection leak.",
+    "description": "Restore draining the HTTP response body in `CloseResponseBody` to avoid issues with TCP connection reuse.",
     "collapse": false,
     "modules": [
         "."

--- a/transport/http/middleware_close_response_body.go
+++ b/transport/http/middleware_close_response_body.go
@@ -20,6 +20,12 @@ func CloseResponseBody(ctx context.Context, resp *Response, isStreaming bool, op
 		return
 	}
 
+	// Drain to EOF before closing; a body closed while unread prevents
+	// connection reuse.
+	if _, copyErr := io.Copy(io.Discard, resp.Body); copyErr != nil {
+		middleware.GetLogger(ctx).Logf(logging.Warn, "failed to discard remaining HTTP response body, this may affect connection reuse")
+	}
+
 	if closeErr := resp.Body.Close(); closeErr != nil {
 		middleware.GetLogger(ctx).Logf(logging.Warn, "failed to close HTTP response body, this may affect connection reuse")
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

#683 dropped the drain assuming deserialize consumed the body. It doesn't when the body isn't read to EOF (e.g. a chunked response with trailing bytes, or a body wrapped so Close no longer reaches the transport body, as S3's 200-error customization does with `io.NopCloser)`. Closing it undrained leaks the connection — seen on S3 `CompleteMultipartUpload`. Restore the drain to EOF.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
