### PR TITLE
fixup some regressions for schema-serde found in json wave 2

### DIFF
--- a/.changelog/300fdf65f88949f98e93269af2a058bd.json
+++ b/.changelog/300fdf65f88949f98e93269af2a058bd.json
@@ -1,0 +1,9 @@
+{
+    "id": "300fdf65-f889-49f9-8e93-269af2a058bd",
+    "type": "bugfix",
+    "description": "Fix an event stream not being closed when its connection is lost, which would cause a caller writing to the stream to block indefinitely.",
+    "collapse": false,
+    "modules": [
+        "."
+    ]
+}

--- a/.changelog/67db039b2eff4af7be733e95b79ad0c5.json
+++ b/.changelog/67db039b2eff4af7be733e95b79ad0c5.json
@@ -1,0 +1,9 @@
+{
+    "id": "67db039b-2eff-4af7-be73-3e95b79ad0c5",
+    "type": "bugfix",
+    "description": "Fix a generic event stream exception not carrying the error code and message from its payload.",
+    "collapse": false,
+    "modules": [
+        "."
+    ]
+}

--- a/.changelog/fce3a10fade646db85d99a3bb7edcafe.json
+++ b/.changelog/fce3a10fade646db85d99a3bb7edcafe.json
@@ -1,0 +1,9 @@
+{
+    "id": "fce3a10f-ade6-46db-85d9-9a3bb7edcafe",
+    "type": "bugfix",
+    "description": "Fix deserialization of an empty list producing a nil slice instead of an empty one.",
+    "collapse": false,
+    "modules": [
+        "."
+    ]
+}

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/EventStreamGenerator.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/EventStreamGenerator.java
@@ -191,6 +191,10 @@ public final class EventStreamGenerator {
                 func (w *$impl:L) Err() error {
                     return w.writer.Err()
                 }
+
+                func (w *$impl:L) ErrorSet() <-chan struct{} {
+                    return w.writer.ErrorSet()
+                }
                 """,
                 MapUtils.of(
                         "impl", implName,
@@ -228,6 +232,9 @@ public final class EventStreamGenerator {
                     reader $esReader:P
                     ch     chan $union:T
                     done   chan struct{}
+                    closed chan struct{}
+
+                    closeOnce $syncOnce:T
                 }
 
                 var _ $iface:L = (*$impl:L)(nil)
@@ -237,12 +244,14 @@ public final class EventStreamGenerator {
                         reader: reader,
                         ch:     make(chan $union:T),
                         done:   make(chan struct{}),
+                        closed: make(chan struct{}),
                     }
                     go r.pipe()
                     return r
                 }
 
                 func (r *$impl:L) pipe() {
+                    defer close(r.closed)
                     defer close(r.ch)
                     for event := range r.reader.Events() {
                         var ev $union:T
@@ -264,12 +273,18 @@ public final class EventStreamGenerator {
                 }
 
                 func (r *$impl:L) Close() error {
-                    close(r.done)
+                    r.closeOnce.Do(func() {
+                        close(r.done)
+                    })
                     return r.reader.Close()
                 }
 
                 func (r *$impl:L) Err() error {
                     return r.reader.Err()
+                }
+
+                func (r *$impl:L) Closed() <-chan struct{} {
+                    return r.closed
                 }
                 """,
                 MapUtils.of(
@@ -277,6 +292,7 @@ public final class EventStreamGenerator {
                         "iface", ifaceName,
                         "newImpl", "new" + StringUtils.capitalize(implName),
                         "esReader", SmithyGoDependency.SMITHY_HTTP_TRANSPORT.pointableSymbol("EventStreamReader"),
+                        "syncOnce", SmithyGoDependency.SYNC.valueSymbol("Once"),
                         "union", unionSymbol,
                         "cases", (Writable) (GoWriter w) -> {
                             for (var member : members) {

--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/ListDeserializer.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/ListDeserializer.java
@@ -39,6 +39,7 @@ public class ListDeserializer implements Writable {
     private void renderDense(GoWriter writer) {
         writer.writeGoTemplate("""
                 func deserialize$shapeName:L(d smithy.ShapeDeserializer, s *smithy.Schema, v *$symbol:T) error {
+                    *v = make($symbol:T, 0)
                     var vv $memberSymbol:T
                     return smithy.ReadList(d, s, func() error {
                         $zeroValue:W
@@ -69,6 +70,7 @@ public class ListDeserializer implements Writable {
     private void renderSparse(GoWriter writer) {
         writer.writeGoTemplate("""
                 func deserialize$shapeName:L(d smithy.ShapeDeserializer, s *smithy.Schema, v *$symbol:T) error {
+                    *v = make($symbol:T, 0)
                     return smithy.ReadList(d, s, func() error {
                         if isNil, err := d.ReadNil(s.ListMember()); err != nil {
                             return err

--- a/internal/eventstream/codec.go
+++ b/internal/eventstream/codec.go
@@ -16,6 +16,9 @@ type Codec struct {
 	Deserializer func([]byte) smithy.ShapeDeserializer
 	ContentType  string
 
+	// Protocol-specific hook to retrieve error information from some payload.
+	ErrorInfo func(payload []byte) (code, message string, err error)
+
 	encoder    *eventstream.Encoder
 	decoder    *eventstream.Decoder
 	payloadBuf []byte
@@ -44,8 +47,10 @@ func (c *Codec) SerializeEventMessage(schema, variant *smithy.Schema, v smithy.S
 
 	v.Serialize(ss)
 
-	msg.Headers.Set(eventstream.MessageTypeHeader, eventstream.StringValue(eventstream.EventMessageType))
+	// header order matches the legacy per-operation serializers: the event type
+	// is written before the message type
 	msg.Headers.Set(eventstream.EventTypeHeader, eventstream.StringValue(variant.MemberName()))
+	msg.Headers.Set(eventstream.MessageTypeHeader, eventstream.StringValue(eventstream.EventMessageType))
 
 	if ct := ss.ContentType(); ct != "" {
 		msg.Headers.Set(eventstream.ContentTypeHeader, eventstream.StringValue(ct))
@@ -146,9 +151,26 @@ func (c *Codec) deserializeException(schema *smithy.Schema, types *smithy.TypeRe
 
 	perr, ok := types.DeserializableError(id)
 	if !ok {
+		code := exType.String()
+		message := "UnknownError"
+		if c.ErrorInfo != nil {
+			bodyCode, bodyMessage, err := c.ErrorInfo(msg.Payload)
+			if err != nil {
+				return &smithy.DeserializationError{
+					Err:      fmt.Errorf("get error info: %w", err),
+					Snapshot: msg.Payload,
+				}
+			}
+			if len(code) == 0 && len(bodyCode) != 0 {
+				code = bodyCode
+			}
+			if len(bodyMessage) != 0 {
+				message = bodyMessage
+			}
+		}
 		return &smithy.GenericAPIError{
-			Code:    exType.String(),
-			Message: "unknown exception",
+			Code:    code,
+			Message: message,
 		}
 	}
 

--- a/transport/http/protocol/awsjson/awsjson.go
+++ b/transport/http/protocol/awsjson/awsjson.go
@@ -48,6 +48,7 @@ func new(version string, service *smithy.ServiceSchema, opts ...func(*ProtocolOp
 			Serializer:   func() smithy.ShapeSerializer { return internaljson.NewShapeSerializer() },
 			Deserializer: func(p []byte) smithy.ShapeDeserializer { return internaljson.NewShapeDeserializer(p) },
 			ContentType:  "application/json",
+			ErrorInfo:    internaljson.EventStreamErrorInfo,
 		},
 	}
 }

--- a/transport/http/protocol/internal/json/error.go
+++ b/transport/http/protocol/internal/json/error.go
@@ -1,6 +1,7 @@
 package json
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"strings"
@@ -51,4 +52,25 @@ func SanitizeErrorCode(code string) string {
 		code = code[idx+1:]
 	}
 	return code
+}
+
+// EventStreamErrorInfo extracts the error code and message from a JSON
+// exception payload.
+func EventStreamErrorInfo(payload []byte) (string, string, error) {
+	if len(payload) == 0 {
+		return "", "", nil
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.UseNumber()
+	info, err := GetProtocolErrorInfo(decoder)
+	if err != nil {
+		return "", "", err
+	}
+
+	var code string
+	if typ, ok := ResolveProtocolErrorType("", info); ok {
+		code = SanitizeErrorCode(typ)
+	}
+	return code, info.Message, nil
 }

--- a/transport/http/protocol/restjson1/restjson1.go
+++ b/transport/http/protocol/restjson1/restjson1.go
@@ -32,6 +32,7 @@ func New(_ *smithy.ServiceSchema, opts ...func(*ProtocolOptions)) *Protocol {
 			Serializer:   func() smithy.ShapeSerializer { return internaljson.NewShapeSerializer() },
 			Deserializer: func(p []byte) smithy.ShapeDeserializer { return internaljson.NewShapeDeserializer(p) },
 			ContentType:  "application/json",
+			ErrorInfo:    internaljson.EventStreamErrorInfo,
 		},
 	}
 }

--- a/transport/http/protocol/rpcv2/rpcv2.go
+++ b/transport/http/protocol/rpcv2/rpcv2.go
@@ -49,6 +49,7 @@ func NewCBOR(service *smithy.ServiceSchema, opts ...func(*ProtocolOptions)) *Pro
 			Serializer:   func() smithy.ShapeSerializer { return internalcbor.NewShapeSerializer() },
 			Deserializer: func(p []byte) smithy.ShapeDeserializer { return internalcbor.NewShapeDeserializer(p) },
 			ContentType:  "application/cbor",
+			ErrorInfo:    internalcbor.GetProtocolErrorInfo,
 		},
 		bufs: internalsync.NewBufferPool(),
 	}


### PR DESCRIPTION
* explicit empty lists were deserialized as nothing rather than an empty slice
* the event stream internals were missing some interface impls that the closing mechanisms depend on
* the new protocol-agnostic event stream stuff wasn't wired up to forward generic API error details