### PR TITLE
Avoid slice allocation in ValidateEndpointHost

### DIFF
--- a/.changelog/3986d7c2-3427-4cce-b0e6-7ed0f7594aba.json
+++ b/.changelog/3986d7c2-3427-4cce-b0e6-7ed0f7594aba.json
@@ -1,0 +1,9 @@
+{
+    "id": "3986d7c2-3427-4cce-b0e6-7ed0f7594aba",
+    "type": "bugfix",
+    "description": "Avoid allocating a slice in ValidateEndpointHost by indexing into the hostname instead of using strings.Split.",
+    "collapse": false,
+    "modules": [
+        "."
+    ]
+}

--- a/transport/http/host.go
+++ b/transport/http/host.go
@@ -29,17 +29,23 @@ func ValidateEndpointHost(host string) error {
 		hostname = host
 	}
 
-	labels := strings.Split(hostname, ".")
-	for i, label := range labels {
-		if i == len(labels)-1 && len(label) == 0 {
-			// Allow trailing dot for FQDN hosts.
-			continue
+	for start := 0; ; {
+		idx := strings.IndexByte(hostname[start:], '.')
+		if idx < 0 {
+			// Last label. Allow it to be empty to permit a trailing dot for
+			// FQDN hosts.
+			if label := hostname[start:]; len(label) != 0 && !ValidHostLabel(label) {
+				errors.WriteString("\nendpoint host domain labels must match \"[a-zA-Z0-9-]{1,63}\", but found: ")
+				errors.WriteString(label)
+			}
+			break
 		}
 
-		if !ValidHostLabel(label) {
+		if label := hostname[start : start+idx]; !ValidHostLabel(label) {
 			errors.WriteString("\nendpoint host domain labels must match \"[a-zA-Z0-9-]{1,63}\", but found: ")
 			errors.WriteString(label)
 		}
+		start += idx + 1
 	}
 
 	if len(hostname) == 0 && len(port) != 0 {


### PR DESCRIPTION
*Description of changes:*

Replaced `strings.Split` with index-based scanning over the hostname so label extraction no longer allocates a `[]string`, while preserving the existing trailing-dot (FQDN) handling and validation semantics. Roughly 43%-56% single core perf improvement, up to 81% under 18 concurrent goroutines. Also considered an LRU or sync.Map cache to avoid the validation entirely but the mutex and map hash cost exceeds the computation cost with the risk of unbounded map growth, so not worth it to try to short circuit the check.

Benchmarked locally with temporary benchmark cases, can add to commit if necessary. Results are as follows:

**Machine**:

```
goos: darwin
goarch: arm64
cpu: Apple M5 Max (18 cores)
go version go1.26.1 darwin/arm64
macOS 26.5.2 (25F84)
```

**Single**

```
                          │   before    │           after            │
                          │   sec/op    │   sec/op     vs base       │
ValidateEndpointHost/short   31.37n ± 2%   11.79n ± 1%  -62.39% (p=0.000 n=10)
ValidateEndpointHost/service 55.38n ± 1%   25.78n ± 3%  -53.45% (p=0.000 n=10)
ValidateEndpointHost/fqdn    64.25n ± 1%   28.39n ± 2%  -55.81% (p=0.000 n=10)
ValidateEndpointHost/with_port 66.12n ± 1% 34.97n ± 1%  -47.12% (p=0.000 n=10)
ValidateEndpointHost/long   107.35n ± 1%   56.29n ± 2%  -47.57% (p=0.000 n=10)
```

**Concurrent (4 to 18)** 

```
                                        │  before   │            after            │
                                        │  sec/op   │   sec/op     vs base        │
ValidateEndpointHostParallel/service       56.49n     26.32n ± 2%  -53.40% (p=0.000 n=10)   (GOMAXPROCS=1)
ValidateEndpointHostParallel/service-4     19.52n      6.55n ± 2%  -66.44% (p=0.000 n=10)   (GOMAXPROCS=4)
ValidateEndpointHostParallel/service-18    20.53n      2.07n ± 3%  -89.90% (p=0.000 n=10)   (GOMAXPROCS=18)
```


Benchmark cases:

```go
var benchmarkHosts = map[string]string{
	"short":     "example.com",
	"service":   "s3.us-west-2.amazonaws.com",
	"fqdn":      "s3.us-west-2.amazonaws.com.",
	"with port": "s3.us-west-2.amazonaws.com:8443",
	"long":      "my-very-long-bucket-name.s3-accesspoint.dualstack.us-west-2.amazonaws.com",
}

func BenchmarkValidateEndpointHost(b *testing.B) {
	for name, host := range benchmarkHosts {
		b.Run(name, func(b *testing.B) {
			b.ReportAllocs()
			for i := 0; i < b.N; i++ {
				if err := ValidateEndpointHost(host); err != nil {
					b.Fatalf("expect no error, got %v", err)
				}
			}
		})
	}
}

func BenchmarkValidateEndpointHostParallel(b *testing.B) {
	for name, host := range benchmarkHosts {
		b.Run(name, func(b *testing.B) {
			b.ReportAllocs()
			b.RunParallel(func(pb *testing.PB) {
				for pb.Next() {
					if err := ValidateEndpointHost(host); err != nil {
						b.Fatalf("expect no error, got %v", err)
					}
				}
			})
		})
	}
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
