### PR TITLE
fix data race on stream

### DIFF
--- a/.changelog/688ceb952b3c4d7381016787a46a66c6.json
+++ b/.changelog/688ceb952b3c4d7381016787a46a66c6.json
@@ -1,0 +1,9 @@
+{
+    "id": "688ceb95-2b3c-4d73-8101-6787a46a66c6",
+    "type": "bugfix",
+    "collapse": false,
+    "description": "Fix a data race on the underlying writer when an event stream is closed while an event write is in flight.",
+    "modules": [
+        "."
+    ]
+}

--- a/transport/http/eventstream.go
+++ b/transport/http/eventstream.go
@@ -56,7 +56,10 @@ func NewEventStreamWriter(protocol ClientProtocol, schema *smithy.Schema, stream
 }
 
 func (w *EventStreamWriter) writeStream() {
-	defer w.Close()
+	defer func() {
+		w.err.SetError(w.eventStream.Close())
+	}()
+	defer w.signalClose()
 
 	for {
 		select {
@@ -100,11 +103,14 @@ func (w *EventStreamWriter) Send(ctx context.Context, variant *smithy.Schema, ev
 // Close signals end-of-stream and closes the underlying writer. Close is
 // safe for concurrent calls.
 func (w *EventStreamWriter) Close() error {
+	w.signalClose()
+	return w.err.Err()
+}
+
+func (w *EventStreamWriter) signalClose() {
 	w.closeOnce.Do(func() {
 		close(w.done)
-		w.err.SetError(w.eventStream.Close())
 	})
-	return w.err.Err()
 }
 
 // Err returns the first error encountered during writing.


### PR DESCRIPTION
the old close could write the closing signal on the stream while something else was writing, this just handles it safely, more or less like the old aws sdk version did