### PR TITLE
encoding: json and xml Value write non-finite floats as strings instead of panicking

### DIFF
--- a/.changelog/b47e0e8f-e94e-4339-8398-f20a1af31ff2.json
+++ b/.changelog/b47e0e8f-e94e-4339-8398-f20a1af31ff2.json
@@ -1,0 +1,9 @@
+{
+    "id": "b47e0e8f-e94e-4339-8398-f20a1af31ff2",
+    "type": "bugfix",
+    "description": "encoding/json and encoding/xml Value encode NaN and the infinities as the strings NaN, Infinity and -Infinity instead of panicking.",
+    "collapse": false,
+    "modules": [
+        "."
+    ]
+}

--- a/encoding/json/value.go
+++ b/encoding/json/value.go
@@ -3,6 +3,7 @@ package json
 import (
 	"bytes"
 	"encoding/base64"
+	"math"
 	"math/big"
 	"strconv"
 
@@ -53,17 +54,31 @@ func (jv Value) ULong(v uint64) {
 	jv.w.Write(*jv.scratch)
 }
 
-// Float encodes v as a JSON number
+// Float encodes v as a JSON number. NaN and the infinities are encoded as
+// the strings "NaN", "Infinity" and "-Infinity".
 func (jv Value) Float(v float32) {
 	jv.float(float64(v), 32)
 }
 
-// Double encodes v as a JSON number
+// Double encodes v as a JSON number. NaN and the infinities are encoded as
+// the strings "NaN", "Infinity" and "-Infinity".
 func (jv Value) Double(v float64) {
 	jv.float(v, 64)
 }
 
 func (jv Value) float(v float64, bits int) {
+	switch {
+	case math.IsNaN(v):
+		jv.String("NaN")
+		return
+	case math.IsInf(v, 1):
+		jv.String("Infinity")
+		return
+	case math.IsInf(v, -1):
+		jv.String("-Infinity")
+		return
+	}
+
 	*jv.scratch = encoding.EncodeFloat((*jv.scratch)[:0], v, bits)
 	jv.w.Write(*jv.scratch)
 }

--- a/encoding/json/value_test.go
+++ b/encoding/json/value_test.go
@@ -18,6 +18,24 @@ func TestValue(t *testing.T) {
 		setter   func(Value)
 		expected string
 	}{
+		"float NaN": {
+			setter: func(value Value) {
+				value.Double(math.NaN())
+			},
+			expected: `"NaN"`,
+		},
+		"float positive infinity": {
+			setter: func(value Value) {
+				value.Double(math.Inf(1))
+			},
+			expected: `"Infinity"`,
+		},
+		"float negative infinity": {
+			setter: func(value Value) {
+				value.Float(float32(math.Inf(-1)))
+			},
+			expected: `"-Infinity"`,
+		},
 		"string value": {
 			setter: func(value Value) {
 				value.String("foo")

--- a/encoding/xml/value.go
+++ b/encoding/xml/value.go
@@ -3,6 +3,7 @@ package xml
 import (
 	"encoding/base64"
 	"fmt"
+	"math"
 	"math/big"
 	"strconv"
 
@@ -135,14 +136,16 @@ func (xv Value) Long(v int64) {
 	xv.Close()
 }
 
-// Float encodes v as a XML number.
+// Float encodes v as a XML number. NaN and the infinities are encoded as
+// the text NaN, Infinity and -Infinity.
 // It will auto close the parent xml element tag.
 func (xv Value) Float(v float32) {
 	xv.float(float64(v), 32)
 	xv.Close()
 }
 
-// Double encodes v as a XML number.
+// Double encodes v as a XML number. NaN and the infinities are encoded as
+// the text NaN, Infinity and -Infinity.
 // It will auto close the parent xml element tag.
 func (xv Value) Double(v float64) {
 	xv.float(v, 64)
@@ -150,6 +153,18 @@ func (xv Value) Double(v float64) {
 }
 
 func (xv Value) float(v float64, bits int) {
+	switch {
+	case math.IsNaN(v):
+		xv.w.WriteString("NaN")
+		return
+	case math.IsInf(v, 1):
+		xv.w.WriteString("Infinity")
+		return
+	case math.IsInf(v, -1):
+		xv.w.WriteString("-Infinity")
+		return
+	}
+
 	*xv.scratch = encoding.EncodeFloat((*xv.scratch)[:0], v, bits)
 	xv.w.Write(*xv.scratch)
 }

--- a/encoding/xml/value_test.go
+++ b/encoding/xml/value_test.go
@@ -21,6 +21,24 @@ func TestValue(t *testing.T) {
 		setter   func(Value)
 		expected string
 	}{
+		"float NaN": {
+			setter: func(value Value) {
+				value.Double(math.NaN())
+			},
+			expected: `NaN`,
+		},
+		"float positive infinity": {
+			setter: func(value Value) {
+				value.Double(math.Inf(1))
+			},
+			expected: `Infinity`,
+		},
+		"float negative infinity": {
+			setter: func(value Value) {
+				value.Float(float32(math.Inf(-1)))
+			},
+			expected: `-Infinity`,
+		},
 		"string value": {
 			setter: func(value Value) {
 				value.String("foo")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`encoding/json` and `encoding/xml` `Value.Float` and `Value.Double` hand every value to `encoding.EncodeFloat`, which panics on NaN and the infinities, so serializing one of those float64 values kills the process. The protocol serializers under `transport/http/protocol/internal` already write them as the strings `NaN`, `Infinity` and `-Infinity`; this change makes the two `Value` encoders do the same, quoted in JSON and as element text in XML.

Three cases each in the existing `TestValue` tables panic on main and pass with the change. `make unit-race` passes across all modules, and gorelease reports the change as compatible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
