### PR TITLE
Keep trailing slash when JoinPath right operand is a slash

### DIFF
--- a/.changelog/e4607e56-ca01-4a77-b05f-68b93c7e06af.json
+++ b/.changelog/e4607e56-ca01-4a77-b05f-68b93c7e06af.json
@@ -1,0 +1,9 @@
+{
+    "id": "e4607e56-ca01-4a77-b05f-68b93c7e06af",
+    "type": "bugfix",
+    "description": "JoinPath keeps a trailing slash when the added path is a slash.",
+    "collapse": false,
+    "modules": [
+        "."
+    ]
+}

--- a/transport/http/url.go
+++ b/transport/http/url.go
@@ -12,11 +12,18 @@ func JoinPath(a, b string) string {
 		a = "/" + a
 	}
 
+	// Record b's trailing slash before the strip below can erase it (a bare
+	// "/" becomes "").
+	keepTrailing := len(b) > 0 && b[len(b)-1] == '/'
 	if len(b) != 0 && b[0] == '/' {
 		b = b[1:]
 	}
 
 	if len(b) != 0 && len(a) > 1 && a[len(a)-1] != '/' {
+		a = a + "/"
+	}
+
+	if keepTrailing && len(b) == 0 && a[len(a)-1] != '/' {
 		a = a + "/"
 	}
 

--- a/transport/http/url_test.go
+++ b/transport/http/url_test.go
@@ -50,6 +50,22 @@ func TestJoinPath(t *testing.T) {
 			A: "foo//", B: "//bar",
 			Expect: "/foo///bar",
 		},
+		10: {
+			A: "/foo", B: "/",
+			Expect: "/foo/",
+		},
+		11: {
+			A: "foo", B: "/",
+			Expect: "/foo/",
+		},
+		12: {
+			A: "/foo/", B: "/",
+			Expect: "/foo/",
+		},
+		13: {
+			A: "/", B: "/",
+			Expect: "/",
+		},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
## Summary
JoinPath("/foo", "/") returned "/foo" because the right operand was stripped to empty and the trailing slash was lost.

The result now keeps that trailing slash. Existing path joins are unchanged.

Fixes #631

## Test plan
Run go test ./transport/http/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.