### PR TITLE
Keep a caller-supplied ContentLength for *io.PipeReader bodies

### DIFF
--- a/.changelog/3a5cb23c-bb8d-4b5e-bdb5-12c52e37fede.json
+++ b/.changelog/3a5cb23c-bb8d-4b5e-bdb5-12c52e37fede.json
@@ -1,0 +1,9 @@
+{
+    "id": "3a5cb23c-bb8d-4b5e-bdb5-12c52e37fede",
+    "type": "bugfix",
+    "description": "Keep a caller-supplied ContentLength when the request stream is an *io.PipeReader.",
+    "collapse": false,
+    "modules": [
+        "."
+    ]
+}

--- a/transport/http/request.go
+++ b/transport/http/request.go
@@ -176,7 +176,13 @@ func (r *Request) Build(ctx context.Context) *http.Request {
 	switch stream := r.stream.(type) {
 	case *io.PipeReader:
 		req.Body = io.NopCloser(stream)
-		req.ContentLength = -1
+		// A pipe cannot report its own length, so fall back to chunked
+		// encoding. A length the caller supplied is still authoritative:
+		// discarding it strands SigV4, which has already signed
+		// content-length by this point.
+		if req.ContentLength <= 0 {
+			req.ContentLength = -1
+		}
 	default:
 		// HTTP Client Request must only have a non-nil body if the
 		// ContentLength is explicitly unknown (-1) or non-zero. The HTTP

--- a/transport/http/request_test.go
+++ b/transport/http/request_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -57,6 +59,18 @@ func TestRequestRewindable(t *testing.T) {
 	}
 }
 
+// pipeReader is a stream whose length cannot be determined from the reader
+// itself, so only a caller-supplied ContentLength can frame the request.
+func pipeReader(t *testing.T) *io.PipeReader {
+	t.Helper()
+	r, w := io.Pipe()
+	t.Cleanup(func() {
+		r.Close()
+		w.Close()
+	})
+	return r
+}
+
 func TestRequestBuild_contentLength(t *testing.T) {
 	cases := []struct {
 		Request  *Request
@@ -96,6 +110,33 @@ func TestRequestBuild_contentLength(t *testing.T) {
 			},
 			Expected: 100,
 		},
+		{
+			Request: &Request{
+				Request: &http.Request{
+					ContentLength: 100,
+				},
+				stream: pipeReader(t),
+			},
+			Expected: 100,
+		},
+		{
+			Request: &Request{
+				Request: &http.Request{
+					ContentLength: 0,
+				},
+				stream: pipeReader(t),
+			},
+			Expected: -1,
+		},
+		{
+			Request: &Request{
+				Request: &http.Request{
+					ContentLength: -1,
+				},
+				stream: pipeReader(t),
+			},
+			Expected: -1,
+		},
 	}
 
 	for i, tt := range cases {
@@ -104,6 +145,81 @@ func TestRequestBuild_contentLength(t *testing.T) {
 
 			if build.ContentLength != tt.Expected {
 				t.Errorf("expect %v, got %v", tt.Expected, build.ContentLength)
+			}
+		})
+	}
+}
+
+// TestRequestBuild_pipeReaderFraming covers what the ContentLength on a built
+// request means once it reaches a server. A pipe cannot report its own length,
+// so an unknown one must still fall back to chunked encoding, but a length the
+// caller supplied has to survive as a Content-Length header: signing runs
+// before Build and has already signed that header in.
+func TestRequestBuild_pipeReaderFraming(t *testing.T) {
+	const body = "hello world"
+
+	cases := map[string]struct {
+		ContentLength  int64
+		ExpectedHeader string
+		ExpectChunked  bool
+	}{
+		"caller supplied length": {
+			ContentLength:  int64(len(body)),
+			ExpectedHeader: strconv.Itoa(len(body)),
+		},
+		"unknown length": {
+			ContentLength: -1,
+			ExpectChunked: true,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			type framing struct {
+				header           string
+				transferEncoding []string
+			}
+			received := make(chan framing, 1)
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				io.Copy(io.Discard, r.Body)
+				received <- framing{
+					header:           r.Header.Get("Content-Length"),
+					transferEncoding: r.TransferEncoding,
+				}
+			}))
+			defer server.Close()
+
+			pr, pw := io.Pipe()
+			go func() {
+				io.WriteString(pw, body)
+				pw.Close()
+			}()
+
+			req := NewStackRequest().(*Request)
+			req, err := req.SetStream(pr)
+			if err != nil {
+				t.Fatalf("expect no error setting stream, got %v", err)
+			}
+			req.Method = http.MethodPut
+			if req.URL, err = url.Parse(server.URL); err != nil {
+				t.Fatalf("expect no error parsing server URL, got %v", err)
+			}
+			req.ContentLength = c.ContentLength
+
+			resp, err := server.Client().Do(req.Build(context.Background()))
+			if err != nil {
+				t.Fatalf("expect no error sending request, got %v", err)
+			}
+			resp.Body.Close()
+
+			got := <-received
+			if e, a := c.ExpectedHeader, got.header; e != a {
+				t.Errorf("expect Content-Length %q, got %q", e, a)
+			}
+			chunked := len(got.transferEncoding) == 1 && got.transferEncoding[0] == "chunked"
+			if e, a := c.ExpectChunked, chunked; e != a {
+				t.Errorf("expect chunked %v, got %v from %v", e, a, got.transferEncoding)
 			}
 		})
 	}


### PR DESCRIPTION
*Issue #, if available:* #703

*Description of changes:*

`Request.Build` overwrote `ContentLength` with -1 whenever the stream was an
`*io.PipeReader`, discarding a length the caller had already set. Signing runs
before `Build`, so SigV4 had put `content-length` in `SignedHeaders` by then.
The request went out chunked with no `Content-Length` header, and no backend
could validate it: 411 where the header is required, 403 SignatureDoesNotMatch
where only the signature is checked.

`Build` now fills in `ContentLength` only when it is unknown. A pipe with no
known length still falls back to chunked encoding, so nothing changes for
callers who do not supply one.

Tests:

- Three cases added to `TestRequestBuild_contentLength` for a pipe with a known
  length, with 0, and with -1.
- `TestRequestBuild_pipeReaderFraming` sends a built request to an httptest
  server and asserts the framing that actually arrives, rather than the field
  alone.

Both fail on main and pass with this change. `make unit-race` and `gorelease`
are clean.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
