### PR TITLE
Print stacktrace when smithy-build fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ smithy-publish-local:
 	cd codegen && ./gradlew publishToMavenLocal
 
 smithy-build:
-	cd codegen && ./gradlew build
+	cd codegen && ./gradlew build --stacktrace
 
 smithy-clean:
 	cd codegen && ./gradlew clean


### PR DESCRIPTION
This will help debug some CI runs where build fails and we don't have a good way to identify where it failed