### PR TITLE
fix v2 event streams orphaning the result channel on error paths in schema-serde

### DIFF
--- a/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/Serde2EventStreamMiddleware.java
+++ b/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/serde2/Serde2EventStreamMiddleware.java
@@ -39,9 +39,25 @@ public class Serde2EventStreamMiddleware extends DeserializeStepMiddleware {
 
     @Override
     public Map<String, Symbol> getFields() {
-        return Map.of(
-                "options", pointerTo(buildPackageSymbol("Options"))
-        );
+        var fields = new java.util.HashMap<String, Symbol>();
+        fields.put("options", pointerTo(buildPackageSymbol("Options")));
+
+        if (isV2EventStream()) {
+            var model = ctx.model();
+            var symbolProvider = ctx.symbolProvider();
+            var outputShape = model.expectShape(operation.getOutputShape());
+            var outputSymbol = symbolProvider.toSymbol(outputShape);
+
+            fields.put("existingResult", pointerTo(outputSymbol));
+            fields.put("asyncResult", software.amazon.smithy.go.codegen.SymbolUtils
+                    .createValueSymbolBuilder("chan deserializeResult").build());
+        }
+
+        return fields;
+    }
+
+    private boolean isV2EventStream() {
+        return EventStreamGenerator.isV2EventStream(ctx.model(), operation);
     }
 
     @Override
@@ -131,6 +147,10 @@ public class Serde2EventStreamMiddleware extends DeserializeStepMiddleware {
     }
 
     private Writable writerSetup(UnionShape inputEventStream) {
+        return writerSetup(inputEventStream, false);
+    }
+
+    private Writable writerSetup(UnionShape inputEventStream, boolean guardFirstAttempt) {
         var service = ctx.service();
         var schemaName = SchemaGenerator.getSchemaRef(inputEventStream, service);
         var adapterName = EventStreamGenerator.getEventStreamWriterAdapterName(service, inputEventStream);
@@ -154,9 +174,7 @@ public class Serde2EventStreamMiddleware extends DeserializeStepMiddleware {
                     writer: $newWriter:T(m.options.Protocol, $schema:L, inputStreamWriter),
                 }
                 defer func() {
-                    if err != nil {
-                        _ = eventWriter.Close()
-                    }
+                    $closeGuard:W
                 }()
                 """,
                 MapUtils.of(
@@ -172,7 +190,16 @@ public class Serde2EventStreamMiddleware extends DeserializeStepMiddleware {
                             SmithyGoDependency.SMITHY_HTTP_TRANSPORT.pointableSymbol("Request"),
                         "newSigningWriter",
                             SmithyGoDependency.SMITHY_EVENTSTREAM.func("NewSigningWriter"),
-                        "schema", schemaName
+                        "schema", schemaName,
+                        "closeGuard", guardFirstAttempt
+                                ? (Writable) w -> w.write("""
+                                        if err != nil && !isFirstAttempt {
+                                            _ = eventWriter.Close()
+                                        }""")
+                                : (Writable) w -> w.write("""
+                                        if err != nil {
+                                            _ = eventWriter.Close()
+                                        }""")
                 ));
     }
 
@@ -252,24 +279,43 @@ public class Serde2EventStreamMiddleware extends DeserializeStepMiddleware {
         // 4. THEN call next.HandleDeserialize (sends the HTTP request)
         // 5. Pipe the response body into the async reader
         // 6. Add output to metadata for the Build-step middleware
+        //
+        // Retries re-enter this middleware, so steps 1-3 only happen on the first
+        // attempt; m.existingResult/m.asyncResult persist the single output/channel
+        // pair that the caller (and the Build-step middleware, on every attempt) must
+        // keep referring to. Without this, a retried attempt would hand the Build-step
+        // middleware a second output no one is listening on, and the caller's copy
+        // would never be signaled.
         return goTemplate("""
                 var out $deserializeOutput:T
                 var md $metadata:T
                 var err error
 
-                output := &$output:T{}
-                output.initialReply = make(chan $initialReply:T, 1)
-
+                output := m.existingResult
+                isFirstAttempt := output == nil
+                $asyncResultDecl:W
                 $writerSetup:W
-                $readerSetup:W
+                if isFirstAttempt {
+                    output = &$output:T{}
+                    output.initialReply = make(chan $initialReply:T, 1)
 
-                output.eventStream = $esConstructor:T(func(stream $esStruct:P) {
-                    $wireWriter:W
-                    $wireReader:W
-                })
+                    $readerSetup:W
 
-                go output.eventStream.waitStreamClose()
+                    output.eventStream = $esConstructor:T(func(stream $esStruct:P) {
+                        $wireWriter:W
+                        $wireReader:W
+                    })
 
+                    go output.eventStream.waitStreamClose()
+
+                    m.existingResult = output
+                    $asyncResultStore:W
+                }
+
+                // Drain and re-send on every attempt (not just the first), mirroring
+                // the legacy hand-written middleware: the caller only ever consumes
+                // one value, but always sending keeps this symmetric with m.existingResult
+                // rather than depending on isFirstAttempt to decide who notifies.
                 prc, _ := ctx.Value(partialResultChan{}).(chan PartialResult)
                 if prc != nil {
                     select {
@@ -316,7 +362,7 @@ public class Serde2EventStreamMiddleware extends DeserializeStepMiddleware {
                         Map.entry("addToMetadata",
                             SmithyGoDependency.SMITHY_MIDDLEWARE.func("AddEventStreamOutputToMetadata")),
                         Map.entry("writerSetup", inputInfo.isPresent()
-                                ? writerSetup(inputInfo.get().getEventStreamTarget().asUnionShape().get())
+                                ? writerSetup(inputInfo.get().getEventStreamTarget().asUnionShape().get(), true)
                                 : (Writable) w -> {}),
                         Map.entry("wireWriter", inputInfo.isPresent()
                                 ? (Writable) w -> w.write("stream.Writer = eventWriter")
@@ -334,6 +380,12 @@ public class Serde2EventStreamMiddleware extends DeserializeStepMiddleware {
                                 : (Writable) w -> {}),
                         Map.entry("asyncPipe", outputInfo.isPresent()
                                 ? (Writable) w -> w.write("asyncResult <- deserializeResult{reader: resp.Body}")
+                                : (Writable) w -> {}),
+                        Map.entry("asyncResultDecl", outputInfo.isPresent()
+                                ? (Writable) w -> w.write("asyncResult := m.asyncResult")
+                                : (Writable) w -> {}),
+                        Map.entry("asyncResultStore", outputInfo.isPresent()
+                                ? (Writable) w -> w.write("m.asyncResult = asyncResult")
                                 : (Writable) w -> {})
                 ));
     }
@@ -345,7 +397,7 @@ public class Serde2EventStreamMiddleware extends DeserializeStepMiddleware {
                 .getEventStreamReaderAdapterConstructor(service, outputEventStream);
 
         return goTemplate("""
-                asyncResult := make(chan deserializeResult, 1)
+                asyncResult = make(chan deserializeResult, 1)
                 asyncReader := newAsyncEventStreamReader(asyncResult)
                 eventReader := $newAdapter:L(
                     $newReader:T(m.options.Protocol, $schema:L, TypeRegistry, asyncReader.pipeReader),


### PR DESCRIPTION
For v2 bidi streams, the schema-serde deserialize middleware re-created the caller's stream handle and its internal signaling channel on *every retry attempt* instead of once per logical call. On a retryable error that channel would get orphaned, and since that's the one the caller sees, they get stuck.

Copied legacy-serde v2's handling of this into schema-serde to fix (just check if the result channel was already created on the middleware struct)